### PR TITLE
Allow is_mutable to be flipped false via update_metadata_accounts_v2

### DIFF
--- a/token-metadata/program/src/error.rs
+++ b/token-metadata/program/src/error.rs
@@ -304,6 +304,10 @@ pub enum MetadataError {
     // In the legacy system the reservation needs to be of size one for cpu limit reasons
     #[error("In the legacy system the reservation needs to be of size one for cpu limit reasons")]
     ReservationArrayShouldBeSizeOne,
+
+    /// Is Mutable can only be flipped to false
+    #[error("Is Mutable can only be flipped to false")]
+    IsMutableCanOnlyBeFlippedToFalse,
 }
 
 impl PrintProgramError for MetadataError {

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -20,6 +20,16 @@ pub struct UpdateMetadataAccountArgs {
 
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone)]
+/// Args for update call
+pub struct UpdateMetadataAccountArgsV2 {
+    pub data: Option<Data>,
+    pub update_authority: Option<Pubkey>,
+    pub primary_sale_happened: Option<bool>,
+    pub is_mutable: Option<bool>,
+}
+
+#[repr(C)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone)]
 /// Args for create call
 pub struct CreateMetadataAccountArgs {
     /// Note that unique metadatas are disabled for now.
@@ -58,6 +68,11 @@ pub enum MetadataInstruction {
     ///   0. `[writable]` Metadata account
     ///   1. `[signer]` Update authority key
     UpdateMetadataAccount(UpdateMetadataAccountArgs),
+
+    /// Update a Metadata with is_mutable as a parameter
+    ///   0. `[writable]` Metadata account
+    ///   1. `[signer]` Update authority key
+    UpdateMetadataAccountV2(UpdateMetadataAccountArgsV2),
 
     /// Register a Metadata as a Master Edition V1, which means Editions can be minted.
     /// Henceforth, no further tokens will be mintable from this primary mint. Will throw an error if more than one
@@ -304,6 +319,33 @@ pub fn update_metadata_accounts(
             data,
             update_authority: new_update_authority,
             primary_sale_happened,
+        })
+        .try_to_vec()
+        .unwrap(),
+    }
+}
+
+// update metadata account v2 instruction
+pub fn update_metadata_accounts_v2(
+    program_id: Pubkey,
+    metadata_account: Pubkey,
+    update_authority: Pubkey,
+    new_update_authority: Option<Pubkey>,
+    data: Option<Data>,
+    primary_sale_happened: Option<bool>,
+    is_mutable: Option<bool>,
+) -> Instruction {
+    Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(metadata_account, false),
+            AccountMeta::new_readonly(update_authority, true),
+        ],
+        data: MetadataInstruction::UpdateMetadataAccountV2(UpdateMetadataAccountArgsV2 {
+            data,
+            update_authority: new_update_authority,
+            primary_sale_happened,
+            is_mutable,
         })
         .try_to_vec()
         .unwrap(),

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -61,6 +61,17 @@ pub fn process_instruction<'a>(
                 args.primary_sale_happened,
             )
         }
