### PR TITLE
feat: add findByOwnerV3 method

### DIFF
--- a/token-metadata/js/src/accounts/Metadata.ts
+++ b/token-metadata/js/src/accounts/Metadata.ts
@@ -274,19 +274,16 @@ export class Metadata extends Account<MetadataData> {
     ).flat();
   }
 
-  static async findByOwnerV3(connection: Connection, owner: AnyPublicKey) {
-    const accounts = await TokenAccount.getTokenAccountsByOwner(connection, owner);
-    const accountsWithAmount = accounts
-      .map(({ data }) => data)
-      .filter(({ amount }) => amount?.toNumber() > 0);
+  static async findByOwnerV3(connection: Connection, owner: AnyPublicKey): Promise<Metadata[]> {
+    const tokenInfo = await Metadata.findInfoByOwner(connection, owner);
 
-    return Promise.all(accountsWithAmount.map(({ mint }) => Metadata.findByMint(connection, mint)));
+    return Array.from(tokenInfo.entries()).map(([pubkey, info]) => new Metadata(pubkey, info));
   }
 
-  static async findDataByOwner(
+  static async findInfoByOwner(
     connection: Connection,
     owner: AnyPublicKey,
-  ): Promise<MetadataData[]> {
+  ): Promise<Map<AnyPublicKey, AccountInfo<Buffer>>> {
     const accounts = await TokenAccount.getTokenAccountsByOwner(connection, owner);
 
     const metadataPdaLookups = accounts.reduce((memo, { data }) => {
@@ -297,7 +294,16 @@ export class Metadata extends Account<MetadataData> {
     }, []);
 
     const metadataAddresses = await Promise.all(metadataPdaLookups);
-    const tokenInfo = await Account.getInfos(connection, metadataAddresses);
+
+    return Account.getInfos(connection, metadataAddresses);
+  }
+
+  static async findDataByOwner(
+    connection: Connection,
+    owner: AnyPublicKey,
+  ): Promise<MetadataData[]> {
+    const tokenInfo = await Metadata.findInfoByOwner(connection, owner);
+
     return Array.from(tokenInfo.values()).map((m) => MetadataData.deserialize(m.data));
   }
 

--- a/token-metadata/js/src/accounts/Metadata.ts
+++ b/token-metadata/js/src/accounts/Metadata.ts
@@ -242,10 +242,10 @@ export class Metadata extends Account<MetadataData> {
     }
   }
 
-  static async findByMint(connection: Connection, mint: AnyPublicKey) {
-    const pda = await this.getPDA(mint);
+  static async findByMint(connection: Connection, mint: AnyPublicKey): Promise<Metadata> {
+    const pda = await Metadata.getPDA(mint);
 
-    return this.load(connection, pda);
+    return Metadata.load(connection, pda);
   }
 
   static async findByOwner(connection: Connection, owner: AnyPublicKey) {


### PR DESCRIPTION
I've tested it with an account with 11 tokens and it's around 10-25 times faster than `findByOwnerV2`. Not sure if it's still faster with wallets that have way more tokens.

Here is the [benchmark file](https://gist.github.com/fersilva16/b34cc997e952d8c4d4573b5e30e24927).
Some results:
| findByOwnerV2  | findByOwnerV3 | Times faster |
| -------------- | ------------- | ------------ |
| `23.220s`      | `840.56ms`    | `26.62x`     |
| `16.619s`      | `1.586s`      | `9.47x`      |
| `15.926s`      | `1.604s`      | `8.92x`      |
| `20.315s`      | `969.688ms`   | `19.95x`     |
| `16.426s`      | `1.596s`      | `9.29x`      |
| `20.174s`      | `1.032s`      | `18.54x`     |
