### PR TITLE
chore(candy-machine): lock dependencies to patch updates

### DIFF
--- a/candy-machine/program/Cargo.lock
+++ b/candy-machine/program/Cargo.lock
@@ -1235,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.3.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc67166ef99d10c18cb5e9c208901e6d8255c6513bb1f877977eba48e6cc4fb"
+checksum = "93bfdd5bd7c869cb565c7d7635c4fafe189b988a0bdef81063cd9585c6b8dc01"
 dependencies = [
  "arrayref",
  "num-derive",

--- a/candy-machine/program/Cargo.toml
+++ b/candy-machine/program/Cargo.toml
@@ -20,10 +20,10 @@ default = []
 
 [dependencies]
 anchor-lang = "=0.19.0"
-arrayref = "0.3.6"
-spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
-mpl-token-metadata = { version = "1.1.0", features = [ "no-entrypoint" ] }
-spl-associated-token-account = {version = "1.0.3", features = ["no-entrypoint"]}
+arrayref = "~0.3.6"
+spl-token = { version="~3.2.0", features = [ "no-entrypoint" ] }
+mpl-token-metadata = { version = "~1.1.0", features = [ "no-entrypoint" ] }
+spl-associated-token-account = {version = "~1.0.3", features = ["no-entrypoint"]}
 anchor-spl = "=0.19.0"
-solana-program = "1.8.9"
-solana-gateway = "0.1.1"
+solana-program = "~1.9.5"
+solana-gateway = "~0.1.1"


### PR DESCRIPTION
Anchor packages are pinned to an exact version, all others pinned to only allow patch updates. `solana-program` bumped to 1.9.x for compatibility with `solana-gateway`. 