### PR TITLE
Adds Freeze Authority

### DIFF
--- a/token-metadata/program/src/error.rs
+++ b/token-metadata/program/src/error.rs
@@ -350,7 +350,7 @@ pub enum MetadataError {
     #[error("This Collection Authority Record Already Exists.")]
     CollectionAuthorityRecordAlreadyExists,
 
-    #[error("This Collection Authoritty Record Does Not Exist.")]
+    #[error("This Collection Authority Record Does Not Exist.")]
     CollectionAuthorityDoesNotExist,
 
     #[error("This Use Authority Record is invalid.")]
@@ -358,6 +358,11 @@ pub enum MetadataError {
 
     #[error("This Collection Authority Record is invalid.")]
     InvalidCollectionAuthorityRecord,
+    
+    #[error("Metadata does not match the freeze authority on the mint")]
+    InvalidFreezeAuthority,
+    #[error("All tokens in this account have not been delegated to this user.")]
+    InvalidDelegate,
 }
 
 impl PrintProgramError for MetadataError {

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -1074,6 +1074,8 @@ pub fn set_and_verify_collection(
         program_id,
         accounts,
         data: MetadataInstruction::SetAndVerifyCollection
+            .try_to_vec()
+            .unwrap(),
     }
 }
 

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -314,8 +314,16 @@ pub enum MetadataInstruction {
     ApproveCollectionAuthority,
     ///See [revoke_collection_authority] for Doc
     RevokeCollectionAuthority,
+<<<<<<< HEAD
     ///See [set_and_verify_collection] for Doc
     SetAndVerifyCollection,
+=======
+
+    ///See [freeze_delegated_account] for Doc
+    FreezeDelegatedAccount,
+    ///See [thaw_delegated_account] for Doc
+    ThawDelegatedAccount,
+>>>>>>> efa533c (Freeze v2 checking all tokens are delegated)
 }
 
 /// Creates an CreateMetadataAccounts instruction
@@ -1069,6 +1077,68 @@ pub fn set_and_verify_collection(
         program_id,
         accounts,
         data: MetadataInstruction::SetAndVerifyCollection
+    }
+}
+
+///# Freeze delegated account
+///
+///Allow freezing of an NFT if this user is the delegate of the NFT
+///
+///### Accounts:
+///   0. `[signer]` Delegate
+///   1. `[writable]` Token account to freeze
+///   2. `[]` Edition
+///   3. `[]` Token mint
+#[allow(clippy::too_many_arguments)]
+pub fn freeze_delegated_account(
+    program_id: Pubkey,
+    delegate: Pubkey,
+    token_account: Pubkey,
+    edition: Pubkey,
+    mint: Pubkey,
+) -> Instruction {
+    Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(delegate, true),
+            AccountMeta::new(token_account, false),
+            AccountMeta::new_readonly(edition, false),
+            AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(spl_token::id(), false),
+        ],
+        data: MetadataInstruction::FreezeDelegatedAccount
+            .try_to_vec()
+            .unwrap(),
+    }
+}
+
+///# Thaw delegated account
+///
+///Allow thawing of an NFT if this user is the delegate of the NFT
+///
+///### Accounts:
+///   0. `[signer]` Delegate
+///   1. `[writable]` Token account to thaw
+///   2. `[]` Edition
+///   3. `[]` Token mint
+#[allow(clippy::too_many_arguments)]
+pub fn thaw_delegated_account(
+    program_id: Pubkey,
+    delegate: Pubkey,
+    token_account: Pubkey,
+    edition: Pubkey,
+    mint: Pubkey,
+) -> Instruction {
+    Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(delegate, true),
+            AccountMeta::new(token_account, false),
+            AccountMeta::new_readonly(edition, false),
+            AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(spl_token::id(), false),
+        ],
+        data: MetadataInstruction::ThawDelegatedAccount
             .try_to_vec()
             .unwrap(),
     }

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -314,16 +314,13 @@ pub enum MetadataInstruction {
     ApproveCollectionAuthority,
     ///See [revoke_collection_authority] for Doc
     RevokeCollectionAuthority,
-<<<<<<< HEAD
     ///See [set_and_verify_collection] for Doc
     SetAndVerifyCollection,
-=======
 
     ///See [freeze_delegated_account] for Doc
     FreezeDelegatedAccount,
     ///See [thaw_delegated_account] for Doc
     ThawDelegatedAccount,
->>>>>>> efa533c (Freeze v2 checking all tokens are delegated)
 }
 
 /// Creates an CreateMetadataAccounts instruction

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -1245,7 +1245,6 @@ pub fn process_freeze_delegated_account(
         return Err(MetadataError::InvalidTokenProgram.into());
     }
 
