### PR TITLE
chore: configuring lerna publish

### DIFF
--- a/core/js/package.json
+++ b/core/js/package.json
@@ -18,6 +18,9 @@
   "files": [
     "/dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "nft",
     "metaplex",

--- a/lerna.json
+++ b/lerna.json
@@ -8,6 +8,9 @@
       "allowBranch": ["master"],
       "message": "chore: version updated packages",
       "ignoreChanges": ["**/test/**", "**/*.md"]
+    },
+    "publish": {
+      "registry": "https://registry.npmjs.org/"
     }
   }
 }

--- a/metaplex/js/package.json
+++ b/metaplex/js/package.json
@@ -18,6 +18,9 @@
   "files": [
     "/dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "nft",
     "metaplex",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "lerna run --parallel lint",
     "fix": "lerna run --parallel fix",
     "lerna:version": "lerna version",
-    "lerna:publish": "lerna publish"
+    "lerna:publish": "lerna publish from-package"
   },
   "workspaces": {
     "packages": [

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -18,6 +18,9 @@
   "files": [
     "/dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "nft",
     "metaplex",

--- a/token-vault/js/package.json
+++ b/token-vault/js/package.json
@@ -18,6 +18,9 @@
   "files": [
     "/dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "nft",
     "metaplex",


### PR DESCRIPTION
Using npm registry and using versions in `package.json` as basis to determine if new version of
a package needs to be published.
