### PR TITLE
(feat) adds collection authority system

### DIFF
--- a/core/rust/testing-utils/src/utils/metadata.rs
+++ b/core/rust/testing-utils/src/utils/metadata.rs
@@ -242,6 +242,7 @@ impl Metadata {
         collection_authority: Keypair,
         collection_mint: Pubkey,
         collection_master_edition_account: Pubkey,
+        collection_authority_record: Option<Pubkey>,
     ) -> transport::Result<()> {
         let tx = Transaction::new_signed_with_payer(
             &[instruction::verify_collection(
@@ -252,6 +253,34 @@ impl Metadata {
                 collection_mint,
                 collection,
                 collection_master_edition_account,
+                collection_authority_record,
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &collection_authority],
+            context.last_blockhash,
+        );
+
+        Ok(context.banks_client.process_transaction(tx).await?)
+    }
+
+    pub async fn unverify_collection(
+        &self,
+        context: &mut ProgramTestContext,
+        collection: Pubkey,
+        collection_authority: Keypair,
+        collection_mint: Pubkey,
+        collection_master_edition_account: Pubkey,
+        collection_authority_record: Option<Pubkey>,
+    ) -> transport::Result<()> {
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::unverify_collection(
+                id(),
+                self.pubkey,
+                collection_authority.pubkey(),
+                collection_mint,
+                collection,
+                collection_master_edition_account,
+                collection_authority_record,
             )],
             Some(&context.payer.pubkey()),
             &[&context.payer, &collection_authority],

--- a/token-metadata/program/src/assertions/collection.rs
+++ b/token-metadata/program/src/assertions/collection.rs
@@ -2,7 +2,11 @@ use solana_program::{account_info::AccountInfo, msg, program_error::ProgramError
 
 use crate::{
     error::MetadataError,
-    state::{Collection, DataV2, MasterEditionV2, Metadata, TokenStandard},
+    pda::find_collection_authority_account,
+    state::{
+        Collection, DataV2, MasterEditionV2, Metadata, TokenStandard, COLLECTION_AUTHORITY, PREFIX,
+    },
+    utils::assert_derivation,
 };
 
 pub fn assert_collection_update_is_valid(
@@ -16,11 +20,48 @@ pub fn assert_collection_update_is_valid(
     Ok(())
 }
 
-pub fn assert_collection_verify_if_valid(
+pub fn assert_is_collection_delegated_authority(
+    authority_record: &AccountInfo,
+    collection_authority: &Pubkey,
+    mint: &Pubkey,
+) -> Result<(), ProgramError> {
+    let (pda, _) = find_collection_authority_account(mint, collection_authority);
+    if pda != *authority_record.key {
+        return Err(MetadataError::DerivedKeyInvalid.into());
+    }
+    Ok(())
+}
+
+pub fn assert_has_collection_authority(
+    collection_authority_info: &AccountInfo,
+    collection_data: &Metadata,
+    mint: &Pubkey,
+    delegate_collection_authority_record: Option<&AccountInfo>,
+) -> Result<(), ProgramError> {
+    if delegate_collection_authority_record.is_some() {
+        assert_is_collection_delegated_authority(
+            delegate_collection_authority_record.unwrap(),
+            collection_authority_info.key,
+            mint,
+        )?;
+        if delegate_collection_authority_record
+            .unwrap()
+            .try_data_is_empty()?
+        {
+            return Err(MetadataError::InvalidCollectionUpdateAuthority.into());
+        }
+    } else {
+        if collection_data.update_authority != *collection_authority_info.key {
+            return Err(MetadataError::InvalidCollectionUpdateAuthority.into());
+        }
+    }
+    Ok(())
+}
+
+pub fn assert_collection_verify_is_valid(
     collection_member: &Metadata,
     collection_data: &Metadata,
     collection_mint: &AccountInfo,
-    collection_authority_info: &AccountInfo,
     edition_account_info: &AccountInfo,
 ) -> Result<(), ProgramError> {
     match &collection_member.collection {
@@ -29,9 +70,6 @@ pub fn assert_collection_verify_if_valid(
                 || collection_data.mint != *collection_mint.key
             {
                 return Err(MetadataError::CollectionNotFound.into());
-            }
-            if collection_data.update_authority != *collection_authority_info.key {
-                return Err(MetadataError::InvalidCollectionUpdateAuthority.into());
             }
         }
         None => {

--- a/token-metadata/program/src/error.rs
+++ b/token-metadata/program/src/error.rs
@@ -344,10 +344,14 @@ pub enum MetadataError {
     #[error("This token has no uses")]
     Unusable,
 
-    #[error("There ar not enough Uses left on this token.")]
+    #[error("There are not enough Uses left on this token.")]
     NotEnoughUses,
 
-    
+    #[error("This Collection Authority Record Already Exists.")]
+    CollectionAuthorityRecordAlreadyExists,
+
+    #[error("This Collection Authoritty Record Does Not Exist.")]
+    CollectionAuthorityDoesNotExist,
 }
 
 impl PrintProgramError for MetadataError {

--- a/token-metadata/program/src/pda.rs
+++ b/token-metadata/program/src/pda.rs
@@ -1,6 +1,6 @@
 use solana_program::pubkey::Pubkey;
 
-use crate::state::{BURN, EDITION, PREFIX, USER};
+use crate::state::{BURN, COLLECTION_AUTHORITY, EDITION, PREFIX, USER};
 
 pub fn find_edition_account(mint: &Pubkey, edition_number: String) -> (Pubkey, u8) {
     Pubkey::find_program_address(
@@ -40,6 +40,19 @@ pub fn find_use_authority_account(mint: &Pubkey, authority: &Pubkey) -> (Pubkey,
             crate::id().as_ref(),
             mint.as_ref(),
             USER.as_bytes(),
+            authority.as_ref(),
+        ],
+        &crate::id(),
+    )
+}
+
+pub fn find_collection_authority_account(mint: &Pubkey, authority: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[
+            PREFIX.as_bytes(),
+            crate::id().as_ref(),
+            mint.as_ref(),
+            COLLECTION_AUTHORITY.as_bytes(),
             authority.as_ref(),
         ],
         &crate::id(),

--- a/token-metadata/program/src/state.rs
+++ b/token-metadata/program/src/state.rs
@@ -16,6 +16,8 @@ pub const USER: &str = "user";
 
 pub const BURN: &str = "burn";
 
+pub const COLLECTION_AUTHORITY: &str = "collection_authority";
+
 pub const MAX_NAME_LENGTH: usize = 32;
 
 pub const MAX_SYMBOL_LENGTH: usize = 10;
@@ -69,7 +71,10 @@ pub const MAX_EDITION_MARKER_SIZE: usize = 32;
 
 pub const EDITION_MARKER_BIT_SIZE: u64 = 248;
 
-pub const USE_AUTHORITY_RECORD_SIZE: usize = 18; // Double Padding
+pub const USE_AUTHORITY_RECORD_SIZE: usize = 18; //10 byte padding
+
+pub const COLLECTION_AUTHORITY_RECORD_SIZE: usize = 11; //10 byte padding
+
 
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone, Copy)]
@@ -82,7 +87,8 @@ pub enum Key {
     ReservationListV2,
     MasterEditionV2,
     EditionMarker,
-    UseAuthorityRecord
+    UseAuthorityRecord,
+    CollectionAuthorityRecord
 }
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone)]
@@ -167,6 +173,22 @@ impl UseAuthorityRecord {
     pub fn from_account_info(a: &AccountInfo) -> Result<UseAuthorityRecord, ProgramError> {
         let ua: UseAuthorityRecord =
             try_from_slice_checked(&a.data.borrow_mut(), Key::UseAuthorityRecord, USE_AUTHORITY_RECORD_SIZE)?;
+
+        Ok(ua)
+    }
+}
+
+
+#[repr(C)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone)]
+pub struct CollectionAuthorityRecord {
+    pub key: Key //1
+}
+
+impl CollectionAuthorityRecord {
+    pub fn from_account_info(a: &AccountInfo) -> Result<CollectionAuthorityRecord, ProgramError> {
+        let ua: CollectionAuthorityRecord =
+            try_from_slice_checked(&a.data.borrow_mut(), Key::CollectionAuthorityRecord, COLLECTION_AUTHORITY_RECORD_SIZE)?;
 
         Ok(ua)
     }

--- a/token-metadata/program/src/utils.rs
+++ b/token-metadata/program/src/utils.rs
@@ -964,6 +964,17 @@ pub fn puffed_out_string(s: &String, size: usize) -> String {
     s.clone() + std::str::from_utf8(&array_of_zeroes).unwrap()
 }
 
+/// Pads the string to the desired size with `0u8`s.
+/// NOTE: it is assumed that the string's size is never larger than the given size.
+pub fn zero_account(s: &String, size: usize) -> String {
+    let mut array_of_zeroes = vec![];
+    let puff_amount = size - s.len();
+    while array_of_zeroes.len() < puff_amount {
+        array_of_zeroes.push(0u8);
+    }
+    s.clone() + std::str::from_utf8(&array_of_zeroes).unwrap()
+}
+
 pub struct MintNewEditionFromMasterEditionViaTokenLogicArgs<'a> {
     pub new_metadata_account_info: &'a AccountInfo<'a>,
     pub new_edition_account_info: &'a AccountInfo<'a>,

--- a/token-metadata/program/tests/approve_use_authority.rs
+++ b/token-metadata/program/tests/approve_use_authority.rs
@@ -342,15 +342,6 @@ mod approve_use_authority {
 
         let (burner, _) = find_program_as_burner_account();
 
-        let thing = context
-            .banks_client
-            .get_account(test_meta.token.pubkey())
-            .await
-            .unwrap()
-            .unwrap();
-
-        println!("{:?}", Account::unpack_from_slice(&thing.data).unwrap());
-
         let ix = mpl_token_metadata::instruction::approve_use_authority(
             mpl_token_metadata::id(),
             record,
@@ -363,6 +354,8 @@ mod approve_use_authority {
             burner,
             1,
         );
+
+        
 
         let tx = Transaction::new_signed_with_payer(
             &[ix],

--- a/token-metadata/program/tests/use.rs
+++ b/token-metadata/program/tests/use.rs
@@ -21,6 +21,8 @@ use solana_sdk::{
 use utils::*;
 mod uses {
 
+    use mpl_token_metadata::pda::find_program_as_burner_account;
+
     use super::*;
     #[tokio::test]
     async fn success() {}

--- a/token-metadata/program/tests/utils/metadata.rs
+++ b/token-metadata/program/tests/utils/metadata.rs
@@ -242,9 +242,10 @@ impl Metadata {
         &self,
         context: &mut ProgramTestContext,
         collection: Pubkey,
-        collection_authority: Keypair,
+        collection_authority: &Keypair,
         collection_mint: Pubkey,
         collection_master_edition_account: Pubkey,
+        collection_authority_record: Option<Pubkey>,
     ) -> transport::Result<()> {
         let tx = Transaction::new_signed_with_payer(
             &[instruction::verify_collection(
@@ -255,6 +256,34 @@ impl Metadata {
                 collection_mint,
                 collection,
                 collection_master_edition_account,
+                collection_authority_record,
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &collection_authority],
+            context.last_blockhash,
+        );
+
+        Ok(context.banks_client.process_transaction(tx).await?)
+    }
+
+    pub async fn unverify_collection(
+        &self,
+        context: &mut ProgramTestContext,
+        collection: Pubkey,
+        collection_authority: &Keypair,
+        collection_mint: Pubkey,
+        collection_master_edition_account: Pubkey,
+        collection_authority_record: Option<Pubkey>,
+    ) -> transport::Result<()> {
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::unverify_collection(
+                id(),
+                self.pubkey,
+                collection_authority.pubkey(),
+                collection_mint,
+                collection,
+                collection_master_edition_account,
+                collection_authority_record,
             )],
             Some(&context.payer.pubkey()),
             &[&context.payer, &collection_authority],

--- a/token-metadata/program/tests/verify_collection.rs
+++ b/token-metadata/program/tests/verify_collection.rs
@@ -1,29 +1,421 @@
 #![cfg(feature = "test-bpf")]
 mod utils;
 
+use mpl_token_metadata::pda::find_collection_authority_account;
+use mpl_token_metadata::state::Collection;
 use mpl_token_metadata::state::{UseMethod, Uses};
-
 use mpl_token_metadata::{
     error::MetadataError,
-    id, instruction,
     state::{Key, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
     utils::puffed_out_string,
 };
 use num_traits::FromPrimitive;
-use solana_program::pubkey::Pubkey;
 use solana_program_test::*;
 use solana_sdk::{
     instruction::InstructionError,
     signature::{Keypair, Signer},
-    transaction::{Transaction, TransactionError},
+    transaction::TransactionError,
     transport::TransportError,
 };
-use mpl_token_metadata::state::Collection;
 use utils::*;
 mod verify_collection {
-    
+
+    use mpl_token_metadata::state::CollectionAuthorityRecord;
+    use solana_program::borsh::try_from_slice_unchecked;
+    use solana_sdk::transaction::Transaction;
 
     use super::*;
+    #[tokio::test]
+    async fn success_verify_collection() {
+        let mut context = program_test().start_with_context().await;
+
+        let test_collection = Metadata::new();
+        test_collection
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let collection_master_edition_account = MasterEditionV2::new(&test_collection);
+        collection_master_edition_account
+            .create_v3(&mut context, Some(0))
+            .await
+            .unwrap();
+
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+        let test_metadata = Metadata::new();
+
+        let puffed_name = puffed_out_string(&name, MAX_NAME_LENGTH);
+        let puffed_symbol = puffed_out_string(&symbol, MAX_SYMBOL_LENGTH);
+        let puffed_uri = puffed_out_string(&uri, MAX_URI_LENGTH);
+
+        let uses = Some(Uses {
+            total: 1,
+            remaining: 1,
+            use_method: UseMethod::Single,
+        });
+        test_metadata
+            .create_v2(
+                &mut context,
+                name,
+                symbol,
+                uri,
+                None,
+                10,
+                false,
+                Some(Collection {
+                    key: test_collection.mint.pubkey(),
+                    verified: false,
+                }),
+                uses.to_owned(),
+            )
+            .await
+            .unwrap();
+
+        let metadata = test_metadata.get_data(&mut context).await;
+
+        assert_eq!(metadata.data.name, puffed_name);
+        assert_eq!(metadata.data.symbol, puffed_symbol);
+        assert_eq!(metadata.data.uri, puffed_uri);
+        assert_eq!(metadata.data.seller_fee_basis_points, 10);
+        assert_eq!(metadata.data.creators, None);
+        assert_eq!(metadata.uses, uses.to_owned());
+
+        assert_eq!(
+            metadata.collection.to_owned().unwrap().key,
+            test_collection.mint.pubkey()
+        );
+        assert_eq!(metadata.collection.unwrap().verified, false);
+
+        assert_eq!(metadata.primary_sale_happened, false);
+        assert_eq!(metadata.is_mutable, false);
+        assert_eq!(metadata.mint, test_metadata.mint.pubkey());
+        assert_eq!(metadata.update_authority, context.payer.pubkey());
+        assert_eq!(metadata.key, Key::MetadataV1);
+        let kpbytes = &context.payer;
+        let kp = Keypair::from_bytes(&kpbytes.to_bytes()).unwrap();
+        test_metadata
+            .verify_collection(
+                &mut context,
+                test_collection.pubkey,
+                &kp,
+                test_collection.mint.pubkey(),
+                collection_master_edition_account.pubkey,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let metadata_after = test_metadata.get_data(&mut context).await;
+        assert_eq!(
+            metadata_after.collection.to_owned().unwrap().key,
+            test_collection.mint.pubkey()
+        );
+        assert_eq!(metadata_after.collection.unwrap().verified, true);
+    }
+
+    #[tokio::test]
+    async fn fail_no_collection_nft_token_standard() {
+        let mut context = program_test().start_with_context().await;
+
+        let test_collection = Metadata::new();
+        test_collection
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let collection_master_edition_account = MasterEditionV2::new(&test_collection);
+        collection_master_edition_account
+            .create(&mut context, Some(0))
+            .await
+            .unwrap();
+
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+        let test_metadata = Metadata::new();
+        let uses = Some(Uses {
+            total: 1,
+            remaining: 1,
+            use_method: UseMethod::Single,
+        });
+        test_metadata
+            .create_v2(
+                &mut context,
+                name,
+                symbol,
+                uri,
+                None,
+                10,
+                false,
+                Some(Collection {
+                    key: test_collection.mint.pubkey(),
+                    verified: false,
+                }),
+                uses.to_owned(),
+            )
+            .await
+            .unwrap();
+
+        let kpbytes = &context.payer;
+        let kp = Keypair::from_bytes(&kpbytes.to_bytes()).unwrap();
+        let err = test_metadata
+            .verify_collection(
+                &mut context,
+                test_collection.pubkey,
+                &kp,
+                test_collection.mint.pubkey(),
+                collection_master_edition_account.pubkey,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_custom_error!(err, MetadataError::CollectionMustBeAUniqueMasterEdition);
+        let metadata_after = test_metadata.get_data(&mut context).await;
+        assert_eq!(
+            metadata_after.collection.to_owned().unwrap().key,
+            test_collection.mint.pubkey()
+        );
+        assert_eq!(metadata_after.collection.unwrap().verified, false);
+    }
+
+    #[tokio::test]
+    async fn fail_non_unique_master_edition() {
+        let mut context = program_test().start_with_context().await;
+
+        let test_collection = Metadata::new();
+        test_collection
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let collection_master_edition_account = MasterEditionV2::new(&test_collection);
+        collection_master_edition_account
+            .create(&mut context, Some(1))
+            .await
+            .unwrap();
+
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+        let test_metadata = Metadata::new();
+        let uses = Some(Uses {
+            total: 1,
+            remaining: 1,
+            use_method: UseMethod::Single,
+        });
+        test_metadata
+            .create_v2(
+                &mut context,
+                name,
+                symbol,
+                uri,
+                None,
+                10,
+                false,
+                Some(Collection {
+                    key: test_collection.mint.pubkey(),
+                    verified: false,
+                }),
+                uses.to_owned(),
+            )
+            .await
+            .unwrap();
+
+        let kpbytes = &context.payer;
+        let kp = Keypair::from_bytes(&kpbytes.to_bytes()).unwrap();
+        let err = test_metadata
+            .verify_collection(
+                &mut context,
+                test_collection.pubkey,
+                &kp,
+                test_collection.mint.pubkey(),
+                collection_master_edition_account.pubkey,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_custom_error!(err, MetadataError::CollectionMustBeAUniqueMasterEdition);
+        let metadata_after = test_metadata.get_data(&mut context).await;
+        assert_eq!(
+            metadata_after.collection.to_owned().unwrap().key,
+            test_collection.mint.pubkey()
+        );
+        assert_eq!(metadata_after.collection.unwrap().verified, false);
+    }
+
+    #[tokio::test]
+    async fn fail_no_master_edition() {
+        let mut context = program_test().start_with_context().await;
+
+        let test_collection = Metadata::new();
+        test_collection
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+        let test_metadata = Metadata::new();
+
+        let uses = Some(Uses {
+            total: 1,
+            remaining: 1,
+            use_method: UseMethod::Single,
+        });
+        test_metadata
+            .create_v2(
+                &mut context,
+                name,
+                symbol,
+                uri,
+                None,
+                10,
+                false,
+                Some(Collection {
+                    key: test_collection.mint.pubkey(),
+                    verified: false,
+                }),
+                uses.to_owned(),
+            )
+            .await
+            .unwrap();
+
+        let kpbytes = &context.payer;
+        let kp = Keypair::from_bytes(&kpbytes.to_bytes()).unwrap();
+        let err = test_metadata
+            .verify_collection(
+                &mut context,
+                test_collection.pubkey,
+                &kp,
+                test_collection.mint.pubkey(),
+                test_collection.pubkey,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_custom_error!(err, MetadataError::CollectionMustBeAUniqueMasterEdition);
+        let metadata_after = test_metadata.get_data(&mut context).await;
+        assert_eq!(
+            metadata_after.collection.to_owned().unwrap().key,
+            test_collection.mint.pubkey()
+        );
+        assert_eq!(metadata_after.collection.unwrap().verified, false);
+    }
+
+    #[tokio::test]
+    async fn fail_collection_authority_mismatch() {
+        let mut context = program_test().start_with_context().await;
+        let collection_authority = Keypair::new();
+
+        let test_collection = Metadata::new();
+        test_collection
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let collection_master_edition_account = MasterEditionV2::new(&test_collection);
+        collection_master_edition_account
+            .create_v3(&mut context, Some(0))
+            .await
+            .unwrap();
+
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+        let test_metadata = Metadata::new();
+
+        let uses = Some(Uses {
+            total: 1,
+            remaining: 1,
+            use_method: UseMethod::Single,
+        });
+        test_metadata
+            .create_v2(
+                &mut context,
+                name,
+                symbol,
+                uri,
+                None,
+                10,
+                false,
+                Some(Collection {
+                    key: test_collection.mint.pubkey(),
+                    verified: false,
+                }),
+                uses.to_owned(),
+            )
+            .await
+            .unwrap();
+
+        let err = test_metadata
+            .verify_collection(
+                &mut context,
+                test_collection.pubkey,
+                &collection_authority,
+                test_collection.mint.pubkey(),
+                collection_master_edition_account.pubkey,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_custom_error!(err, MetadataError::InvalidCollectionUpdateAuthority);
+        let metadata_after = test_metadata.get_data(&mut context).await;
+        assert_eq!(
+            metadata_after.collection.to_owned().unwrap().key,
+            test_collection.mint.pubkey()
+        );
+        assert_eq!(metadata_after.collection.unwrap().verified, false);
+    }
+
     #[tokio::test]
     async fn success() {
         let mut context = program_test().start_with_context().await;
@@ -107,9 +499,10 @@ mod verify_collection {
             .verify_collection(
                 &mut context,
                 test_collection.pubkey,
-                kp,
+                &kp,
                 test_collection.mint.pubkey(),
                 collection_master_edition_account.pubkey,
+                None,
             )
             .await
             .unwrap();
@@ -123,225 +516,9 @@ mod verify_collection {
     }
 
     #[tokio::test]
-    async fn fail_no_collection_nft_token_standard() {
+    async fn success_verify_collection_with_authority() {
         let mut context = program_test().start_with_context().await;
-
-        let test_collection = Metadata::new();
-        test_collection
-            .create_v2(
-                &mut context,
-                "Test".to_string(),
-                "TST".to_string(),
-                "uri".to_string(),
-                None,
-                10,
-                false,
-                None,
-                None,
-            )
-            .await
-            .unwrap();
-        let collection_master_edition_account = MasterEditionV2::new(&test_collection);
-        collection_master_edition_account
-            .create(&mut context, Some(0))
-            .await
-            .unwrap();
-
-        let name = "Test".to_string();
-        let symbol = "TST".to_string();
-        let uri = "uri".to_string();
-        let test_metadata = Metadata::new();
-        let uses = Some(Uses {
-            total: 1,
-            remaining: 1,
-            use_method: UseMethod::Single,
-        });
-        test_metadata
-            .create_v2(
-                &mut context,
-                name,
-                symbol,
-                uri,
-                None,
-                10,
-                false,
-                Some(Collection {
-                    key: test_collection.mint.pubkey(),
-                    verified: false,
-                }),
-                uses.to_owned(),
-            )
-            .await
-            .unwrap();
-
-        let kpbytes = &context.payer;
-        let kp = Keypair::from_bytes(&kpbytes.to_bytes()).unwrap();
-        let err = test_metadata
-            .verify_collection(
-                &mut context,
-                test_collection.pubkey,
-                kp,
-                test_collection.mint.pubkey(),
-                collection_master_edition_account.pubkey,
-            )
-            .await
-            .unwrap_err();
-        assert_custom_error!(err, MetadataError::CollectionMustBeAUniqueMasterEdition);
-        let metadata_after = test_metadata.get_data(&mut context).await;
-        assert_eq!(
-            metadata_after.collection.to_owned().unwrap().key,
-            test_collection.mint.pubkey()
-        );
-        assert_eq!(metadata_after.collection.unwrap().verified, false);
-    }
-
-    #[tokio::test]
-    async fn fail_non_unique_master_edition() {
-        let mut context = program_test().start_with_context().await;
-
-        let test_collection = Metadata::new();
-        test_collection
-            .create_v2(
-                &mut context,
-                "Test".to_string(),
-                "TST".to_string(),
-                "uri".to_string(),
-                None,
-                10,
-                false,
-                None,
-                None,
-            )
-            .await
-            .unwrap();
-        let collection_master_edition_account = MasterEditionV2::new(&test_collection);
-        collection_master_edition_account
-            .create(&mut context, Some(1))
-            .await
-            .unwrap();
-
-        let name = "Test".to_string();
-        let symbol = "TST".to_string();
-        let uri = "uri".to_string();
-        let test_metadata = Metadata::new();
-        let uses = Some(Uses {
-            total: 1,
-            remaining: 1,
-            use_method: UseMethod::Single,
-        });
-        test_metadata
-            .create_v2(
-                &mut context,
-                name,
-                symbol,
-                uri,
-                None,
-                10,
-                false,
-                Some(Collection {
-                    key: test_collection.mint.pubkey(),
-                    verified: false,
-                }),
-                uses.to_owned(),
-            )
-            .await
-            .unwrap();
-
-        let kpbytes = &context.payer;
-        let kp = Keypair::from_bytes(&kpbytes.to_bytes()).unwrap();
-        let err = test_metadata
-            .verify_collection(
-                &mut context,
-                test_collection.pubkey,
-                kp,
-                test_collection.mint.pubkey(),
-                collection_master_edition_account.pubkey,
-            )
-            .await
-            .unwrap_err();
-        assert_custom_error!(err, MetadataError::CollectionMustBeAUniqueMasterEdition);
-        let metadata_after = test_metadata.get_data(&mut context).await;
-        assert_eq!(
-            metadata_after.collection.to_owned().unwrap().key,
-            test_collection.mint.pubkey()
-        );
-        assert_eq!(metadata_after.collection.unwrap().verified, false);
-    }
-
-    #[tokio::test]
-    async fn fail_no_master_edition() {
-        let mut context = program_test().start_with_context().await;
-
-        let test_collection = Metadata::new();
-        test_collection
-            .create_v2(
-                &mut context,
-                "Test".to_string(),
-                "TST".to_string(),
-                "uri".to_string(),
-                None,
-                10,
-                false,
-                None,
-                None,
-            )
-            .await
-            .unwrap();
-
-        let name = "Test".to_string();
-        let symbol = "TST".to_string();
-        let uri = "uri".to_string();
-        let test_metadata = Metadata::new();
-
-        let uses = Some(Uses {
-            total: 1,
-            remaining: 1,
-            use_method: UseMethod::Single,
-        });
-        test_metadata
-            .create_v2(
-                &mut context,
-                name,
-                symbol,
-                uri,
-                None,
-                10,
-                false,
-                Some(Collection {
-                    key: test_collection.mint.pubkey(),
-                    verified: false,
-                }),
-                uses.to_owned(),
-            )
-            .await
-            .unwrap();
-
-        let kpbytes = &context.payer;
-        let kp = Keypair::from_bytes(&kpbytes.to_bytes()).unwrap();
-        let err = test_metadata
-            .verify_collection(
-                &mut context,
-                test_collection.pubkey,
-                kp,
-                test_collection.mint.pubkey(),
-                test_collection.pubkey,
-            )
-            .await
-            .unwrap_err();
-        assert_custom_error!(err, MetadataError::CollectionMustBeAUniqueMasterEdition);
-        let metadata_after = test_metadata.get_data(&mut context).await;
-        assert_eq!(
-            metadata_after.collection.to_owned().unwrap().key,
-            test_collection.mint.pubkey()
-        );
-        assert_eq!(metadata_after.collection.unwrap().verified, false);
-    }
-
-    #[tokio::test]
-    async fn fail_collection_authority_mismatch() {
-        let mut context = program_test().start_with_context().await;
-        let collection_authority = Keypair::new();
-
+        let new_collection_authority = Keypair::new();
         let test_collection = Metadata::new();
         test_collection
             .create_v2(
@@ -367,7 +544,120 @@ mod verify_collection {
         let symbol = "TST".to_string();
         let uri = "uri".to_string();
         let test_metadata = Metadata::new();
+        test_metadata
+            .create_v2(
+                &mut context,
+                name,
+                symbol,
+                uri,
+                None,
+                10,
+                false,
+                Some(Collection {
+                    key: test_collection.mint.pubkey(),
+                    verified: false,
+                }),
+                None,
+            )
+            .await
+            .unwrap();
 
+        let metadata = test_metadata.get_data(&mut context).await;
+        assert_eq!(
+            metadata.collection.to_owned().unwrap().key,
+            test_collection.mint.pubkey()
+        );
+        assert_eq!(metadata.collection.unwrap().verified, false);
+        let (record, _) = find_collection_authority_account(
+            &test_collection.mint.pubkey(),
+            &new_collection_authority.pubkey(),
+        );
+        let ix = mpl_token_metadata::instruction::approve_collection_authority(
+            mpl_token_metadata::id(),
+            record,
+            new_collection_authority.pubkey(),
+            context.payer.pubkey(),
+            context.payer.pubkey(),
+            test_collection.pubkey,
+            test_collection.mint.pubkey(),
+        );
+
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+
+        context.banks_client.process_transaction(tx).await.unwrap();
+
+        let record_account = get_account(&mut context, &record).await;
+        let record_data: CollectionAuthorityRecord =
+            try_from_slice_unchecked(&record_account.data).unwrap();
+        assert_eq!(record_data.key, Key::CollectionAuthorityRecord);
+
+        test_metadata
+            .verify_collection(
+                &mut context,
+                test_collection.pubkey,
+                &new_collection_authority,
+                test_collection.mint.pubkey(),
+                collection_master_edition_account.pubkey,
+                Some(record),
+            )
+            .await
+            .unwrap();
+
+        let metadata_after = test_metadata.get_data(&mut context).await;
+        assert_eq!(
+            metadata_after.collection.to_owned().unwrap().key,
+            test_collection.mint.pubkey()
+        );
+        assert_eq!(metadata_after.collection.unwrap().verified, true);
+
+        test_metadata
+            .unverify_collection(
+                &mut context,
+                test_collection.pubkey,
+                &new_collection_authority,
+                test_collection.mint.pubkey(),
+                collection_master_edition_account.pubkey,
+                Some(record),
+            )
+            .await
+            .unwrap();
+        let metadata_after_unverify = test_metadata.get_data(&mut context).await;
+        assert_eq!(metadata_after_unverify.collection.unwrap().verified, false);
+    }
+
+    async fn fail_verify_collection_with_authority() {
+        let mut context = program_test().start_with_context().await;
+        let new_collection_authority = Keypair::new();
+        let test_collection = Metadata::new();
+        test_collection
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let collection_master_edition_account = MasterEditionV2::new(&test_collection);
+        collection_master_edition_account
+            .create_v3(&mut context, Some(0))
+            .await
+            .unwrap();
+
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+        let test_metadata = Metadata::new();
         let uses = Some(Uses {
             total: 1,
             remaining: 1,
@@ -391,22 +681,69 @@ mod verify_collection {
             .await
             .unwrap();
 
+        let metadata = test_metadata.get_data(&mut context).await;
+        assert_eq!(
+            metadata.collection.to_owned().unwrap().key,
+            test_collection.mint.pubkey()
+        );
+        assert_eq!(metadata.collection.unwrap().verified, false);
+        let (record, _) = find_collection_authority_account(
+            &test_metadata.mint.pubkey(),
+            &new_collection_authority.pubkey(),
+        );
+        let ix = mpl_token_metadata::instruction::approve_collection_authority(
+            mpl_token_metadata::id(),
+            record,
+            new_collection_authority.pubkey(),
+            context.payer.pubkey(),
+            context.payer.pubkey(),
+            test_metadata.token.pubkey(),
+            test_metadata.mint.pubkey(),
+        );
+
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+
+        context.banks_client.process_transaction(tx).await.unwrap();
+
+        let ixrevoke = mpl_token_metadata::instruction::revoke_collection_authority(
+            mpl_token_metadata::id(),
+            record,
+            new_collection_authority.pubkey(),
+            test_metadata.pubkey,
+            test_metadata.mint.pubkey(),
+        );
+
+        let txrevoke = Transaction::new_signed_with_payer(
+            &[ixrevoke],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+
+        context
+            .banks_client
+            .process_transaction(txrevoke)
+            .await
+            .unwrap();
+
         let err = test_metadata
             .verify_collection(
                 &mut context,
                 test_collection.pubkey,
-                collection_authority,
+                &new_collection_authority,
                 test_collection.mint.pubkey(),
                 collection_master_edition_account.pubkey,
+                Some(record),
             )
             .await
             .unwrap_err();
         assert_custom_error!(err, MetadataError::InvalidCollectionUpdateAuthority);
         let metadata_after = test_metadata.get_data(&mut context).await;
-        assert_eq!(
-            metadata_after.collection.to_owned().unwrap().key,
-            test_collection.mint.pubkey()
-        );
         assert_eq!(metadata_after.collection.unwrap().verified, false);
     }
 }


### PR DESCRIPTION
Closes #87 
Allows collection authority to be delegated to another key.

- [ ] check data on verify or un verify of record pda