+        MetadataInstruction::UpdateMetadataAccountV2(args) => {
+            msg!("Instruction: Update Metadata Accounts");
+            process_update_metadata_accounts_v2(
+                program_id,
+                accounts,
+                args.data,
+                args.update_authority,
+                args.primary_sale_happened,
+                args.is_mutable,
+            )
+        }
         MetadataInstruction::DeprecatedCreateMasterEdition(args) => {
             msg!("Instruction: Deprecated Create Master Edition");
             process_deprecated_create_master_edition(program_id, accounts, args.max_supply)
@@ -218,6 +229,65 @@ pub fn process_update_metadata_accounts(
     Ok(())
 }
 
+// Update existing account instruction
+pub fn process_update_metadata_accounts_v2(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    optional_data: Option<Data>,
+    update_authority: Option<Pubkey>,
+    primary_sale_happened: Option<bool>,
+    is_mutable: Option<bool>,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let metadata_account_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+    let mut metadata = Metadata::from_account_info(metadata_account_info)?;
+
+    assert_owned_by(metadata_account_info, program_id)?;
+    assert_update_authority_is_correct(&metadata, update_authority_info)?;
+
+    if let Some(data) = optional_data {
+        if metadata.is_mutable {
+            assert_data_valid(
+                &data,
+                update_authority_info.key,
+                &metadata,
+                false,
+                update_authority_info.is_signer,
+                true,
+            )?;
+            metadata.data = data;
+        } else {
+            return Err(MetadataError::DataIsImmutable.into());
+        }
+    }
+
+    if let Some(val) = update_authority {
+        metadata.update_authority = val;
+    }
+
+    if let Some(val) = primary_sale_happened {
+        if val {
+            metadata.primary_sale_happened = val
+        } else {
+            return Err(MetadataError::PrimarySaleCanOnlyBeFlippedToTrue.into());
+        }
+    }
+
+    if let Some(val) = is_mutable {
+        if !val {
+            metadata.is_mutable = val
+        } else {
+            return Err(MetadataError::IsMutableCanOnlyBeFlippedToFalse.into());
+        }
+    }
+
+    puff_out_data_fields(&mut metadata);
+
+    metadata.serialize(&mut *metadata_account_info.data.borrow_mut())?;
+    Ok(())
+}
 pub fn process_update_primary_sale_happened_via_token(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token-metadata/program/tests/update_metadata_account_v2.rs
+++ b/token-metadata/program/tests/update_metadata_account_v2.rs
@@ -112,7 +112,7 @@ async fn fail_invalid_update_authority() {
 }
 
 #[tokio::test]
-async fn cannot_flip_immutable_to_true() {
+async fn cannot_flip_is_mutable_from_false_to_true() {
     let mut context = program_test().start_with_context().await;
     let test_metadata = Metadata::new();
     let name = "Test".to_string();

--- a/token-metadata/program/tests/update_metadata_account_v2.rs
+++ b/token-metadata/program/tests/update_metadata_account_v2.rs
@@ -1,0 +1,162 @@
+#![cfg(feature = "test-bpf")]
+mod utils;
+
+use mpl_token_metadata::{
+    error::MetadataError,
+    id, instruction,
+    state::{Key, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    utils::puffed_out_string,
+};
+use num_traits::FromPrimitive;
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::InstructionError,
+    signature::{Keypair, Signer},
+    transaction::{Transaction, TransactionError},
+    transport::TransportError,
+};
+use utils::*;
+
+mod update_metadata_account_v2 {
+    use super::*;
+
+    #[tokio::test]
+    async fn success() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+
+        let puffed_symbol = puffed_out_string(&symbol, MAX_SYMBOL_LENGTH);
+        let puffed_uri = puffed_out_string(&uri, MAX_URI_LENGTH);
+
+        test_metadata
+            .create(
+                &mut context,
+                name,
+                symbol.clone(),
+                uri.clone(),
+                None,
+                10,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let updated_name = "New Name".to_string();
+        let puffed_updated_name = puffed_out_string(&updated_name, MAX_NAME_LENGTH);
+
+        test_metadata
+            .update_v2(&mut context, updated_name, symbol, uri, None, 10, false)
+            .await
+            .unwrap();
+
+        let metadata = test_metadata.get_data(&mut context).await;
+
+        assert_eq!(metadata.data.name, puffed_updated_name,);
+        assert_eq!(metadata.data.symbol, puffed_symbol);
+        assert_eq!(metadata.data.uri, puffed_uri);
+        assert_eq!(metadata.data.seller_fee_basis_points, 10);
+        assert_eq!(metadata.data.creators, None);
+
+        assert_eq!(metadata.primary_sale_happened, false);
+        assert_eq!(metadata.is_mutable, false);
+        assert_eq!(metadata.mint, test_metadata.mint.pubkey());
+        assert_eq!(metadata.update_authority, context.payer.pubkey());
+        assert_eq!(metadata.key, Key::MetadataV1);
+    }
+}
+
+#[tokio::test]
+async fn fail_invalid_update_authority() {
+    let mut context = program_test().start_with_context().await;
+    let test_metadata = Metadata::new();
+    let fake_update_authority = Keypair::new();
+
+    test_metadata
+        .create(
+            &mut context,
+            "Test".to_string(),
+            "TST".to_string(),
+            "uri".to_string(),
+            None,
+            10,
+            true,
+        )
+        .await
+        .unwrap();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[instruction::update_metadata_accounts_v2(
+            id(),
+            test_metadata.pubkey,
+            fake_update_authority.pubkey(),
+            None,
+            None,
+            None,
+            None,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &fake_update_authority],
+        context.last_blockhash,
+    );
+
+    let result = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    assert_custom_error!(result, MetadataError::UpdateAuthorityIncorrect);
+}
+
+#[tokio::test]
+async fn cannot_flip_immutable_to_true() {
+    let mut context = program_test().start_with_context().await;
+    let test_metadata = Metadata::new();
+    let name = "Test".to_string();
+    let symbol = "TST".to_string();
+    let uri = "uri".to_string();
+
+    // Start with NFT immutable.
+    let is_mutable = false;
+
+    test_metadata
+        .create(
+            &mut context,
+            name,
+            symbol.clone(),
+            uri.clone(),
+            None,
+            10,
+            is_mutable,
+        )
+        .await
+        .unwrap();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[instruction::update_metadata_accounts_v2(
+            id(),
+            test_metadata.pubkey,
+            context.payer.pubkey().clone(),
+            None,
+            None,
+            None,
+            // Try to flip to be mutable.
+            Some(true),
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let result = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    // We should not be able to make an immutable NFT mutable again.
+    assert_custom_error!(result, MetadataError::IsMutableCanOnlyBeFlippedToFalse);
+}

--- a/token-metadata/program/tests/utils/metadata.rs
+++ b/token-metadata/program/tests/utils/metadata.rs
@@ -143,4 +143,38 @@ impl Metadata {
 
         Ok(context.banks_client.process_transaction(tx).await?)
     }
+
+    pub async fn update_v2(
+        &self,
+        context: &mut ProgramTestContext,
+        name: String,
+        symbol: String,
+        uri: String,
+        creators: Option<Vec<Creator>>,
+        seller_fee_basis_points: u16,
+        is_mutable: bool,
+    ) -> transport::Result<()> {
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::update_metadata_accounts_v2(
+                id(),
+                self.pubkey,
+                context.payer.pubkey().clone(),
+                None,
+                Some(Data {
+                    name,
+                    symbol,
+                    uri,
+                    creators,
+                    seller_fee_basis_points,
+                }),
+                None,
+                Some(is_mutable),
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+
+        Ok(context.banks_client.process_transaction(tx).await?)
+    }
 }

--- a/token-metadata/test/src/main.rs
+++ b/token-metadata/test/src/main.rs
@@ -2,7 +2,7 @@ use solana_client::rpc_request::TokenAccountsFilter;
 
 use {
     clap::{crate_description, crate_name, crate_version, App, Arg, ArgMatches, SubCommand},
-    metaplex_token_metadata::{
+    mpl_token_metadata::{
         instruction::{
             create_master_edition, create_metadata_accounts,
             mint_new_edition_from_master_edition_via_token, puff_metadata_account,
@@ -37,7 +37,7 @@ use {
 const TOKEN_PROGRAM_PUBKEY: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 fn puff_unpuffed_metadata(_app_matches: &ArgMatches, payer: Keypair, client: RpcClient) {
     let metadata_accounts = client
-        .get_program_accounts(&metaplex_token_metadata::id())
+        .get_program_accounts(&mpl_token_metadata::id())
         .unwrap();
     let mut needing_puffing = vec![];
     for acct in metadata_accounts {
@@ -65,7 +65,7 @@ fn puff_unpuffed_metadata(_app_matches: &ArgMatches, payer: Keypair, client: Rpc
     let mut i = 0;
     while i < needing_puffing.len() {
         let pubkey = needing_puffing[i];
-        instructions.push(puff_metadata_account(metaplex_token_metadata::id(), pubkey));
+        instructions.push(puff_metadata_account(mpl_token_metadata::id(), pubkey));
         if instructions.len() >= 20 {
             let mut transaction = Transaction::new_with_payer(&instructions, Some(&payer.pubkey()));
             let recent_blockhash = client.get_recent_blockhash().unwrap().0;
@@ -171,7 +171,7 @@ fn show_reservation_list(app_matches: &ArgMatches, _payer: Keypair, client: RpcC
 }
 
 fn show(app_matches: &ArgMatches, _payer: Keypair, client: RpcClient) {
-    let program_key = metaplex_token_metadata::id();
+    let program_key = mpl_token_metadata::id();
 
     let printing_mint_key = pubkey_of(app_matches, "mint").unwrap();
     let master_metadata_seeds = &[
@@ -234,7 +234,7 @@ fn mint_edition_via_token_call(
     )
     .unwrap();
 
-    let program_key = metaplex_token_metadata::id();
+    let program_key = mpl_token_metadata::id();
     let token_key = Pubkey::from_str(TOKEN_PROGRAM_PUBKEY).unwrap();
 
     let mint_key = pubkey_of(app_matches, "mint").unwrap();
@@ -384,7 +384,7 @@ fn master_edition_call(
     )
     .unwrap();
 
-    let program_key = metaplex_token_metadata::id();
+    let program_key = mpl_token_metadata::id();
     let token_key = Pubkey::from_str(TOKEN_PROGRAM_PUBKEY).unwrap();
 
     let mint_key = pubkey_of(app_matches, "mint").unwrap();
@@ -478,7 +478,7 @@ fn update_metadata_account_call(
             .unwrap_or_else(|| app_matches.value_of("keypair").unwrap()),
     )
     .unwrap();
-    let program_key = metaplex_token_metadata::id();
+    let program_key = mpl_token_metadata::id();
     let mint_key = pubkey_of(app_matches, "mint").unwrap();
     let metadata_seeds = &[PREFIX.as_bytes(), &program_key.as_ref(), mint_key.as_ref()];
     let (metadata_key, _) = Pubkey::find_program_address(metadata_seeds, &program_key);
@@ -538,7 +538,7 @@ fn create_metadata_account_call(
     )
     .unwrap();
 
-    let program_key = metaplex_token_metadata::id();
+    let program_key = mpl_token_metadata::id();
     let token_key = Pubkey::from_str(TOKEN_PROGRAM_PUBKEY).unwrap();
     let name = app_matches.value_of("name").unwrap().to_owned();
     let symbol = app_matches.value_of("symbol").unwrap().to_owned();


### PR DESCRIPTION
Ported from [metaplex repo:](https://github.com/metaplex-foundation/metaplex/pull/984). 

> Currently there appears to be no way to set is_mutable to be false after an NFT metadata account has been created. Many NFTs, such as any created with default settings by candy_machine_cli, are created with the flag to true. It is desirable to have the ability to flip it to false at a later date, once any metadata issues are resolved or the community makes a decision to do so, etc.

I'll be looking at adding tests to this next before it gets merged. @thlorenz would like to discuss tests with you (it appears the tests for `token-metadata` are currently broken).