### PR TITLE
Remove default values from AuctionManagerStateV2

### DIFF
--- a/metaplex/js/src/accounts/AuctionManager.ts
+++ b/metaplex/js/src/accounts/AuctionManager.ts
@@ -36,10 +36,10 @@ export class AuctionManagerStateV2 extends Borsh.Data<{
     ['hasParticipation', 'u8'],
   ]);
 
-  status: AuctionManagerStatus = AuctionManagerStatus.Initialized;
-  safetyConfigItemsValidated: BN = new BN(0);
-  bidsPushedToAcceptPayment: BN = new BN(0);
-  hasParticipation = false;
+  status: AuctionManagerStatus;
+  safetyConfigItemsValidated: BN;
+  bidsPushedToAcceptPayment: BN;
+  hasParticipation;
 }
 
 type Args = {


### PR DESCRIPTION
The default values in AuctionManagerStateV2 override the values assigned in the Borsch.Data constructor, resulting in an object that always has default values.