-
     // assert that edition pda is the freeze authority of this mint 
     let mint: Mint = assert_initialized(mint_info)?;
     assert_owned_by(edition_info, program_id)?;

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -16,15 +16,15 @@ use crate::{
         Collection, CollectionAuthorityRecord, DataV2, Key, MasterEditionV1, MasterEditionV2,
         Metadata, TokenStandard, UseAuthorityRecord, UseMethod, Uses, BURN, COLLECTION_AUTHORITY,
         COLLECTION_AUTHORITY_RECORD_SIZE, EDITION, MAX_MASTER_EDITION_LEN, PREFIX, USER,
-        USE_AUTHORITY_RECORD_SIZE,
+        USE_AUTHORITY_RECORD_SIZE, EDITION_MARKER_BIT_SIZE
     },
     solana_program::{
         program_memory::{ sol_memset},
     },
     utils::{
         assert_currently_holding, assert_data_valid, assert_derivation, assert_initialized,
-        assert_mint_authority_matches_mint, assert_owned_by, assert_signer,
-        assert_token_program_matches_package, assert_update_authority_is_correct,
+        assert_mint_authority_matches_mint, assert_owned_by, assert_signer, assert_delegated_tokens,
+        assert_token_program_matches_package, assert_update_authority_is_correct, assert_freeze_authority_matches_mint,
         create_or_allocate_account_raw, get_owner_from_token_account,
         process_create_metadata_accounts_logic,
         process_mint_new_edition_from_master_edition_via_token_logic, puff_out_data_fields,
@@ -39,12 +39,12 @@ use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
     msg,
-    program::invoke,
+    program::{invoke, invoke_signed},
     program_error::ProgramError,
     pubkey::Pubkey,
 };
 use spl_token::{
-    instruction::{approve, revoke},
+    instruction::{approve, revoke, freeze_account, thaw_account},
     state::{Account, Mint},
 };
 use spl_token::instruction::close_account;
@@ -194,6 +194,14 @@ pub fn process_instruction<'a>(
         MetadataInstruction::RevokeCollectionAuthority => {
             msg!("Instruction: Revoke Collection Authority");
             process_revoke_collection_authority(program_id, accounts)
+        }
+        MetadataInstruction::FreezeDelegatedAccount => {
+            msg!("Instruction: Freeze Delegated Account");
+            process_freeze_delegated_account(program_id, accounts)
+        }
+        MetadataInstruction::ThawDelegatedAccount => {
+            msg!("Instruction: Thaw Delegated Account");
+            process_thaw_delegated_account(program_id, accounts)
         }
     }
 }
@@ -1219,5 +1227,126 @@ pub fn set_and_verify_collection(program_id: &Pubkey, accounts: &[AccountInfo]) 
         edition_account_info,
     )?;
     metadata.serialize(&mut *metadata_info.try_borrow_mut_data()?)?;
