### PR TITLE
fix: switch fixed-price-sale findPayoutTicketAddress arguments

### DIFF
--- a/fixed-price-sale/js/src/utils/index.ts
+++ b/fixed-price-sale/js/src/utils/index.ts
@@ -37,11 +37,11 @@ export const findTradeHistoryAddress = (
   );
 
 export const findPayoutTicketAddress = (
-  funder: PublicKey,
   market: PublicKey,
+  funder: PublicKey,
 ): Promise<[PublicKey, number]> => {
   return PublicKey.findProgramAddress(
-    [Buffer.from(PAYOUT_TICKET_PREFIX), funder.toBuffer(), market.toBuffer()],
+    [Buffer.from(PAYOUT_TICKET_PREFIX), market.toBuffer(), funder.toBuffer()],
     new PublicKey(PROGRAM_ID),
   );
 };


### PR DESCRIPTION
The findPayoutTicketAddress arguments were named incorrectly. This switches the names to match the PDA seeds. The function was already being called with the correct arguments.

lib.rs:
```
pub struct Withdraw<'info> {
...
    #[account(mut, seeds=[PAYOUT_TICKET_PREFIX.as_bytes(), market.key().as_ref(), funder.key().as_ref()], bump=payout_ticket_bump)]
    payout_ticket: UncheckedAccount<'info>,
```