### PR TITLE
(fix) idl and code gen

### DIFF
--- a/auction-house/js/idl/auction_house.json
+++ b/auction-house/js/idl/auction_house.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.2",
   "name": "auction_house",
   "instructions": [
     {
@@ -694,7 +694,7 @@
         },
         {
           "name": "transferAuthority",
-          "isMut": true,
+          "isMut": false,
           "isSigner": false
         },
         {

--- a/auction-house/js/package.json
+++ b/auction-house/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaplex-foundation/mpl-auction-house",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MPL Auction House JavaScript API.",
   "main": "dist/src/mpl-auction-house.js",
   "types": "dist/src/mpl-auction-house.d.ts",

--- a/auction-house/js/src/generated/instructions/buy.ts
+++ b/auction-house/js/src/generated/instructions/buy.ts
@@ -103,7 +103,7 @@ export function createBuyInstruction(accounts: BuyInstructionAccounts, args: Buy
     },
     {
       pubkey: transferAuthority,
-      isWritable: true,
+      isWritable: false,
       isSigner: false,
     },
     {

--- a/auction-house/program/Cargo.lock
+++ b/auction-house/program/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-auction-house"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/auction-house/program/Cargo.toml
+++ b/auction-house/program/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 name = "mpl-auction-house"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2018"
 description = "Decentralized Sales Protocol for Solana Tokens"
 authors = ["Metaplex Developers <dev@metaplex.com>"]

--- a/auction-house/program/src/bid/mod.rs
+++ b/auction-house/program/src/bid/mod.rs
@@ -70,7 +70,6 @@ pub struct Buy<'info> {
     wallet: Signer<'info>,
     #[account(mut)]
     payment_account: UncheckedAccount<'info>,
-    #[account(mut)]
     transfer_authority: UncheckedAccount<'info>,
     treasury_mint: Account<'info, Mint>,
     token_account: Account<'info, TokenAccount>,


### PR DESCRIPTION
1.0.1 went to devnet with a mut where there shouldn't be , in my cli testing I found it and fixed that and another longstanding bug hidden in the layers of cli garbage https://github.com/metaplex-foundation/metaplex/pull/1847

This pr fixes that and bumps for publishing