### PR TITLE
[Proposal] append mint_number to metadata uri

### DIFF
--- a/candy-machine/program/src/lib.rs
+++ b/candy-machine/program/src/lib.rs
@@ -28,7 +28,8 @@ use {
     std::{cell::RefMut, ops::Deref, str::FromStr},
 };
 use solana_program::sysvar::SysvarId;
-anchor_lang::declare_id!("cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ");
+anchor_lang::declare_id!("8VRwdyLCnj3KYuKpsEuWZqyaqgTMQ5ESAZEohS5vwBDN");
+// anchor_lang::declare_id!("cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ");
 
 const EXPIRE_OFFSET: i64 = 10 * 60;
 const PREFIX: &str = "candy_machine";
@@ -962,7 +963,7 @@ pub fn get_config_line<'info>(
     if let Some(hs) = &a.data.hidden_settings {
         return Ok(ConfigLine {
             name: hs.name.clone() + "#" + &(mint_number + 1).to_string(),
-            uri: hs.uri.clone(),
+            uri: hs.uri.clone() + &(mint_number + 1).to_string(),
         });
     }
     msg!("Index is set to {:?}", index);


### PR DESCRIPTION
As mentioned [here](https://github.com/metaplex-foundation/metaplex/issues/1331)
I've added mint_number in the tail of metadata uri. This makes more sense because nft issuer doesn't have to update every metadata uri for each mint to reveal, which will be cumbersome and wasting transaction fees.

I understand that updating candy machine program will involve many changes to docs and address changes for related programs. But here is the proposal and please let me know what should I do to contribute. Many Thanks.

# Changes
- Append mint_number to metadata uri
- Update program id