+    Ok(())
+}
+
+pub fn process_freeze_delegated_account(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let delegate_info = next_account_info(account_info_iter)?;
+    let token_account_info = next_account_info(account_info_iter)?;
+    let edition_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let token_program_account_info = next_account_info(account_info_iter)?;
+
+    if *token_program_account_info.key != spl_token::id() {
+        return Err(MetadataError::InvalidTokenProgram.into());
+    }
+
+
+    // assert that edition pda is the freeze authority of this mint 
+    let mint: Mint = assert_initialized(mint_info)?;
+    assert_owned_by(edition_info, program_id)?;
+    assert_freeze_authority_matches_mint(&mint.freeze_authority, edition_info)?;
+
+    // assert delegate is signer and delegated tokens
+    assert_signer(&delegate_info)?;
+    assert_delegated_tokens(
+        delegate_info,
+        mint_info,
+        token_account_info,
+    )?;
+
+
+    let edition_info_path = Vec::from([
+        PREFIX.as_bytes(),
+        program_id.as_ref(),
+        &mint_info.key.as_ref(),
+        EDITION.as_bytes(),
+    ]);
+    let edition_info_path_bump_seed = &[assert_derivation(
+        program_id,
+        edition_info,
+        &edition_info_path,
+    )?];
+    let mut edition_info_seeds = edition_info_path.clone();
+    edition_info_seeds.push(edition_info_path_bump_seed);
+    invoke_signed(
+        &freeze_account(
+            &token_program_account_info.key,
+            &token_account_info.key,
+            &mint_info.key,
+            &edition_info.key,
+            &[],
+        )
+        .unwrap(),
+        &[
+            token_account_info.clone(),
+            mint_info.clone(),
+            edition_info.clone(),
+        ],
+        &[&edition_info_seeds],
+    )?;
+    Ok(())
+}
+
+pub fn process_thaw_delegated_account(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let delegate_info = next_account_info(account_info_iter)?;
+    let token_account_info = next_account_info(account_info_iter)?;
+    let edition_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let token_program_account_info = next_account_info(account_info_iter)?;
+    if *token_program_account_info.key != spl_token::id() {
+        return Err(MetadataError::InvalidTokenProgram.into());
+    }
+
+    // assert that edition pda is the freeze authority of this mint 
+    let mint: Mint = assert_initialized(mint_info)?;
+    assert_owned_by(edition_info, program_id)?;
+    assert_freeze_authority_matches_mint(&mint.freeze_authority, edition_info)?;
+   
+    // assert delegate is signer and delegated tokens
+    assert_signer(&delegate_info)?;
+    assert_delegated_tokens(
+        delegate_info,
+        mint_info,
+        token_account_info,
+    )?;
+    
+    let edition_info_path = Vec::from([
+        PREFIX.as_bytes(),
+        program_id.as_ref(),
+        &mint_info.key.as_ref(),
+        EDITION.as_bytes(),
+    ]);
+    let edition_info_path_bump_seed = &[assert_derivation(
+        program_id,
+        edition_info,
+        &edition_info_path,
+    )?];
+    let mut edition_info_seeds = edition_info_path.clone();
+    edition_info_seeds.push(edition_info_path_bump_seed);
+    invoke_signed(
+        &thaw_account(
+            &token_program_account_info.key,
+            &token_account_info.key,
+            &mint_info.key,
+            &edition_info.key,
+            &[],
+        )
+        .unwrap(),
+        &[
+            token_account_info.clone(),
+            mint_info.clone(),
+            edition_info.clone(),
+        ],
+        &[&edition_info_seeds],
+    )?;
     Ok(())
 }

