### PR TITLE
Allow limited editions to have a different metadata uri than their master edition

### DIFF
--- a/token-metadata/cli/src/main.rs
+++ b/token-metadata/cli/src/main.rs
@@ -1,39 +1,36 @@
-
 use solana_client::rpc_request::TokenAccountsFilter;
 
-use {
-    clap::{crate_description, crate_name, crate_version, App, Arg, ArgMatches, SubCommand},
-    mpl_token_metadata::{
-        instruction::{
-            create_master_edition, create_metadata_accounts,
-            mint_new_edition_from_master_edition_via_token, puff_metadata_account,
-            update_metadata_accounts,
-        },
-        state::{
-            get_reservation_list, Data, Edition, Key, MasterEditionV1, MasterEditionV2, Metadata,
-            EDITION, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH, PREFIX,
-        },
+use clap::{crate_description, crate_name, crate_version, App, Arg, ArgMatches, SubCommand};
+use mpl_token_metadata::{
+    instruction::{
+        create_master_edition, create_metadata_accounts,
+        mint_new_edition_from_master_edition_via_token, puff_metadata_account,
+        update_metadata_accounts,
     },
-    solana_clap_utils::{
-        input_parsers::pubkey_of,
-        input_validators::{is_url, is_valid_pubkey, is_valid_signer},
+    state::{
+        get_reservation_list, Data, Edition, Key, MasterEditionV1, MasterEditionV2, Metadata,
+        EDITION, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH, PREFIX,
     },
-    solana_client::rpc_client::RpcClient,
-    solana_program::{
-        account_info::AccountInfo, borsh::try_from_slice_unchecked, program_pack::Pack,
-    },
-    solana_sdk::{
-        pubkey::Pubkey,
-        signature::{read_keypair_file, Keypair, Signer},
-        system_instruction::create_account,
-        transaction::Transaction,
-    },
-    spl_token::{
-        instruction::{initialize_account, initialize_mint, mint_to},
-        state::{Account, Mint},
-    },
-    std::str::FromStr,
 };
+use solana_clap_utils::{
+    input_parsers::pubkey_of,
+    input_validators::{is_url, is_valid_pubkey, is_valid_signer},
+};
+use solana_client::rpc_client::RpcClient;
+use solana_program::{
+    account_info::AccountInfo, borsh::try_from_slice_unchecked, program_pack::Pack,
+};
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{read_keypair_file, Keypair, Signer},
+    system_instruction::create_account,
+    transaction::Transaction,
+};
+use spl_token::{
+    instruction::{initialize_account, initialize_mint, mint_to},
+    state::{Account, Mint},
+};
+use std::str::FromStr;
 
 const TOKEN_PROGRAM_PUBKEY: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 fn puff_unpuffed_metadata(_app_matches: &ArgMatches, payer: Keypair, client: RpcClient) {
@@ -355,6 +352,7 @@ fn mint_edition_via_token_call(
         master_metadata_key,
         master_metadata.mint,
         master_edition.supply + 1,
+        app_matches.value_of("uri").map(|s| s.to_string()),
     ));
 
     let mut transaction = Transaction::new_with_payer(&instructions, Some(&payer.pubkey()));
@@ -822,6 +820,14 @@ fn main() {
                                 .takes_value(true)
                                 .help("Metadata Mint from which to mint this new edition"),
                         ).arg(
+                            Arg::with_name("uri")
+                                .long("uri")
+                                .value_name("URI")
+                                .takes_value(true)
+                                .required(false)
+                                .help("new URI for the Metadata"),
+                        )
+                        .arg(
                             Arg::with_name("account")
                                 .long("account")
                                 .value_name("ACCOUNT")

--- a/token-metadata/js/src/transactions/MintNewEditionFromMasterEditionViaToken.ts
+++ b/token-metadata/js/src/transactions/MintNewEditionFromMasterEditionViaToken.ts
@@ -10,14 +10,16 @@ import {
 import BN from 'bn.js';
 import { MetadataProgram } from '../MetadataProgram';
 
-export class MintNewEditionFromMasterEditionViaTokenArgs extends Borsh.Data<{ edition: BN }> {
+export class MintNewEditionFromMasterEditionViaTokenArgs extends Borsh.Data<{ edition: BN, uri: String | null }> {
   static readonly SCHEMA = MintNewEditionFromMasterEditionViaTokenArgs.struct([
     ['instruction', 'u8'],
     ['edition', 'u64'],
+    ['uri', { kind: 'option', type: String }],
   ]);
 
   instruction = 11;
   edition: BN;
+  uri: String | null
 }
 
 type MintNewEditionFromMasterEditionViaTokenParams = {
@@ -32,6 +34,7 @@ type MintNewEditionFromMasterEditionViaTokenParams = {
   tokenOwner: PublicKey;
   tokenAccount: PublicKey;
   editionValue: BN;
+  uriValue: String | null;
 };
 
 export class MintNewEditionFromMasterEditionViaToken extends Transaction {
@@ -53,10 +56,11 @@ export class MintNewEditionFromMasterEditionViaToken extends Transaction {
       tokenOwner,
       tokenAccount,
       editionValue,
+      uriValue
     } = params;
 
     const data = MintNewEditionFromMasterEditionViaTokenArgs.serialize({
-      edition: editionValue,
+      edition: editionValue, uri: uriValue
     });
 
     this.add(

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -59,6 +59,7 @@ pub struct CreateMasterEditionArgs {
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone)]
 pub struct MintNewEditionFromMasterEditionViaTokenArgs {
     pub edition: u64,
+    pub uri: Option<String>,
 }
 
 #[repr(C)]
@@ -580,6 +581,7 @@ pub fn mint_new_edition_from_master_edition_via_token(
     metadata: Pubkey,
     metadata_mint: Pubkey,
     edition: u64,
+    uri: Option<String>,
 ) -> Instruction {
     let edition_number = edition.checked_div(EDITION_MARKER_BIT_SIZE).unwrap();
     let as_string = edition_number.to_string();
@@ -615,7 +617,7 @@ pub fn mint_new_edition_from_master_edition_via_token(
         program_id,
         accounts,
         data: MetadataInstruction::MintNewEditionFromMasterEditionViaToken(
-            MintNewEditionFromMasterEditionViaTokenArgs { edition },
+            MintNewEditionFromMasterEditionViaTokenArgs { edition, uri },
         )
         .try_to_vec()
         .unwrap(),
@@ -676,6 +678,7 @@ pub fn mint_edition_from_master_edition_via_vault_proxy(
     token_program: Pubkey,
     token_vault_program_info: Pubkey,
     edition: u64,
+    uri: Option<String>,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new(new_metadata, false),
@@ -701,7 +704,7 @@ pub fn mint_edition_from_master_edition_via_vault_proxy(
         program_id,
         accounts,
         data: MetadataInstruction::MintNewEditionFromMasterEditionViaVaultProxy(
-            MintNewEditionFromMasterEditionViaTokenArgs { edition },
+            MintNewEditionFromMasterEditionViaTokenArgs { edition, uri },
         )
         .try_to_vec()
         .unwrap(),

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -1,30 +1,30 @@
-use std::ops::Deref;
 use crate::{
     assertions::{
         collection::{
             assert_collection_update_is_valid, assert_collection_verify_is_valid,
             assert_has_collection_authority,
         },
-        uses::process_use_authority_validation,
+        uses::{
+            assert_use_authority_derivation, assert_valid_bump, process_use_authority_validation,
+        },
     },
     deprecated_processor::{
         process_deprecated_create_metadata_accounts, process_deprecated_update_metadata_accounts,
     },
     error::MetadataError,
     instruction::MetadataInstruction,
+    solana_program::program_memory::sol_memset,
     state::{
         Collection, CollectionAuthorityRecord, DataV2, Key, MasterEditionV1, MasterEditionV2,
         Metadata, TokenStandard, UseAuthorityRecord, UseMethod, Uses, BURN, COLLECTION_AUTHORITY,
-        COLLECTION_AUTHORITY_RECORD_SIZE, EDITION, MAX_MASTER_EDITION_LEN, PREFIX, USER,
-        USE_AUTHORITY_RECORD_SIZE, EDITION_MARKER_BIT_SIZE
-    },
-    solana_program::{
-        program_memory::{ sol_memset},
+        COLLECTION_AUTHORITY_RECORD_SIZE, EDITION, EDITION_MARKER_BIT_SIZE, MAX_MASTER_EDITION_LEN,
+        PREFIX, USER, USE_AUTHORITY_RECORD_SIZE,
     },
     utils::{
-        assert_currently_holding, assert_data_valid, assert_derivation, assert_initialized,
-        assert_mint_authority_matches_mint, assert_owned_by, assert_signer, assert_delegated_tokens,
-        assert_token_program_matches_package, assert_update_authority_is_correct, assert_freeze_authority_matches_mint,
+        assert_currently_holding, assert_data_valid, assert_delegated_tokens, assert_derivation,
+        assert_freeze_authority_matches_mint, assert_initialized,
+        assert_mint_authority_matches_mint, assert_owned_by, assert_signer,
+        assert_token_program_matches_package, assert_update_authority_is_correct,
         create_or_allocate_account_raw, get_owner_from_token_account,
         process_create_metadata_accounts_logic,
         process_mint_new_edition_from_master_edition_via_token_logic, puff_out_data_fields,
@@ -44,11 +44,9 @@ use solana_program::{
     pubkey::Pubkey,
 };
 use spl_token::{
-    instruction::{approve, revoke, freeze_account, thaw_account},
+    instruction::{approve, close_account, freeze_account, revoke, thaw_account},
     state::{Account, Mint},
 };
-use spl_token::instruction::close_account;
-use crate::assertions::uses::{assert_use_authority_derivation, assert_valid_bump};
 
 pub fn process_instruction<'a>(
     program_id: &'a Pubkey,
@@ -144,6 +142,7 @@ pub fn process_instruction<'a>(
                 program_id,
                 accounts,
                 args.edition,
+                args.uri,
                 false,
             )
         }
@@ -157,6 +156,7 @@ pub fn process_instruction<'a>(
                 program_id,
                 accounts,
                 args.edition,
+                args.uri,
             )
         }
         MetadataInstruction::PuffMetadata => {
@@ -470,6 +470,7 @@ pub fn process_mint_new_edition_from_master_edition_via_token<'a>(
     program_id: &'a Pubkey,
     accounts: &'a [AccountInfo<'a>],
     edition: u64,
+    uri: Option<String>,
     ignore_owner_signer: bool,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
@@ -508,6 +509,7 @@ pub fn process_mint_new_edition_from_master_edition_via_token<'a>(
             rent_info,
         },
         edition,
+        uri,
         ignore_owner_signer,
     )
 }
@@ -558,6 +560,7 @@ pub fn process_mint_new_edition_from_master_edition_via_vault_proxy<'a>(
     program_id: &'a Pubkey,
     accounts: &'a [AccountInfo<'a>],
     edition: u64,
+    uri: Option<String>,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
@@ -666,7 +669,9 @@ pub fn process_mint_new_edition_from_master_edition_via_vault_proxy<'a>(
         rent_info,
     };
 
-    process_mint_new_edition_from_master_edition_via_token_logic(program_id, args, edition, true)
+    process_mint_new_edition_from_master_edition_via_token_logic(
+        program_id, args, edition, uri, true,
+    )
 }
 
 /// Puff out the variable length fields to a fixed length on a metadata
@@ -841,10 +846,7 @@ pub fn process_approve_use_authority(
         &user_info.key.as_ref(),
         &[bump_seed],
     ];
-    process_use_authority_validation(
-        use_authority_record_info.data_len(),
-        true,
-    )?;
+    process_use_authority_validation(use_authority_record_info.data_len(), true)?;
     create_or_allocate_account_raw(
         *program_id,
         use_authority_record_info,
@@ -914,10 +916,7 @@ pub fn process_revoke_use_authority(
         token_account_info,
     )?;
     let data = &mut use_authority_record_info.try_borrow_mut_data()?;
-    process_use_authority_validation(
-        data.len(),
-        false,
-    )?;
+    process_use_authority_validation(data.len(), false)?;
     assert_owned_by(use_authority_record_info, program_id)?;
     let canonical_bump = assert_use_authority_derivation(
         program_id,
@@ -929,10 +928,7 @@ pub fn process_revoke_use_authority(
     if record.bump_empty() {
         record.bump = canonical_bump;
     }
-    assert_valid_bump(
-        canonical_bump,
-        &record
-    )?;
+    assert_valid_bump(canonical_bump, &record)?;
     let metadata_uses = metadata.uses.unwrap();
     if metadata_uses.use_method == UseMethod::Burn {
         invoke(
@@ -1010,12 +1006,9 @@ pub fn process_utilize(
     if approved_authority_is_using {
         let use_authority_record_info = next_account_info(account_info_iter)?;
         let data = &mut *use_authority_record_info.try_borrow_mut_data()?;
-        process_use_authority_validation(
-            data.len(),
-            false,
-        )?;
+        process_use_authority_validation(data.len(), false)?;
         assert_owned_by(use_authority_record_info, program_id)?;
-        let canonical_bump= assert_use_authority_derivation(
+        let canonical_bump = assert_use_authority_derivation(
             program_id,
             use_authority_record_info,
             user_info,
@@ -1026,10 +1019,7 @@ pub fn process_utilize(
         if record.bump_empty() {
             record.bump = canonical_bump;
         }
-        assert_valid_bump(
-            canonical_bump,
-            &record
-        )?;
+        assert_valid_bump(canonical_bump, &record)?;
         record.allowed_uses = record
             .allowed_uses
             .checked_sub(number_of_uses)
@@ -1169,7 +1159,11 @@ pub fn process_revoke_collection_authority(
         .lamports()
         .checked_add(lamports)
         .ok_or(MetadataError::NumericalOverflowError)?;
-    sol_memset(*collection_authority_record.try_borrow_mut_data()?, 0, USE_AUTHORITY_RECORD_SIZE);
+    sol_memset(
+        *collection_authority_record.try_borrow_mut_data()?,
+        0,
+        USE_AUTHORITY_RECORD_SIZE,
+    );
 
     Ok(())
 }
@@ -1245,19 +1239,14 @@ pub fn process_freeze_delegated_account(
         return Err(MetadataError::InvalidTokenProgram.into());
     }
 
-    // assert that edition pda is the freeze authority of this mint 
+    // assert that edition pda is the freeze authority of this mint
     let mint: Mint = assert_initialized(mint_info)?;
     assert_owned_by(edition_info, program_id)?;
     assert_freeze_authority_matches_mint(&mint.freeze_authority, edition_info)?;
 
     // assert delegate is signer and delegated tokens
     assert_signer(&delegate_info)?;
-    assert_delegated_tokens(
-        delegate_info,
-        mint_info,
-        token_account_info,
-    )?;
-
+    assert_delegated_tokens(delegate_info, mint_info, token_account_info)?;
 
     let edition_info_path = Vec::from([
         PREFIX.as_bytes(),
@@ -1305,19 +1294,15 @@ pub fn process_thaw_delegated_account(
         return Err(MetadataError::InvalidTokenProgram.into());
     }
 
-    // assert that edition pda is the freeze authority of this mint 
+    // assert that edition pda is the freeze authority of this mint
     let mint: Mint = assert_initialized(mint_info)?;
     assert_owned_by(edition_info, program_id)?;
     assert_freeze_authority_matches_mint(&mint.freeze_authority, edition_info)?;
-   
+
     // assert delegate is signer and delegated tokens
     assert_signer(&delegate_info)?;
-    assert_delegated_tokens(
-        delegate_info,
-        mint_info,
-        token_account_info,
-    )?;
-    
+    assert_delegated_tokens(delegate_info, mint_info, token_account_info)?;
+
     let edition_info_path = Vec::from([
         PREFIX.as_bytes(),
         program_id.as_ref(),

--- a/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
+++ b/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
@@ -14,6 +14,8 @@ use utils::*;
 
 // NOTE: these tests depend on the token-vault program having been compiled
 // via (cd ../../token-vault/program/ && cargo build-bpf)
+// If you are running these tests from inside the token-metadata directory, use
+// cargo build-bpf --manifest-path ../token-vault/program/Cargo.toml --bpf-out-dir target/deploy
 mod mint_new_edition_from_master_edition_via_token {
     use super::*;
     #[tokio::test]
@@ -21,7 +23,12 @@ mod mint_new_edition_from_master_edition_via_token {
         let mut context = program_test().start_with_context().await;
         let test_metadata = Metadata::new();
         let test_master_edition = MasterEditionV2::new(&test_metadata);
-        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
+        let test_edition_marker = EditionMarker::new(
+            &test_metadata,
+            &test_master_edition,
+            1,
+            Some("edition_uri".to_string()),
+        );
 
         test_metadata
             .create(
@@ -54,7 +61,12 @@ mod mint_new_edition_from_master_edition_via_token {
         let mut context = program_test().start_with_context().await;
         let test_metadata = Metadata::new();
         let test_master_edition = MasterEditionV2::new(&test_metadata);
-        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
+        let test_edition_marker = EditionMarker::new(
+            &test_metadata,
+            &test_master_edition,
+            1,
+            Some("edition_uri".to_string()),
+        );
 
         test_metadata
             .create(
@@ -86,7 +98,12 @@ mod mint_new_edition_from_master_edition_via_token {
         let mut context = program_test().start_with_context().await;
         let test_metadata = Metadata::new();
         let test_master_edition = MasterEditionV2::new(&test_metadata);
-        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
+        let test_edition_marker = EditionMarker::new(
+            &test_metadata,
+            &test_master_edition,
+            1,
+            Some("edition_uri".to_string()),
+        );
         let fake_mint = Keypair::new();
         let fake_account = Keypair::new();
         let payer_pubkey = context.payer.pubkey();
@@ -148,6 +165,7 @@ mod mint_new_edition_from_master_edition_via_token {
                 test_edition_marker.metadata_pubkey,
                 test_edition_marker.metadata_mint_pubkey,
                 test_edition_marker.edition,
+                test_edition_marker.uri,
             )],
             Some(&context.payer.pubkey()),
             &[&context.payer, &context.payer, &context.payer],
@@ -168,8 +186,18 @@ mod mint_new_edition_from_master_edition_via_token {
         let mut context = program_test().start_with_context().await;
         let test_metadata = Metadata::new();
         let test_master_edition = MasterEditionV2::new(&test_metadata);
-        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
-        let test_edition_marker1 = EditionMarker::new(&test_metadata, &test_master_edition, 1);
+        let test_edition_marker = EditionMarker::new(
+            &test_metadata,
+            &test_master_edition,
+            1,
+            Some("edition_uri".to_string()),
+        );
+        let test_edition_marker1 = EditionMarker::new(
+            &test_metadata,
+            &test_master_edition,
+            1,
+            Some("edition_uri1".to_string()),
+        );
 
         test_metadata
             .create(

--- a/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -28,7 +28,12 @@ mod mint_new_edition_from_master_edition_via_vault_proxy {
         let test_master_edition = MasterEditionV2::new(&test_metadata);
         let test_external_price = ExternalPrice::new();
         let test_vault = Vault::new();
-        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
+        let test_edition_marker = EditionMarker::new(
+            &test_metadata,
+            &test_master_edition,
+            10,
+            Some("edition_uri".to_string()),
+        );
 
         test_metadata
             .create(
@@ -97,7 +102,12 @@ mod mint_new_edition_from_master_edition_via_vault_proxy {
         let test_master_edition = MasterEditionV2::new(&test_metadata);
         let test_external_price = ExternalPrice::new();
         let test_vault = Vault::new();
-        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
+        let test_edition_marker = EditionMarker::new(
+            &test_metadata,
+            &test_master_edition,
+            10,
+            Some("edition_uri".to_string()),
+        );
         let fake_store = Keypair::new();
         let payer_pubkey = context.payer.pubkey();
 
@@ -175,6 +185,7 @@ mod mint_new_edition_from_master_edition_via_vault_proxy {
                     spl_token::id(),
                     mpl_token_vault::id(),
                     test_edition_marker.edition,
+                    test_edition_marker.uri,
                 ),
             ],
             Some(&context.payer.pubkey()),
@@ -201,7 +212,12 @@ mod mint_new_edition_from_master_edition_via_vault_proxy {
         let test_master_edition = MasterEditionV2::new(&test_metadata);
         let test_external_price = ExternalPrice::new();
         let test_vault = Vault::new();
-        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
+        let test_edition_marker = EditionMarker::new(
+            &test_metadata,
+            &test_master_edition,
+            10,
+            Some("edition_uri".to_string()),
+        );
         let fake_vault_authority = Keypair::new();
 
         test_metadata
@@ -270,6 +286,7 @@ mod mint_new_edition_from_master_edition_via_vault_proxy {
                     spl_token::id(),
                     mpl_token_vault::id(),
                     test_edition_marker.edition,
+                    test_edition_marker.uri,
                 ),
             ],
             Some(&context.payer.pubkey()),
@@ -300,7 +317,12 @@ mod mint_new_edition_from_master_edition_via_vault_proxy {
         let test_external_price = ExternalPrice::new();
         let test_vault = Vault::new();
 
-        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
+        let test_edition_marker = EditionMarker::new(
+            &test_metadata,
+            &test_master_edition,
+            10,
+            Some("edition_uri".to_string()),
+        );
 
         // TEST VAULT
         test_metadata
@@ -391,6 +413,7 @@ mod mint_new_edition_from_master_edition_via_vault_proxy {
                     spl_token::id(),
                     mpl_token_vault::id(),
                     test_edition_marker.edition,
+                    test_edition_marker.uri,
                 ),
             ],
             Some(&context.payer.pubkey()),

--- a/token-metadata/program/tests/utils/edition_marker.rs
+++ b/token-metadata/program/tests/utils/edition_marker.rs
@@ -26,12 +26,18 @@ pub struct EditionMarker {
     pub metadata_pubkey: Pubkey,
     pub pubkey: Pubkey,
     pub edition: u64,
+    pub uri: Option<String>,
     pub token: Keypair,
     pub metadata_token_pubkey: Pubkey,
 }
 
 impl EditionMarker {
-    pub fn new(metadata: &Metadata, master_edition: &MasterEditionV2, edition: u64) -> Self {
+    pub fn new(
+        metadata: &Metadata,
+        master_edition: &MasterEditionV2,
+        edition: u64,
+        uri: Option<String>,
+    ) -> Self {
         let mint = Keypair::new();
         let mint_pubkey = mint.pubkey();
         let metadata_mint_pubkey = metadata.mint.pubkey();
@@ -64,6 +70,7 @@ impl EditionMarker {
         EditionMarker {
             pubkey,
             edition,
+            uri,
             mint,
             metadata_mint_pubkey,
             metadata_pubkey: metadata.pubkey,
@@ -139,6 +146,7 @@ impl EditionMarker {
                     spl_token::id(),
                     mpl_token_vault::id(),
                     self.edition,
+                    self.uri.clone(),
                 ),
             ],
             Some(&context.payer.pubkey()),
@@ -183,6 +191,7 @@ impl EditionMarker {
                 self.metadata_pubkey,
                 self.metadata_mint_pubkey,
                 self.edition,
+                None,
             )],
             Some(&context.payer.pubkey()),
             &[&context.payer, &context.payer],
@@ -235,6 +244,7 @@ impl EditionMarker {
             data: MetadataInstruction::MintNewEditionFromMasterEditionViaToken(
                 MintNewEditionFromMasterEditionViaTokenArgs {
                     edition: self.edition,
+                    uri: self.uri.clone(),
                 },
             )
             .try_to_vec()


### PR DESCRIPTION
Allows limited editions to have a different uri value in their metadata accounts. Edition name gets set as master edition name with edition number appended if new uri provided.