### PR TITLE
fixes prints when collection is added

### DIFF
--- a/token-metadata/Cargo.lock
+++ b/token-metadata/Cargo.lock
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "arrayref",
  "borsh",

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaplex-foundation/mpl-token-metadata",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "MPL Token Metadata JavaScript API.",
   "main": "dist/src/mpl-token-metadata.js",
   "types": "dist/src/mpl-token-metadata.d.ts",

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -1,7 +1,7 @@
 cargo-features = ["edition2021"]
 [package]
 name = "mpl-token-metadata"
-version = "1.2.4"
+version = "1.2.5"
 description = "Metaplex Metadata"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/metaplex-program-library"

--- a/token-metadata/program/src/assertions/collection.rs
+++ b/token-metadata/program/src/assertions/collection.rs
@@ -7,10 +7,11 @@ use crate::{
 };
 
 pub fn assert_collection_update_is_valid(
+    edition: bool,
     _existing: &Option<Collection>,
     incoming: &Option<Collection>,
 ) -> Result<(), ProgramError> {
-    if incoming.is_some() && incoming.as_ref().unwrap().verified == true {
+    if incoming.is_some() && incoming.as_ref().unwrap().verified == true && !edition {
         // Never allow a collection to be verified outside of verify_collection instruction
         return Err(MetadataError::CollectionCannotBeVerifiedInThisInstruction.into());
     }

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -275,7 +275,7 @@ pub fn process_update_metadata_accounts_v2(
                 true,
             )?;
             metadata.data = compatible_data;
-            assert_collection_update_is_valid(false,&metadata.collection, &data.collection)?;
+            assert_collection_update_is_valid(false, &metadata.collection, &data.collection)?;
             metadata.collection = data.collection;
         } else {
             return Err(MetadataError::DataIsImmutable.into());

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -275,7 +275,7 @@ pub fn process_update_metadata_accounts_v2(
                 true,
             )?;
             metadata.data = compatible_data;
-            assert_collection_update_is_valid(&metadata.collection, &data.collection)?;
+            assert_collection_update_is_valid(false,&metadata.collection, &data.collection)?;
             metadata.collection = data.collection;
         } else {
             return Err(MetadataError::DataIsImmutable.into());

--- a/token-metadata/program/src/utils.rs
+++ b/token-metadata/program/src/utils.rs
@@ -912,7 +912,7 @@ pub fn process_create_metadata_accounts_logic(
     metadata.update_authority = update_authority_key;
     assert_valid_use(&data.uses, &None)?;
     metadata.uses = data.uses;
-    assert_collection_update_is_valid(&None, &data.collection)?;
+    assert_collection_update_is_valid(is_edition, &None, &data.collection)?;
     metadata.collection = data.collection;
     if add_token_standard {
         let token_standard = if is_edition {
@@ -926,7 +926,6 @@ pub fn process_create_metadata_accounts_logic(
     } else {
         metadata.token_standard = None;
     }
-
     puff_out_data_fields(&mut metadata);
 
     let edition_seeds = &[


### PR DESCRIPTION
# Problem
Collections on Master Editions that are Verified were breaking Editions being minted

#Solution
Allow Creation Verification if the token standard is NonFungible Edition