--- a/token-metadata/program/tests/approve_use_authority.rs
+++ b/token-metadata/program/tests/approve_use_authority.rs
@@ -37,6 +37,7 @@ mod approve_use_authority {
                 10,
                 false,
                 None,
+                None,
                 Some(Uses {
                     use_method: UseMethod::Single,
                     total: 1,
@@ -95,6 +96,7 @@ mod approve_use_authority {
                 10,
                 false,
                 None,
+                None,
                 Some(Uses {
                     use_method: UseMethod::Burn,
                     total: 1,
@@ -151,6 +153,7 @@ mod approve_use_authority {
                 None,
                 10,
                 false,
+                None,
                 None,
                 None,
             )
@@ -213,6 +216,7 @@ mod approve_use_authority {
                 None,
                 10,
                 false,
+                None,
                 None,
                 Some(Uses {
                     use_method: UseMethod::Single,
@@ -303,6 +307,7 @@ mod approve_use_authority {
                 10,
                 false,
                 None,
+                None,
                 Some(Uses {
                     use_method: UseMethod::Single,
                     total: 1,
@@ -370,6 +375,7 @@ mod approve_use_authority {
                 None,
                 10,
                 false,
+                None,
                 None,
                 Some(Uses {
                     use_method: UseMethod::Single,

--- a/token-metadata/program/tests/bump_seed_migration.rs
+++ b/token-metadata/program/tests/bump_seed_migration.rs
@@ -57,6 +57,7 @@ mod bump_seed_migration {
                 10,
                 false,
                 None,
+                None,
                 uses.to_owned(),
             )
             .await

--- a/token-metadata/program/tests/create_master_edition.rs
+++ b/token-metadata/program/tests/create_master_edition.rs
@@ -71,6 +71,7 @@ mod create_master_edition {
                 false,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -287,6 +288,7 @@ mod create_master_edition {
                 false,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -334,6 +336,7 @@ mod create_master_edition {
                 None,
                 10,
                 false,
+                None,
                 None,
                 None,
             )

--- a/token-metadata/program/tests/create_metadata_account.rs
+++ b/token-metadata/program/tests/create_metadata_account.rs
@@ -85,6 +85,7 @@ mod create_meta_accounts {
                 10,
                 false,
                 None,
+                None,
                 uses.to_owned(),
             )
             .await

--- a/token-metadata/program/tests/freeze_delegated_account.rs
+++ b/token-metadata/program/tests/freeze_delegated_account.rs
@@ -24,6 +24,7 @@ mod freeze_delegated {
     #[tokio::test]
     async fn freeze_delegated_token_success() {
         let mut context = program_test().start_with_context().await;
+        let freeze_authority = &context.payer.pubkey();
         let delegate = Keypair::new();
 
         // create metadata
@@ -37,6 +38,7 @@ mod freeze_delegated {
                 None,
                 10,
                 false,
+                Some(freeze_authority),
                 None,
                 None,
             )
@@ -104,6 +106,7 @@ mod freeze_delegated {
     #[tokio::test]
     async fn freeze_delegated_no_freeze_authority() {
         let mut context = program_test().start_with_context().await;
+        let freeze_authority = &context.payer.pubkey();
         let delegate = Keypair::new();
 
         // create metadata
@@ -117,6 +120,7 @@ mod freeze_delegated {
                 None,
                 10,
                 false,
+                Some(freeze_authority),
                 None,
                 None,
             )
@@ -155,6 +159,7 @@ mod freeze_delegated {
     #[tokio::test]
     async fn freeze_delegated_token_not_delegated() {
         let mut context = program_test().start_with_context().await;
+        let freeze_authority = &context.payer.pubkey();
         let delegate = Keypair::new();
 
         // create metadata
@@ -168,6 +173,7 @@ mod freeze_delegated {
                 None,
                 10,
                 false,
+                Some(freeze_authority),
                 None,
                 None,
             )
@@ -211,6 +217,7 @@ mod freeze_delegated {
     #[tokio::test]
     async fn freeze_delegated_token_try_thaw() {
         let mut context = program_test().start_with_context().await;
+        let freeze_authority = &context.payer.pubkey();
         let delegate = Keypair::new();
 
         // create metadata
@@ -224,6 +231,7 @@ mod freeze_delegated {
                 None,
                 10,
                 false,
+                Some(freeze_authority),
                 None,
                 None,
             )

--- a/token-metadata/program/tests/freeze_delegated_account.rs
+++ b/token-metadata/program/tests/freeze_delegated_account.rs
@@ -1,0 +1,282 @@
+#![cfg(feature = "test-bpf")]
+mod utils;
+
+use mpl_token_metadata::state::{UseAuthorityRecord, UseMethod, Uses};
+
+use mpl_token_metadata::error::MetadataError;
+use mpl_token_metadata::pda::find_use_authority_account;
+use num_traits::FromPrimitive;
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::InstructionError,
+    signature::{Keypair, Signer},
+    transaction::{Transaction, TransactionError},
+    transport::TransportError,
+};
+use utils::*;
+mod freeze_delegated {
+
+    use mpl_token_metadata::{pda::find_program_as_burner_account, state::Key};
+    use solana_program::{borsh::try_from_slice_unchecked, program_pack::Pack};
+    use spl_token::state::Account;
+
+    use super::*;
+    #[tokio::test]
+    async fn freeze_delegated_token_success() {
+        let mut context = program_test().start_with_context().await;
+        let delegate = Keypair::new();
+
+        // create metadata
+        let test_metadata = Metadata::new();
+        test_metadata
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // create master edition
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        test_master_edition
+            .create_v3(&mut context, Some(1))
+            .await
+            .unwrap();
+
+        let approve_ix = spl_token::instruction::approve(&spl_token::id(), &test_metadata.token.pubkey(), &delegate.pubkey(), &context.payer.pubkey(), &[], 1).unwrap();
+        let approve_tx = Transaction::new_signed_with_payer(
+            &[approve_ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+        context
+            .banks_client
+            .process_transaction(approve_tx)
+            .await
+            .unwrap();
+
+        // delegate freezes token
+        let freeze_tx = Transaction::new_signed_with_payer(
+            &[mpl_token_metadata::instruction::freeze_delegated_account(
+                mpl_token_metadata::id(),
+                delegate.pubkey(),
+                test_metadata.token.pubkey(),
+                test_master_edition.pubkey,
+                test_master_edition.mint_pubkey,
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &delegate],
+            context.last_blockhash,
+        );
+        context
+            .banks_client
+            .process_transaction(freeze_tx)
+            .await
+            .unwrap();
+
+        // transfer fails because frozen
+        let transfer_ix = spl_token::instruction::transfer(&spl_token::id(), &test_metadata.token.pubkey(), &test_metadata.token.pubkey(), &context.payer.pubkey(), &[], 1).unwrap();
+        let transfer_tx = Transaction::new_signed_with_payer(
+            &[transfer_ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+        let err = context
+            .banks_client
+            .process_transaction(transfer_tx)
+            .await
+            .unwrap_err();
+
+        assert_custom_error!(err, spl_token::error::TokenError::AccountFrozen);
+    }
+
+
+    use super::*;
+    #[tokio::test]
+    async fn freeze_delegated_no_freeze_authority() {
+        let mut context = program_test().start_with_context().await;
+        let delegate = Keypair::new();
+
+        // create metadata
+        let test_metadata = Metadata::new();
+        test_metadata
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+
+        // delegate token to delegate
+        spl_token::instruction::approve(&spl_token::id(), &test_metadata.token.pubkey(), &delegate.pubkey(), &context.payer.pubkey(), &[], 1).unwrap();
+
+        // delegate freezes token
+        let freeze_ix = mpl_token_metadata::instruction::freeze_delegated_account(
+            mpl_token_metadata::id(),
+            delegate.pubkey(),
+            test_metadata.token.pubkey(),
+            test_metadata.pubkey,
+            test_metadata.mint.pubkey(),
+        );
+        let freeze_tx = Transaction::new_signed_with_payer(
+            &[freeze_ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &delegate],
+            context.last_blockhash,
+        );
+        // fails because not delegate
+        let err = context
+            .banks_client
+            .process_transaction(freeze_tx)
+            .await
+            .unwrap_err();
+
+        assert_custom_error!(err, MetadataError::InvalidFreezeAuthority);
+    }
+
+    use super::*;
+    #[tokio::test]
+    async fn freeze_delegated_token_not_delegated() {
+        let mut context = program_test().start_with_context().await;
+        let delegate = Keypair::new();
+
+        // create metadata
+        let test_metadata = Metadata::new();
+        test_metadata
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // create master edition
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        test_master_edition
+            .create_v3(&mut context, None)
+            .await
+            .unwrap();
+
+        // attempt to freeze delegated account
+        let freeze_ix = mpl_token_metadata::instruction::freeze_delegated_account(
+            mpl_token_metadata::id(),
+            context.payer.pubkey(),
+            test_metadata.token.pubkey(),
+            test_master_edition.pubkey,
+            test_master_edition.mint_pubkey,
+        );
+        let freeze_tx = Transaction::new_signed_with_payer(
+            &[freeze_ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+
+        // expected error because token not delegated
+        let err = context
+            .banks_client
+            .process_transaction(freeze_tx)
+            .await
+            .unwrap_err();
+
+        assert_custom_error!(err, MetadataError::InvalidDelegate);
+    }
+
+
+    use super::*;
+    #[tokio::test]
+    async fn freeze_delegated_token_try_thaw() {
+        let mut context = program_test().start_with_context().await;
+        let delegate = Keypair::new();
+
+        // create metadata
+        let test_metadata = Metadata::new();
+        test_metadata
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // create master edition
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        test_master_edition
+            .create_v3(&mut context, None)
+            .await
+            .unwrap();
+
+        // delegate token to delegate
+        spl_token::instruction::approve(&spl_token::id(), &test_metadata.token.pubkey(), &delegate.pubkey(), &context.payer.pubkey(), &[], 1).unwrap();
+
+        // delegate freezes token
+        let freeze_ix = mpl_token_metadata::instruction::freeze_delegated_account(
+            mpl_token_metadata::id(),
+            delegate.pubkey(),
+            test_metadata.token.pubkey(),
+            test_master_edition.pubkey,
+            test_master_edition.mint_pubkey,
+        );
+        let freeze_tx = Transaction::new_signed_with_payer(
+            &[freeze_ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &delegate],
+            context.last_blockhash,
+        );
+
+        // owner attempt to thaw account
+        let thaw_ix = mpl_token_metadata::instruction::thaw_delegated_account(
+            mpl_token_metadata::id(),
+            context.payer.pubkey(),
+            test_metadata.token.pubkey(),
+            test_master_edition.pubkey,
+            test_master_edition.mint_pubkey,
+        );
+        let thaw_tx = Transaction::new_signed_with_payer(
+            &[thaw_ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+
+        // fails because not delegate
+        let err = context
+            .banks_client
+            .process_transaction(thaw_tx)
+            .await
+            .unwrap_err();
+
+        assert_custom_error!(err, MetadataError::InvalidDelegate);
+    }
+}

--- a/token-metadata/program/tests/revoke_use_authority.rs
+++ b/token-metadata/program/tests/revoke_use_authority.rs
@@ -32,6 +32,7 @@ mod revoke_use_authority {
                 10,
                 false,
                 None,
+                None,
                 Some(Uses {
                     use_method: UseMethod::Single,
                     total: 1,

--- a/token-metadata/program/tests/update_metadata_account_v2.rs
+++ b/token-metadata/program/tests/update_metadata_account_v2.rs
@@ -103,6 +103,7 @@ mod update_metadata_account_v2 {
                 true,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -249,6 +250,7 @@ mod update_metadata_account_v2 {
                 true,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -262,6 +264,7 @@ mod update_metadata_account_v2 {
                 None,
                 10,
                 false,
+                None,
                 None,
                 None,
             )

--- a/token-metadata/program/tests/uses.rs
+++ b/token-metadata/program/tests/uses.rs
@@ -36,6 +36,7 @@ mod uses {
                 10,
                 false,
                 None,
+                None,
                 Some(Uses {
                     use_method: UseMethod::Single,
                     total: 1,
@@ -89,6 +90,7 @@ mod uses {
                 None,
                 10,
                 false,
+                None,
                 None,
                 Some(Uses {
                     use_method: UseMethod::Single,
@@ -145,6 +147,7 @@ mod uses {
                 None,
                 10,
                 false,
+                None,
                 None,
                 Some(Uses {
                     use_method: UseMethod::Multiple,
@@ -230,6 +233,7 @@ mod uses {
                 None,
                 10,
                 false,
+                None,
                 None,
                 Some(Uses {
                     use_method: UseMethod::Multiple,
@@ -363,6 +367,7 @@ mod uses {
                 10,
                 false,
                 None,
+                None,
                 Some(Uses {
                     use_method: UseMethod::Burn,
                     total: 1,
@@ -452,6 +457,7 @@ mod uses {
                 None,
                 10,
                 false,
+                None,
                 None,
                 Some(Uses {
                     use_method: UseMethod::Burn,

--- a/token-metadata/program/tests/utils/metadata.rs
+++ b/token-metadata/program/tests/utils/metadata.rs
@@ -102,10 +102,11 @@ impl Metadata {
         creators: Option<Vec<Creator>>,
         seller_fee_basis_points: u16,
         is_mutable: bool,
+        freeze_authority: Option<&Pubkey>,
         collection: Option<Collection>,
         uses: Option<Uses>,
     ) -> transport::Result<()> {
-        create_mint(context, &self.mint, &context.payer.pubkey(), Some(&context.payer.pubkey())).await?;
+        create_mint(context, &self.mint, &context.payer.pubkey(), freeze_authority).await?;
         create_token_account(
             context,
             &self.token,

--- a/token-metadata/program/tests/utils/metadata.rs
+++ b/token-metadata/program/tests/utils/metadata.rs
@@ -105,7 +105,7 @@ impl Metadata {
         collection: Option<Collection>,
         uses: Option<Uses>,
     ) -> transport::Result<()> {
-        create_mint(context, &self.mint, &context.payer.pubkey(), None).await?;
+        create_mint(context, &self.mint, &context.payer.pubkey(), Some(&context.payer.pubkey())).await?;
         create_token_account(
             context,
             &self.token,

--- a/token-metadata/program/tests/verify_collection.rs
+++ b/token-metadata/program/tests/verify_collection.rs
@@ -41,6 +41,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -73,6 +74,7 @@ mod verify_collection {
                 None,
                 10,
                 false,
+                None,
                 Some(Collection {
                     key: test_collection.mint.pubkey(),
                     verified: false,
@@ -254,6 +256,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -281,6 +284,7 @@ mod verify_collection {
                 None,
                 10,
                 false,
+                None,
                 Some(Collection {
                     key: test_collection.mint.pubkey(),
                     verified: false,
@@ -328,6 +332,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -355,6 +360,7 @@ mod verify_collection {
                 None,
                 10,
                 false,
+                None,
                 Some(Collection {
                     key: test_collection.mint.pubkey(),
                     verified: false,
@@ -402,6 +408,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -425,6 +432,7 @@ mod verify_collection {
                 None,
                 10,
                 false,
+                None,
                 Some(Collection {
                     key: test_collection.mint.pubkey(),
                     verified: false,
@@ -473,6 +481,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -501,6 +510,7 @@ mod verify_collection {
                 None,
                 10,
                 false,
+                None,
                 Some(Collection {
                     key: test_collection.mint.pubkey(),
                     verified: false,
@@ -546,6 +556,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -578,6 +589,7 @@ mod verify_collection {
                 None,
                 10,
                 false,
+                None,
                 Some(Collection {
                     key: test_collection.mint.pubkey(),
                     verified: false,
@@ -645,6 +657,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -667,6 +680,7 @@ mod verify_collection {
                 None,
                 10,
                 false,
+                None,
                 Some(Collection {
                     key: test_collection.mint.pubkey(),
                     verified: false,
@@ -860,6 +874,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -887,6 +902,7 @@ mod verify_collection {
                 None,
                 10,
                 false,
+                None,
                 Some(Collection {
                     key: test_collection.mint.pubkey(),
                     verified: false,

--- a/token-metadata/program/tests/verify_collection.rs
+++ b/token-metadata/program/tests/verify_collection.rs
@@ -142,6 +142,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
+                None
             )
             .await
             .unwrap();
@@ -163,6 +164,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
+                None
             )
             .await
             .unwrap();
@@ -195,6 +197,7 @@ mod verify_collection {
                 None,
                 10,
                 false,
+                None,
                 Some(Collection {
                     key: test_collection.mint.pubkey(),
                     verified: false,
@@ -774,6 +777,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
+                None
             )
             .await
             .unwrap();
@@ -788,7 +792,7 @@ mod verify_collection {
         let uri = "uri".to_string();
         let test_metadata = Metadata::new();
         test_metadata
-            .create_v2(&mut context, name, symbol, uri, None, 10, false, None, None)
+            .create_v2(&mut context, name, symbol, uri, None, 10, false, None, None, None)
             .await
             .unwrap();
 


### PR DESCRIPTION
https://github.com/metaplex-foundation/metaplex-program-library/pull/171

I had to re make the PR so I could fix it.

We have been building a protocol that enabled rentals for new tokens and were planning to try to enable this functionality for existing NFTs (whose freeze_authority is held by metaplex-token-metadata)

Our proposal is: freeze/unfreeze instructions that proxy instruction through to spl_token_program IF the signer is the delegate of the single token in the token_account that they are trying to freeze.

In other words, if someone delegated you the NFT in a token account, you can freeze that specific token account. Essentially this opens up a world of possibilities around conditional ownership, rentals, time-revoking tokens etc. where you as the holder can claim it but agree by signing away delegate rights that this other program can manage / revoke it from you.

I can't think of any reasons this would cause issues. The only interesting thing is that if I delegate tokens to someone, they could always freeze my account forever, but they also could always just take the tokens so I think thats okay because the user has signed away their rights to the token by delegating it

@austbot
One thing I just thought of was that if this is your ATA, freeze might cause you to not be able to accept new tokens. This should be a non-issue with NFTs of course unless there is a specific scenario where a semi-fungible token has an edition but dont think thats possible