### PR TITLE
prepare candy-machine for crate publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,7 +1916,7 @@ dependencies = [
  "bincode",
  "borsh 0.9.1",
  "clap",
- "mpl-token-metadata",
+ "mpl-token-metadata 1.1.0",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
@@ -2005,7 +2005,7 @@ dependencies = [
  "arrayref",
  "env_logger",
  "mpl-testing-utils",
- "mpl-token-metadata",
+ "mpl-token-metadata 1.1.0",
  "serde_json",
  "shellexpand",
  "solana-program",
@@ -2024,7 +2024,7 @@ dependencies = [
  "anchor-lang 0.20.1",
  "anchor-spl 0.20.1",
  "chrono",
- "mpl-token-metadata",
+ "mpl-token-metadata 1.1.0",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
@@ -2038,7 +2038,7 @@ dependencies = [
  "arrayref",
  "borsh 0.9.1",
  "mpl-auction",
- "mpl-token-metadata",
+ "mpl-token-metadata 1.1.0",
  "mpl-token-vault 0.1.0",
  "num-derive",
  "num-traits",
@@ -2050,12 +2050,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpl-nft-candy-machine"
+version = "2.0.1"
+dependencies = [
+ "anchor-lang 0.19.0",
+ "anchor-spl 0.19.0",
+ "arrayref",
+ "mpl-token-metadata 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-gateway",
+ "solana-program",
+ "spl-associated-token-account",
+ "spl-token",
+]
+
+[[package]]
 name = "mpl-nft-packs"
 version = "0.1.0"
 dependencies = [
  "borsh 0.9.1",
  "mpl-metaplex",
- "mpl-token-metadata",
+ "mpl-token-metadata 1.1.0",
  "mpl-token-vault 0.1.0",
  "num-derive",
  "num-traits",
@@ -2076,7 +2090,7 @@ version = "0.0.1"
 dependencies = [
  "anchor-client 0.19.0",
  "borsh 0.9.1",
- "mpl-token-metadata",
+ "mpl-token-metadata 1.1.0",
  "mpl-token-vault 0.1.0",
  "num",
  "num-derive",
@@ -2097,7 +2111,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang 0.19.0",
  "anchor-spl 0.19.0",
- "mpl-token-metadata",
+ "mpl-token-metadata 1.1.0",
  "spl-associated-token-account",
  "spl-token",
  "thiserror",
@@ -2115,6 +2129,23 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-associated-token-account",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
+name = "mpl-token-metadata"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5e23f9f14cbd35ab82c471e7a024f617a8f65b0468fa2c8c7eb4def7ebaa18"
+dependencies = [
+ "arrayref",
+ "borsh 0.9.1",
+ "mpl-token-vault 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive",
+ "num-traits",
+ "solana-program",
  "spl-associated-token-account",
  "spl-token",
  "thiserror",
@@ -2152,23 +2183,9 @@ version = "0.0.1"
 dependencies = [
  "anchor-lang 0.19.0",
  "anchor-spl 0.19.0",
- "mpl-token-metadata",
+ "mpl-token-metadata 1.1.0",
  "solana-program",
  "spl-associated-token-account",
-]
-
-[[package]]
-name = "nft-candy-machine"
-version = "2.0.0"
-dependencies = [
- "anchor-lang 0.19.0",
- "anchor-spl 0.19.0",
- "arrayref",
- "mpl-token-metadata",
- "solana-gateway",
- "solana-program",
- "spl-associated-token-account",
- "spl-token",
 ]
 
 [[package]]
@@ -3377,8 +3394,9 @@ dependencies = [
 
 [[package]]
 name = "solana-gateway"
-version = "0.0.4"
-source = "git+https://github.com/identity-com/on-chain-identity-gateway?rev=2d195dcd33bcd1a26b09d79ee90cc6f7282c87aa#2d195dcd33bcd1a26b09d79ee90cc6f7282c87aa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6959300f6f428ee036e9b20d227f45b8908ebe9c7decf9d6c559d713de02ac55"
 dependencies = [
  "bitflags",
  "borsh 0.9.1",

--- a/nft-candy-machine/program/Cargo.toml
+++ b/nft-candy-machine/program/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
-name = "nft-candy-machine"
-version = "2.0.0"
-description = "Created with Anchor"
+name = "mpl-nft-candy-machine"
+version = "2.0.1"
+description = "NFT Candy Machine v2: programmatic and trustless NFT drops."
+authors = ["Jordan Prince", "Metaplex Developers <dev@metaplex.com>"]
+repository = "https://github.com/metaplex-foundation/metaplex-program-library"
+license = "Apache-2.0"
 edition = "2018"
+readme = "README.md"
 
 [lib]
 crate-type = ["cdylib", "lib"]
-name = "nft_candy_machine"
 
 [features]
 no-entrypoint = []
@@ -18,8 +21,8 @@ default = []
 anchor-lang = "0.19.0"
 arrayref = "0.3.6"
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
-mpl-token-metadata = { path = "../../token-metadata/program", features = [ "no-entrypoint" ] }
+mpl-token-metadata = { version = "1.1.0", features = [ "no-entrypoint" ] }
 spl-associated-token-account = {version = "1.0.3", features = ["no-entrypoint"]}
 anchor-spl = "0.19.0"
 solana-program = "1.8.9"
-solana-gateway = { git = "https://github.com/identity-com/on-chain-identity-gateway", rev = "2d195dcd33bcd1a26b09d79ee90cc6f7282c87aa" }
+solana-gateway = "0.1.1"

--- a/nft-candy-machine/program/src/lib.rs
+++ b/nft-candy-machine/program/src/lib.rs
@@ -107,6 +107,7 @@ pub mod nft_candy_machine_v2 {
                     gateway_token_info,
                     &payer.key(),
                     &gatekeeper.gatekeeper_network,
+                    None,
                 )?;
             }
             // verifies that the gatway token was not created before the candy
@@ -116,7 +117,8 @@ pub mod nft_candy_machine_v2 {
                     msg!(
                         "Comparing token expire time {} and go_live_date {}",
                         expire_time,
-                        val);
+                        val
+                    );
                     if (expire_time - EXPIRE_OFFSET) < val {
                         if let Some(ws) = &candy_machine.data.whitelist_mint_settings {
                             // when dealing with whitelist, the expire_time can be


### PR DESCRIPTION
@febo in order to publish this as a crate I'm updating the `solana-gateway` lib from a git dependency to a versioned one on crates.io. This changes the `verify_gateway_token_account_info` to accept a `VerificationOptions` `Option` as you can see from the latest docs [here](https://docs.rs/solana-gateway/0.1.1/solana_gateway/struct.Gateway.html#method.verify_gateway_token_account_info). Passing in `None` uses the default options which I think is what we want, but it might make our time expired check redundant. Take a look when you get a chance and let me know if you have any questions. 