### PR TITLE
chore: repair broken fixed price sales tests

### DIFF
--- a/.github/workflows/program-fixed-price-sale.yml
+++ b/.github/workflows/program-fixed-price-sale.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.5
+  SOLANA_VERSION: 1.9.9
   RUST_TOOLCHAIN: stable
 
 jobs:

--- a/.github/workflows/program-fixed-price-sale.yml
+++ b/.github/workflows/program-fixed-price-sale.yml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       core: ${{ steps.filter.outputs.core }}
       package: ${{ steps.filter.outputs.package }}
+      workflow: ${{ steps.filter.outputs.workflow }}
     steps:
       - uses: actions/checkout@v2
       # For pull requests it's not necessary to checkout the code
@@ -29,9 +30,11 @@ jobs:
               - 'core/**'
             package:
               - 'fixed-price-sale/**'
+            workflow:
+              - '.github/workflows/program-fixed-price-sale.yml'
   build-and-test-fixed-price-sale:
     needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-fixed-price-sale

--- a/.github/workflows/program-token-metadata.yml
+++ b/.github/workflows/program-token-metadata.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.5
+  SOLANA_VERSION: 1.9.9
   RUST_TOOLCHAIN: stable
 
 jobs:

--- a/.github/workflows/program-token-metadata.yml
+++ b/.github/workflows/program-token-metadata.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.9
+  SOLANA_VERSION: 1.9.5
   RUST_TOOLCHAIN: stable
 
 jobs:


### PR DESCRIPTION
Updating solana version for fixed prices sales tests to `1.9.9`. This is given the info that solana validator instability causes those tests to fail. There were some [stability changes](https://github.com/solana-labs/solana/releases) in the releases from `1.9.5  - 1.9.9`.
They [appear to be fixed now](https://github.com/metaplex-foundation/metaplex-program-library/runs/5360803661?check_suite_focus=true)