### PR TITLE
fix: token vault ci filter

### DIFF
--- a/.github/workflows/program-token-vault.yml
+++ b/.github/workflows/program-token-vault.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      core: ${{ steps.filter.outputs.core }}
+      package: ${{ steps.filter.outputs.package }}
     steps:
     - uses: actions/checkout@v2
     # For pull requests it's not necessary to checkout the code
@@ -24,12 +25,13 @@ jobs:
       id: filter
       with:
         filters: |
-          code:
+          core:
             - 'core/**'
+          package:
             - 'token-vault/**'
   build-and-test-token-vault:
     needs: changes
-    if: ${{ needs.changes.outputs.code == 'true' }}
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-token-vault 


### PR DESCRIPTION
Token Vault Program Checks didn't run even if changes were applied to it.
Each filter is `AND` and thus this was changed to have one filter per folder and `OR` them as
part of the query.
