### PR TITLE
[Candy Machine v2] Adding rent exemption to CMv2 account creation

### DIFF
--- a/nft-candy-machine/program/src/lib.rs
+++ b/nft-candy-machine/program/src/lib.rs
@@ -116,7 +116,8 @@ pub mod nft_candy_machine_v2 {
                     msg!(
                         "Comparing token expire time {} and go_live_date {}",
                         expire_time,
-                        val);
+                        val
+                    );
                     if (expire_time - EXPIRE_OFFSET) < val {
                         if let Some(ws) = &candy_machine.data.whitelist_mint_settings {
                             // when dealing with whitelist, the expire_time can be
@@ -660,7 +661,7 @@ fn get_space_for_candy(data: CandyMachineData) -> core::result::Result<usize, Pr
 #[derive(Accounts)]
 #[instruction(data: CandyMachineData)]
 pub struct InitializeCandyMachine<'info> {
-    #[account(zero, constraint= candy_machine.to_account_info().owner == program_id && candy_machine.to_account_info().data_len() >= get_space_for_candy(data)?)]
+    #[account(zero, rent_exempt = skip, constraint = candy_machine.to_account_info().owner == program_id && candy_machine.to_account_info().data_len() >= get_space_for_candy(data)?)]
     candy_machine: UncheckedAccount<'info>,
     wallet: UncheckedAccount<'info>,
     authority: UncheckedAccount<'info>,


### PR DESCRIPTION
Users are complaining ([see issue here](https://github.com/metaplex-foundation/metaplex/issues/1371)) about a lack of rent exemption when creating their Candy Machines. Opening this PR to start a discuss if we want to move forward with this change, if there are unknown security side effects or anything else we'd like to discuss before we go ahead, or reject, this change.

https://docs.rs/anchor-lang/0.18.0/anchor_lang/derive.Accounts.html

`Optional attribute to skip the rent exemption check. By default, all accounts marked with #[account(init)] will be rent exempt, and so this should rarely (if ever) be used. Similarly, omitting = skip will mark the account rent exempt.`