### PR TITLE
(fix) migrate bump seeds on UARs

### DIFF
--- a/token-metadata/Cargo.lock
+++ b/token-metadata/Cargo.lock
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "arrayref",
  "borsh",

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -1,7 +1,7 @@
 cargo-features = ["edition2021"]
 [package]
 name = "mpl-token-metadata"
-version = "1.2.0"
+version = "1.2.1"
 description = "Metaplex Metadata"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/metaplex-program-library"

--- a/token-metadata/program/src/assertions/collection.rs
+++ b/token-metadata/program/src/assertions/collection.rs
@@ -35,7 +35,6 @@ pub fn assert_has_collection_authority(
     mint: &Pubkey,
     delegate_collection_authority_record: Option<&AccountInfo>,
 ) -> Result<(), ProgramError> {
-
     if let Some(collection_authority_record) = delegate_collection_authority_record {
         let bump = assert_is_collection_delegated_authority(
             collection_authority_record,

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -811,7 +811,6 @@ pub fn unverify_collection(
 ///   7. `[]` System program
 ///   8. `[]` Rent info
 ///   9. Optional `[writable]` Use Authority Record PDA If present the program Assumes a delegated use authority
-
 #[allow(clippy::too_many_arguments)]
 pub fn utilize(
     program_id: Pubkey,
@@ -1068,7 +1067,7 @@ pub fn set_and_verify_collection(
     }
     Instruction {
         program_id,
-        accounts: accounts,
+        accounts,
         data: MetadataInstruction::SetAndVerifyCollection
             .try_to_vec()
             .unwrap(),

--- a/token-metadata/program/src/state.rs
+++ b/token-metadata/program/src/state.rs
@@ -207,10 +207,6 @@ impl CollectionAuthorityRecord {
         let ca: CollectionAuthorityRecord = try_from_slice_checked(b, Key::CollectionAuthorityRecord, COLLECTION_AUTHORITY_RECORD_SIZE)?;
         Ok(ca)
     }
-
-    pub fn bump_empty(&self) -> bool {
-        return self.bump == 0 && self.key != Key::CollectionAuthorityRecord;
-    }
 }
 
 #[repr(C)]

--- a/token-metadata/program/src/state.rs
+++ b/token-metadata/program/src/state.rs
@@ -71,7 +71,7 @@ pub const MAX_EDITION_MARKER_SIZE: usize = 32;
 
 pub const EDITION_MARKER_BIT_SIZE: u64 = 248;
 
-pub const USE_AUTHORITY_RECORD_SIZE: usize = 18; //10 byte padding
+pub const USE_AUTHORITY_RECORD_SIZE: usize = 18; //8 byte padding
 
 pub const COLLECTION_AUTHORITY_RECORD_SIZE: usize = 11; //10 byte padding
 
@@ -174,14 +174,16 @@ impl UseAuthorityRecord {
     pub fn from_account_info(a: &AccountInfo) -> Result<UseAuthorityRecord, ProgramError> {
         let ua: UseAuthorityRecord =
             try_from_slice_checked(&a.data.borrow_mut(), Key::UseAuthorityRecord, USE_AUTHORITY_RECORD_SIZE)?;
-
         Ok(ua)
     }
 
     pub fn from_bytes(b: &[u8]) -> Result<UseAuthorityRecord, ProgramError> {
         let ua: UseAuthorityRecord = try_from_slice_checked(b, Key::UseAuthorityRecord, USE_AUTHORITY_RECORD_SIZE)?;
-
         Ok(ua)
+    }
+
+    pub fn bump_empty(&self) -> bool {
+       return self.bump == 0 && self.key == Key::UseAuthorityRecord;
     }
 }
 
@@ -204,6 +206,10 @@ impl CollectionAuthorityRecord {
     pub fn from_bytes(b: &[u8]) -> Result<CollectionAuthorityRecord, ProgramError> {
         let ca: CollectionAuthorityRecord = try_from_slice_checked(b, Key::CollectionAuthorityRecord, COLLECTION_AUTHORITY_RECORD_SIZE)?;
         Ok(ca)
+    }
+
+    pub fn bump_empty(&self) -> bool {
+        return self.bump == 0 && self.key != Key::CollectionAuthorityRecord;
     }
 }
 

--- a/token-metadata/program/tests/bump_seed_migration.rs
+++ b/token-metadata/program/tests/bump_seed_migration.rs
@@ -1,0 +1,110 @@
+#![cfg(feature = "test-bpf")]
+mod utils;
+
+use mpl_token_metadata::pda::find_collection_authority_account;
+use mpl_token_metadata::state::Collection;
+use mpl_token_metadata::state::{UseMethod, Uses};
+use mpl_token_metadata::{
+    error::MetadataError,
+    state::{Key, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    utils::puffed_out_string,
+};
+use num_traits::FromPrimitive;
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::InstructionError,
+    signature::{Keypair, Signer},
+    transaction::TransactionError,
+    transport::TransportError,
+};
+use utils::*;
+use borsh::{BorshSerialize};
+use mpl_token_metadata::state::{CollectionAuthorityRecord, UseAuthorityRecord};
+use solana_program::borsh::try_from_slice_unchecked;
+use solana_sdk::account::{Account, AccountSharedData};
+use solana_sdk::transaction::Transaction;
+use mpl_token_metadata::pda::{find_program_as_burner_account, find_use_authority_account};
+use mpl_token_metadata::state::Key as MetadataKey;
+use solana_sdk::account::{ReadableAccount, WritableAccount};
+mod bump_seed_migration {
+    use std::borrow::BorrowMut;
+    use solana_program::program_memory::sol_memset;
+    use mpl_token_metadata::state::USE_AUTHORITY_RECORD_SIZE;
+    use super::*;
+
+    #[tokio::test]
+    async fn success_migrate_account() {
+        let mut context = program_test().start_with_context().await;
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+        let test_metadata = Metadata::new();
+        let puffed_name = puffed_out_string(&name, MAX_NAME_LENGTH);
+        let puffed_symbol = puffed_out_string(&symbol, MAX_SYMBOL_LENGTH);
+        let puffed_uri = puffed_out_string(&uri, MAX_URI_LENGTH);
+        let uses = Some(Uses {
+            total: 1,
+            remaining: 1,
+            use_method: UseMethod::Single,
+        });
+        test_metadata
+            .create_v2(
+                &mut context,
+                name,
+                symbol,
+                uri,
+                None,
+                10,
+                false,
+                None,
+                uses.to_owned(),
+            )
+            .await
+            .unwrap();
+        let use_authority_account = Keypair::new();
+        let (record, record_bump) =
+            find_use_authority_account(&test_metadata.mint.pubkey(), &use_authority_account.pubkey());
+        let use_record_struct = UseAuthorityRecord {
+            key: MetadataKey::UseAuthorityRecord,
+            allowed_uses: 10,
+            bump: 0
+        };
+        let mut account = Account {
+            lamports: 1113600,
+            data: vec![],
+            owner: mpl_token_metadata::id(),
+            executable: false,
+            rent_epoch: 1
+        };
+        let data_mut = account.data_mut();
+        use_record_struct.serialize(data_mut).unwrap();
+        data_mut.append(&mut vec![0,0,0,0,0,0,0,0]);
+        let shared_data = &AccountSharedData::from(account);
+        context.set_account(&record, shared_data);
+        airdrop(&mut context, &use_authority_account.pubkey(), 1113600).await.unwrap();
+        let (burner, _) = find_program_as_burner_account();
+        let utilize_with_use_authority = mpl_token_metadata::instruction::utilize(
+            mpl_token_metadata::id(),
+            test_metadata.pubkey.clone(),
+            test_metadata.token.pubkey(),
+            test_metadata.mint.pubkey(),
+            Some(record),
+            use_authority_account.pubkey(),
+            context.payer.pubkey(),
+            Some(burner),
+            1,
+        );
+
+        let tx = Transaction::new_signed_with_payer(
+            &[utilize_with_use_authority],
+            Some(&use_authority_account.pubkey()),
+            &[&use_authority_account],
+            context.last_blockhash,
+        );
+
+        context.banks_client.process_transaction(tx).await.unwrap();
+        let account_after = context.banks_client.get_account(record).await.unwrap().unwrap();
+        let uar : UseAuthorityRecord = try_from_slice_unchecked(&account_after.data).unwrap();
+        assert_eq!(uar.bump, record_bump);
+    }
+}


### PR DESCRIPTION
# Problem
Existing UseAuthorityRecords would become unusable if  1.2.0 was shipped
#Solution
As a part of the 1.2.0 changes we identified a migration case we could accomplish to avoid breaking the 100s of use Authority records in the wild.
We did not implement this migration for the CollectionAuthority records as they are not in use yet
