### PR TITLE
feature: add ValidateSafetyDepositBoxV2 instruction

### DIFF
--- a/metaplex/js/src/accounts/SafetyDepositConfig.ts
+++ b/metaplex/js/src/accounts/SafetyDepositConfig.ts
@@ -1,13 +1,11 @@
-import { AccountInfo, PublicKey, SystemProgram } from '@solana/web3.js';
+import { AccountInfo, PublicKey } from '@solana/web3.js';
 import BN from 'bn.js';
-import bs58 from 'bs58';
 import {
   AnyPublicKey,
   StringPublicKey,
   Account,
   ERROR_INVALID_ACCOUNT_DATA,
   ERROR_INVALID_OWNER,
-  getBNFromData,
   TupleNumericType,
   Borsh,
 } from '@metaplex-foundation/mpl-core';
@@ -65,12 +63,6 @@ export class AmountRange extends Borsh.Data<AmountRangeArgs> {
 
   amount: BN;
   length: BN;
-
-  constructor(args: AmountRangeArgs) {
-    super(args);
-    this.amount = args.amount || new BN(1);
-    this.length = args.length || new BN(1);
-  }
 }
 
 export interface ParticipationConfigV2Args {
@@ -89,14 +81,6 @@ export class ParticipationConfigV2 extends Borsh.Data<ParticipationConfigV2Args>
   winnerConstraint: WinningConstraint;
   nonWinningConstraint: NonWinningConstraint;
   fixedPrice: BN | null;
-
-  constructor(args: ParticipationConfigV2Args) {
-    super(args);
-    this.winnerConstraint = args.winnerConstraint || WinningConstraint.NoParticipationPrize;
-    this.nonWinningConstraint =
-      args.nonWinningConstraint || NonWinningConstraint.GivenForFixedPrice;
-    this.fixedPrice = args.fixedPrice || null;
-  }
 }
 
 export interface ParticipationStateV2Args {
@@ -107,11 +91,6 @@ export class ParticipationStateV2 extends Borsh.Data<ParticipationStateV2Args> {
   static readonly SCHEMA = this.struct([['collectedToAcceptPayment', 'u64']]);
 
   collectedToAcceptPayment: BN;
-
-  constructor(args: ParticipationStateV2Args) {
-    super(args);
-    this.collectedToAcceptPayment = args.collectedToAcceptPayment || new BN(0);
-  }
 }
 
 export interface SafetyDepositConfigDataArgs {
@@ -156,14 +135,6 @@ export class SafetyDepositConfigData extends Borsh.Data<SafetyDepositConfigDataA
   constructor(args: SafetyDepositConfigDataArgs) {
     super(args);
     this.key = MetaplexKey.SafetyDepositConfigV1;
-    this.auctionManager = args.auctionManager || SystemProgram.programId.toString();
-    this.order = args.order || new BN(0);
-    this.winningConfigType = args.winningConfigType || WinningConfigType.PrintingV2;
-    this.amountType = args.amountType || TupleNumericType.U8;
-    this.lengthType = args.lengthType || TupleNumericType.U8;
-    this.amountRanges = args.amountRanges || [];
-    this.participationConfig = args.participationConfig || null;
-    this.participationState = args.participationState || null;
   }
 }
 

--- a/metaplex/js/src/accounts/SafetyDepositConfig.ts
+++ b/metaplex/js/src/accounts/SafetyDepositConfig.ts
@@ -1,4 +1,4 @@
-import { AccountInfo, PublicKey } from '@solana/web3.js';
+import { AccountInfo, PublicKey, SystemProgram } from '@solana/web3.js';
 import BN from 'bn.js';
 import bs58 from 'bs58';
 import {
@@ -9,6 +9,7 @@ import {
   ERROR_INVALID_OWNER,
   getBNFromData,
   TupleNumericType,
+  Borsh,
 } from '@metaplex-foundation/mpl-core';
 import { MetaplexKey, MetaplexProgram } from '../MetaplexProgram';
 import { Buffer } from 'buffer';
@@ -51,23 +52,69 @@ export enum NonWinningConstraint {
   GivenForBidPrice = 2,
 }
 
-export interface AmountRange {
+export interface AmountRangeArgs {
   amount: BN;
   length: BN;
 }
 
-export interface ParticipationConfigV2 {
+export class AmountRange extends Borsh.Data<AmountRangeArgs> {
+  static readonly SCHEMA = this.struct([
+    ['amount', 'u64'],
+    ['length', 'u64'],
+  ]);
+
+  amount: BN;
+  length: BN;
+
+  constructor(args: AmountRangeArgs) {
+    super(args);
+    this.amount = args.amount || new BN(1);
+    this.length = args.length || new BN(1);
+  }
+}
+
+export interface ParticipationConfigV2Args {
   winnerConstraint: WinningConstraint;
   nonWinningConstraint: NonWinningConstraint;
   fixedPrice: BN | null;
 }
 
-export interface ParticipationStateV2 {
+export class ParticipationConfigV2 extends Borsh.Data<ParticipationConfigV2Args> {
+  static readonly SCHEMA = this.struct([
+    ['winnerConstraint', 'u8'],
+    ['nonWinningConstraint', 'u8'],
+    ['fixedPrice', { kind: 'option', type: 'u64' }],
+  ]);
+
+  winnerConstraint: WinningConstraint;
+  nonWinningConstraint: NonWinningConstraint;
+  fixedPrice: BN | null;
+
+  constructor(args: ParticipationConfigV2Args) {
+    super(args);
+    this.winnerConstraint = args.winnerConstraint || WinningConstraint.NoParticipationPrize;
+    this.nonWinningConstraint =
+      args.nonWinningConstraint || NonWinningConstraint.GivenForFixedPrice;
+    this.fixedPrice = args.fixedPrice || null;
+  }
+}
+
+export interface ParticipationStateV2Args {
   collectedToAcceptPayment: BN;
 }
 
-export interface SafetyDepositConfigData {
-  key: MetaplexKey;
+export class ParticipationStateV2 extends Borsh.Data<ParticipationStateV2Args> {
+  static readonly SCHEMA = this.struct([['collectedToAcceptPayment', 'u64']]);
+
+  collectedToAcceptPayment: BN;
+
+  constructor(args: ParticipationStateV2Args) {
+    super(args);
+    this.collectedToAcceptPayment = args.collectedToAcceptPayment || new BN(0);
+  }
+}
+
+export interface SafetyDepositConfigDataArgs {
   auctionManager: StringPublicKey;
   order: BN;
   winningConfigType: WinningConfigType;
@@ -76,6 +123,48 @@ export interface SafetyDepositConfigData {
   amountRanges: AmountRange[];
   participationConfig: ParticipationConfigV2 | null;
   participationState: ParticipationStateV2 | null;
+}
+
+export class SafetyDepositConfigData extends Borsh.Data<SafetyDepositConfigDataArgs> {
+  static readonly SCHEMA = new Map([
+    ...ParticipationConfigV2.SCHEMA,
+    ...ParticipationStateV2.SCHEMA,
+    ...AmountRange.SCHEMA,
+    ...this.struct([
+      ['key', 'u8'],
+      ['auctionManager', 'pubkeyAsString'],
+      ['order', 'u64'],
+      ['winningConfigType', 'u8'],
+      ['amountType', 'u8'],
+      ['lengthType', 'u8'],
+      ['amountRanges', [AmountRange]],
+      ['participationConfig', { kind: 'option', type: ParticipationConfigV2 }],
+      ['participationState', { kind: 'option', type: ParticipationStateV2 }],
+    ]),
+  ]);
+
+  key: MetaplexKey = MetaplexKey.SafetyDepositConfigV1;
+  auctionManager: StringPublicKey;
+  order: BN;
+  winningConfigType: WinningConfigType;
+  amountType: TupleNumericType;
+  lengthType: TupleNumericType;
+  amountRanges: AmountRange[];
+  participationConfig: ParticipationConfigV2 | null;
+  participationState: ParticipationStateV2 | null;
+
+  constructor(args: SafetyDepositConfigDataArgs) {
+    super(args);
+    this.key = MetaplexKey.SafetyDepositConfigV1;
+    this.auctionManager = args.auctionManager || SystemProgram.programId.toString();
+    this.order = args.order || new BN(0);
+    this.winningConfigType = args.winningConfigType || WinningConfigType.PrintingV2;
+    this.amountType = args.amountType || TupleNumericType.U8;
+    this.lengthType = args.lengthType || TupleNumericType.U8;
+    this.amountRanges = args.amountRanges || [];
+    this.participationConfig = args.participationConfig || null;
+    this.participationState = args.participationState || null;
+  }
 }
 
 export class SafetyDepositConfig extends Account<SafetyDepositConfigData> {
@@ -90,7 +179,7 @@ export class SafetyDepositConfig extends Account<SafetyDepositConfigData> {
       throw ERROR_INVALID_ACCOUNT_DATA();
     }
 
-    this.data = deserialize(this.info.data);
+    this.data = SafetyDepositConfigData.deserialize(this.info.data);
   }
 
   static isCompatible(data: Buffer) {
@@ -106,65 +195,3 @@ export class SafetyDepositConfig extends Account<SafetyDepositConfigData> {
     ]);
   }
 }
-
-const deserialize = (buffer: Buffer) => {
-  const data: SafetyDepositConfigData = {
-    key: MetaplexKey.SafetyDepositConfigV1,
-    auctionManager: bs58.encode(buffer.slice(1, 33)),
-    order: new BN(buffer.slice(33, 41), 'le'),
-    winningConfigType: buffer[41],
-    amountType: buffer[42],
-    lengthType: buffer[43],
-    amountRanges: [],
-    participationConfig: null,
-    participationState: null,
-  };
-
-  const lengthOfArray = new BN(buffer.slice(44, 48), 'le');
-  let offset = 48;
-
-  for (let i = 0; i < lengthOfArray.toNumber(); i++) {
-    const amount = getBNFromData(buffer, offset, data.amountType);
-    offset += data.amountType;
-    const length = getBNFromData(buffer, offset, data.lengthType);
-    offset += data.lengthType;
-    data.amountRanges.push({ amount, length });
-  }
-
-  if (buffer[offset] == 0) {
-    offset += 1;
-    data.participationConfig = null;
-  } else {
-    // pick up participation config manually
-    const winnerConstraint = buffer[offset + 1];
-    const nonWinningConstraint = buffer[offset + 2];
-    let fixedPrice: BN | null = null;
-    offset += 3;
-
-    if (buffer[offset] == 1) {
-      fixedPrice = new BN(buffer.slice(offset + 1, offset + 9), 'le');
-      offset += 9;
-    } else {
-      offset += 1;
-    }
-    data.participationConfig = {
-      winnerConstraint,
-      nonWinningConstraint,
-      fixedPrice,
-    };
-  }
-
-  if (buffer[offset] == 0) {
-    offset += 1;
-    data.participationState = null;
-  } else {
-    // pick up participation state manually
-    const collectedToAcceptPayment = new BN(buffer.slice(offset + 1, offset + 9), 'le');
-    offset += 9;
-    data.participationState = {
-      collectedToAcceptPayment,
-    };
-  }
-
-  return data;
-};

--- a/metaplex/js/src/transactions/ValidateSafetyDepositBoxV2.ts
+++ b/metaplex/js/src/transactions/ValidateSafetyDepositBoxV2.ts
@@ -36,7 +36,7 @@ type ValidateSafetyDepositBoxV2Params = {
   tokenAccount: PublicKey;
   tokenMint: PublicKey;
   edition: PublicKey;
-  whitelistedCreator: PublicKey | undefined;
+  whitelistedCreator: PublicKey;
   safetyDepositBox: PublicKey;
   safetyDepositTokenStore: PublicKey;
   safetyDepositConfig: PublicKey;
@@ -101,7 +101,7 @@ export class ValidateSafetyDepositBoxV2 extends Transaction {
             isWritable: true,
           },
           {
-            pubkey: whitelistedCreator || SystemProgram.programId,
+            pubkey: whitelistedCreator,
             isSigner: false,
             isWritable: false,
           },

--- a/metaplex/js/src/transactions/ValidateSafetyDepositBoxV2.ts
+++ b/metaplex/js/src/transactions/ValidateSafetyDepositBoxV2.ts
@@ -1,0 +1,175 @@
+import { Borsh, Transaction } from '@metaplex-foundation/mpl-core';
+import { MetadataProgram } from '@metaplex-foundation/mpl-token-metadata';
+import { ParamsWithStore } from '@metaplex-foundation/mpl-token-vault';
+import {
+  PublicKey,
+  SystemProgram,
+  SYSVAR_RENT_PUBKEY,
+  TransactionCtorFields,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import { MetaplexProgram } from '../MetaplexProgram';
+import { SafetyDepositConfigData } from '../mpl-metaplex';
+
+export class ValidateSafetyDepositBoxV2Args extends Borsh.Data<{
+  safetyDepositConfig: SafetyDepositConfigData;
+}> {
+  static readonly SCHEMA = new Map([
+    ...SafetyDepositConfigData.SCHEMA,
+    ...this.struct([
+      ['instruction', 'u8'],
+      ['safetyDepositConfig', SafetyDepositConfigData],
+    ]),
+  ]);
+  instruction = 18;
+  safetyDepositConfig: SafetyDepositConfigData;
+}
+
+type ValidateSafetyDepositBoxV2Params = {
+  store: PublicKey;
+  vault: PublicKey;
+  auctionManager: PublicKey;
+  auctionManagerAuthority: PublicKey;
+  metadataAuthority: PublicKey;
+  originalAuthorityLookup: PublicKey;
+  tokenTracker: PublicKey;
+  tokenAccount: PublicKey;
+  tokenMint: PublicKey;
+  edition: PublicKey;
+  whitelistedCreator: PublicKey | undefined;
+  safetyDepositBox: PublicKey;
+  safetyDepositTokenStore: PublicKey;
+  safetyDepositConfig: PublicKey;
+  safetyDepositConfigData: SafetyDepositConfigData;
+};
+
+export class ValidateSafetyDepositBoxV2 extends Transaction {
+  constructor(
+    options: TransactionCtorFields,
+    params: ParamsWithStore<ValidateSafetyDepositBoxV2Params>,
+  ) {
+    super(options);
+    const { feePayer } = options;
+    const {
+      store,
+      vault,
+      auctionManager,
+      auctionManagerAuthority,
+      metadataAuthority,
+      originalAuthorityLookup,
+      tokenTracker,
+      tokenAccount,
+      tokenMint,
+      edition,
+      whitelistedCreator,
+      safetyDepositBox,
+      safetyDepositTokenStore,
+      safetyDepositConfig,
+      safetyDepositConfigData,
+    } = params;
+
+    const data = ValidateSafetyDepositBoxV2Args.serialize({
+      safetyDepositConfig: safetyDepositConfigData,
+    });
+
+    this.add(
+      new TransactionInstruction({
+        keys: [
+          {
+            pubkey: safetyDepositConfig,
+            isSigner: false,
+            isWritable: true,
+          },
+          {
+            pubkey: tokenTracker,
+            isSigner: false,
+            isWritable: true,
+          },
+          {
+            pubkey: auctionManager,
+            isSigner: false,
+            isWritable: true,
+          },
+          {
+            pubkey: tokenAccount,
+            isSigner: false,
+            isWritable: true,
+          },
+          {
+            pubkey: originalAuthorityLookup,
+            isSigner: false,
+            isWritable: true,
+          },
+          {
+            pubkey: whitelistedCreator || SystemProgram.programId,
+            isSigner: false,
+            isWritable: false,
+          },
+          {
+            pubkey: store,
+            isSigner: false,
+            isWritable: false,
+          },
+          {
+            pubkey: safetyDepositBox,
+            isSigner: false,
+            isWritable: false,
+          },
+          {
+            pubkey: safetyDepositTokenStore,
+            isSigner: false,
+            isWritable: false,
+          },
+          {
+            pubkey: tokenMint,
+            isSigner: false,
+            isWritable: false,
+          },
+          {
+            pubkey: edition,
+            isSigner: false,
+            isWritable: false,
+          },
+          {
+            pubkey: vault,
+            isSigner: false,
+            isWritable: false,
+          },
+          {
+            pubkey: auctionManagerAuthority,
+            isSigner: true,
+            isWritable: false,
+          },
+          {
+            pubkey: metadataAuthority,
+            isSigner: true,
+            isWritable: false,
+          },
+
+          {
+            pubkey: feePayer,
+            isSigner: true,
+            isWritable: false,
+          },
+          {
+            pubkey: MetadataProgram.PUBKEY,
+            isSigner: false,
+            isWritable: false,
+          },
+          {
+            pubkey: SystemProgram.programId,
+            isSigner: false,
+            isWritable: false,
+          },
+          {
+            pubkey: SYSVAR_RENT_PUBKEY,
+            isSigner: false,
+            isWritable: false,
+          },
+        ],
+        programId: MetaplexProgram.PUBKEY,
+        data,
+      }),
+    );
+  }
+}

--- a/metaplex/js/src/transactions/index.ts
+++ b/metaplex/js/src/transactions/index.ts
@@ -9,3 +9,4 @@ export * from './SetStoreV2';
 export * from './SetWhitelistedCreator';
 export * from './StartAuction';
 export * from './RedeemParticipationBidV3';
+export * from './ValidateSafetyDepositBoxV2';


### PR DESCRIPTION
- add `ValidateSafetyDepositBoxV2` instruction (needed for start auction)
- add schema for `SafetyDepositConfigData`, `ParticipationStateV2`, `ParticipationConfigV2`, `AmountRange`
- remove manual deserialize for `SafetyDepositConfigData`