### PR TITLE
Change edition number source in buy instruction

### DIFF
--- a/fixed-price-sale/program/src/lib.rs
+++ b/fixed-price-sale/program/src/lib.rs
@@ -25,6 +25,7 @@ use anchor_spl::{
     associated_token::{self, get_associated_token_address, AssociatedToken},
     token::{self, accessor, Mint, Token, TokenAccount},
 };
+use mpl_token_metadata::utils::get_supply_off_master_edition;
 
 declare_id!("SaLeTjyUa5wXHnGuewUSyJ5JWZaHwz3TxqUntCE9czo");
 
@@ -178,7 +179,10 @@ pub mod fixed_price_sale {
         let system_program = &ctx.accounts.system_program;
 
         let metadata_mint = selling_resource.resource.clone();
-        let edition = selling_resource.supply;
+        // do supply +1 to increase master edition supply
+        let edition = get_supply_off_master_edition(&master_edition.to_account_info())?
+            .checked_add(1)
+            .ok_or(ErrorCode::MathOverflow)?;
 
         // Check, that `Market` is not in `Suspended` state
         if market.state == MarketState::Suspended {


### PR DESCRIPTION
## What
Fix in Buy instruction
## Why
Edition number in Buy instruction was calculated incorrect and instruction produced error when users try to sell the same NFT second time. Also because of this bug the wrong value was set for master edition supply
## How
Now we calculate edition number like this `master_edition_supply + 1` instead of `selling_resource.supply`