### PR TITLE
Publish token metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,7 +1932,7 @@ dependencies = [
  "bincode",
  "borsh 0.9.1",
  "clap",
- "mpl-token-vault",
+ "mpl-token-vault 0.1.0",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
@@ -2039,7 +2039,7 @@ dependencies = [
  "borsh 0.9.1",
  "mpl-auction",
  "mpl-token-metadata",
- "mpl-token-vault",
+ "mpl-token-vault 0.1.0",
  "num-derive",
  "num-traits",
  "solana-program",
@@ -2056,7 +2056,7 @@ dependencies = [
  "borsh 0.9.1",
  "mpl-metaplex",
  "mpl-token-metadata",
- "mpl-token-vault",
+ "mpl-token-vault 0.1.0",
  "num-derive",
  "num-traits",
  "num_enum",
@@ -2077,7 +2077,7 @@ dependencies = [
  "anchor-client 0.19.0",
  "borsh 0.9.1",
  "mpl-token-metadata",
- "mpl-token-vault",
+ "mpl-token-vault 0.1.0",
  "num",
  "num-derive",
  "num-traits",
@@ -2109,7 +2109,7 @@ version = "1.1.0"
 dependencies = [
  "arrayref",
  "borsh 0.9.1",
- "mpl-token-vault",
+ "mpl-token-vault 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive",
  "num-traits",
  "solana-program",
@@ -2123,6 +2123,20 @@ dependencies = [
 [[package]]
 name = "mpl-token-vault"
 version = "0.1.0"
+dependencies = [
+ "borsh 0.9.1",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
+name = "mpl-token-vault"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ade4ef15bc06a6033076c4ff28cba9b42521df5ec61211d6f419415ace2746a"
 dependencies = [
  "borsh 0.9.1",
  "num-derive",

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -2,10 +2,11 @@
 name = "mpl-token-metadata"
 version = "1.1.0"
 description = "Metaplex Metadata"
-authors = ["Metaplex Maintainers <maintainers@metaplex.com>"]
-repository = "https://github.com/metaplex-foundation/metaplex"
+authors = ["Metaplex Developers <dev@metaplex.com>"]
+repository = "https://github.com/metaplex-foundation/metaplex-program-library"
 license = "Apache-2.0"
 edition = "2018"
+readme = "README.md"
 
 [features]
 no-entrypoint = []
@@ -16,7 +17,7 @@ num-derive = "0.3"
 arrayref = "0.3.6"
 num-traits = "0.2"
 solana-program = "1.7.11"
-mpl-token-vault = { path = "../../token-vault/program", features = [ "no-entrypoint" ] }
+mpl-token-vault = { version = "0.1.0", features = [ "no-entrypoint" ] }
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
 spl-associated-token-account = { version = "1.0.3", features = ["no-entrypoint"] }
 thiserror = "1.0"

--- a/token-metadata/program/README.md
+++ b/token-metadata/program/README.md
@@ -13,17 +13,17 @@ document are available at:
 ## Source
 
 The Token Metadata Program's source is available on
-[github](https://github.com/metaplex-foundation/metaplex)
+[github](https://github.com/metaplex-foundation/metaplex-program-library)
 
 There is also an example Rust client located at
-[github](https://github.com/metaplex-foundation/metaplex/tree/master/rust/token-metadata/test/src/main.rs)
+[github](https://github.com/metaplex-foundation/metaplex-program-library/tree/master/token-metadata/test/src/main.rs)
 that can be perused for learning and run if desired with `cargo run --bin metaplex-token-metadata-test-client`. It allows testing out a variety of scenarios.
 
 ## Interface
 
 The on-chain Token Metadata program is written in Rust and available on crates.io as
-[metaplex-token-metadata](https://crates.io/crates/metaplex-token-metadata) and
-[docs.rs](https://docs.rs/metaplex-token-metadata).
+[mpl-token-metadata](https://crates.io/crates/mpl-token-metadata) and
+[docs.rs](https://docs.rs/mpl-token-metadata).
 
 The crate provides four instructions, `create_metadata_accounts()`, `update_metadata_account()`, `create_master_edition()`, `mint_new_edition_from_master_edition_via_token(),` to easily create instructions for the program.
 

--- a/token-metadata/program/src/assertions/collection.rs
+++ b/token-metadata/program/src/assertions/collection.rs
@@ -1,12 +1,9 @@
-use solana_program::{account_info::AccountInfo, msg, program_error::ProgramError, pubkey::Pubkey};
+use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
 
 use crate::{
     error::MetadataError,
     pda::find_collection_authority_account,
-    state::{
-        Collection, DataV2, MasterEditionV2, Metadata, TokenStandard, COLLECTION_AUTHORITY, PREFIX,
-    },
-    utils::assert_derivation,
+    state::{Collection, MasterEditionV2, Metadata, TokenStandard},
 };
 
 pub fn assert_collection_update_is_valid(

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -35,7 +35,7 @@ use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
     msg,
-    program::{invoke, invoke_signed},
+    program::invoke,
     program_error::ProgramError,
     pubkey::Pubkey,
 };
@@ -92,7 +92,7 @@ pub fn process_instruction<'a>(
                 args.is_mutable,
             )
         }
-        MetadataInstruction::DeprecatedCreateMasterEdition(args) => {
+        MetadataInstruction::DeprecatedCreateMasterEdition(_args) => {
             msg!("Instruction: Deprecated Create Master Edition, Removed in 1.1.0");
             Err(MetadataError::Removed.into())
         }
@@ -104,7 +104,7 @@ pub fn process_instruction<'a>(
             msg!("Instruction: Update primary sale via token");
             process_update_primary_sale_happened_via_token(program_id, accounts)
         }
-        MetadataInstruction::DeprecatedSetReservationList(args) => {
+        MetadataInstruction::DeprecatedSetReservationList(_args) => {
             msg!("Instruction: Deprecated Set Reservation List, Removed in 1.1.0");
             Err(MetadataError::Removed.into())
         }
@@ -116,11 +116,11 @@ pub fn process_instruction<'a>(
             msg!("Instruction: Sign Metadata");
             process_sign_metadata(program_id, accounts)
         }
-        MetadataInstruction::DeprecatedMintPrintingTokensViaToken(args) => {
+        MetadataInstruction::DeprecatedMintPrintingTokensViaToken(_args) => {
             msg!("Instruction: Deprecated Mint Printing Tokens Via Token, Removed in 1.1.0");
             Err(MetadataError::Removed.into())
         }
-        MetadataInstruction::DeprecatedMintPrintingTokens(args) => {
+        MetadataInstruction::DeprecatedMintPrintingTokens(_args) => {
             msg!("Instruction: Deprecated Mint Printing Tokens, Removed in 1.1.0");
             Err(MetadataError::Removed.into())
         }


### PR DESCRIPTION
Prepares `token-metadata` v1.1.0 to be published on crates.io.