### PR TITLE
add reset_v2_metadata handler

### DIFF
--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -1169,3 +1169,26 @@ pub fn thaw_delegated_account(
             .unwrap(),
     }
 }
+
+//# Reset V2 Metadata
+///
+/// Allows the update authority of a NFT to reset the V2 data of a NFT to fix data corruption issues. It zeroes out all data after the edition_nonce field.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` Metadata account
+///   1. `[signer]` Metadata update authority
+pub fn reset_v2_metadata(
+    program_id: Pubkey,
+    metadata: Pubkey,
+    update_authority: Pubkey,
+) -> Instruction {
+    Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(metadata, false),
+            AccountMeta::new_readonly(update_authority, true),
+        ],
+        data: MetadataInstruction::ResetV2Metadata.try_to_vec().unwrap(),
+    }
+}

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -322,7 +322,10 @@ pub enum MetadataInstruction {
     ///See [thaw_delegated_account] for Doc
     ThawDelegatedAccount,
     ///See [remove_creator_verification] for Doc
-    RemoveCreatorVerification
+    RemoveCreatorVerification,
+
+    /// See [reset_v2_data] for Doc
+    ResetV2Metadata,
 }
 
 /// Creates an CreateMetadataAccounts instruction
@@ -639,14 +642,20 @@ pub fn sign_metadata(program_id: Pubkey, metadata: Pubkey, creator: Pubkey) -> I
 
 /// Remove Creator Verificaton
 #[allow(clippy::too_many_arguments)]
-pub fn remove_creator_verification(program_id: Pubkey, metadata: Pubkey, creator: Pubkey) -> Instruction {
+pub fn remove_creator_verification(
+    program_id: Pubkey,
+    metadata: Pubkey,
+    creator: Pubkey,
+) -> Instruction {
     Instruction {
         program_id,
         accounts: vec![
             AccountMeta::new(metadata, false),
             AccountMeta::new_readonly(creator, true),
         ],
-        data: MetadataInstruction::RemoveCreatorVerification.try_to_vec().unwrap(),
+        data: MetadataInstruction::RemoveCreatorVerification
+            .try_to_vec()
+            .unwrap(),
     }
 }
 

--- a/token-metadata/program/src/state.rs
+++ b/token-metadata/program/src/state.rs
@@ -218,6 +218,30 @@ pub struct Collection {
 
 #[repr(C)]
 #[derive(Clone, BorshSerialize, BorshDeserialize, Debug)]
+pub struct MetadataV1 {
+    pub key: Key,
+    pub update_authority: Pubkey,
+    pub mint: Pubkey,
+    pub data: Data,
+    // Immutable, once flipped, all sales of this metadata are considered secondary.
+    pub primary_sale_happened: bool,
+    // Whether or not the data struct is mutable, default is not
+    pub is_mutable: bool,
+    /// nonce for easy calculation of editions, if present
+    pub edition_nonce: Option<u8>,
+}
+
+impl MetadataV1 {
+    pub fn from_account_info(a: &AccountInfo) -> Result<MetadataV1, ProgramError> {
+        let md: MetadataV1 =
+            try_from_slice_checked(&a.data.borrow_mut(), Key::MetadataV1, MAX_METADATA_LEN)?;
+
+        Ok(md)
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, BorshSerialize, BorshDeserialize, Debug)]
 pub struct Metadata {
     pub key: Key,
     pub update_authority: Pubkey,

--- a/token-metadata/program/tests/reset_v2_metadata.rs
+++ b/token-metadata/program/tests/reset_v2_metadata.rs
@@ -1,0 +1,331 @@
+#![cfg(feature = "test-bpf")]
+pub mod utils;
+
+use mpl_token_metadata::{
+    error::MetadataError,
+    id, instruction,
+    state::{Collection, Key, UseMethod, Uses, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    utils::puffed_out_string,
+};
+use num_traits::FromPrimitive;
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::InstructionError,
+    signature::{Keypair, Signer},
+    signer::SignerError,
+    transaction::{Transaction, TransactionError},
+    transport::TransportError,
+};
+use utils::*;
+
+mod reset_v2_metadata {
+    use super::*;
+
+    #[tokio::test]
+    async fn success() {
+        // ARRANGE
+        let mut context = program_test().start_with_context().await;
+
+        let update_authority = clone_keypair(&context.payer);
+
+        // Create a test collection to use in our metadata.
+        let test_collection = Metadata::new();
+        test_collection
+            .create_v2(
+                &mut context,
+                "Test Collection".to_string(),
+                "".to_string(),
+                "uri".to_string(),
+                None,
+                0,
+                false,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let collection_master_edition_account = MasterEditionV2::new(&test_collection);
+        collection_master_edition_account
+            .create_v3(&mut context, Some(0))
+            .await
+            .unwrap();
+
+        // Create metadata to test clearing v2 data.
+        let test_metadata = Metadata::new();
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+
+        let puffed_name = puffed_out_string(&name, MAX_NAME_LENGTH);
+        let puffed_symbol = puffed_out_string(&symbol, MAX_SYMBOL_LENGTH);
+        let puffed_uri = puffed_out_string(&uri, MAX_URI_LENGTH);
+
+        let uses = Some(Uses {
+            total: 1,
+            remaining: 1,
+            use_method: UseMethod::Single,
+        });
+        test_metadata
+            .create_v2(
+                &mut context,
+                name,
+                symbol,
+                uri,
+                None,
+                10,
+                false,
+                None,
+                Some(Collection {
+                    key: test_collection.mint.pubkey(),
+                    verified: false,
+                }),
+                uses.to_owned(),
+            )
+            .await
+            .unwrap();
+
+        // ACT
+        let metadata = test_metadata.get_data(&mut context).await;
+        test_metadata
+            .reset_v2_metadata(&mut context, update_authority)
+            .await
+            .unwrap();
+        let post_metadata = test_metadata.get_data(&mut context).await;
+
+        // ASSERT
+
+        // Metadata V1 values are correct.
+        assert_eq!(metadata.key, Key::MetadataV1);
+        assert_eq!(metadata.update_authority, context.payer.pubkey());
+        assert_eq!(metadata.mint, test_metadata.mint.pubkey());
+        assert_eq!(metadata.data.name, puffed_name);
+        assert_eq!(metadata.data.symbol, puffed_symbol);
+        assert_eq!(metadata.data.uri, puffed_uri);
+        assert_eq!(metadata.data.seller_fee_basis_points, 10);
+        assert_eq!(metadata.data.creators, None);
+        assert_eq!(metadata.primary_sale_happened, false);
+        assert_eq!(metadata.is_mutable, false);
+
+        // Metadata has correct collection values.
+        assert_eq!(
+            metadata.collection.to_owned().unwrap().key,
+            test_collection.mint.pubkey()
+        );
+        assert_eq!(metadata.collection.unwrap().verified, false);
+
+        // Metadata has correct use values.
+        assert_eq!(metadata.uses, uses.to_owned());
+
+        // Post metadata has new values cleared.
+        assert_eq!(post_metadata.token_standard, None);
+        assert_eq!(post_metadata.collection, None);
+        assert_eq!(post_metadata.uses, None);
+    }
+
+    #[tokio::test]
+    async fn incorrect_update_authority_fails() {
+        // ARRANGE
+        let mut context = program_test().start_with_context().await;
+
+        // Create a test collection to use in our metadata.
+        let test_collection = Metadata::new();
+        test_collection
+            .create_v2(
+                &mut context,
+                "Test Collection".to_string(),
+                "".to_string(),
+                "uri".to_string(),
+                None,
+                0,
+                false,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to create test collection.");
+        let collection_master_edition_account = MasterEditionV2::new(&test_collection);
+        collection_master_edition_account
+            .create_v3(&mut context, Some(0))
+            .await
+            .unwrap();
+
+        let collection = Collection {
+            key: test_collection.mint.pubkey(),
+            verified: false,
+        };
+
+        // Create metadata to test clearing v2 data.
+        let test_metadata = Metadata::new();
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+
+        let uses = Some(Uses {
+            total: 1,
+            remaining: 1,
+            use_method: UseMethod::Single,
+        });
+        test_metadata
+            .create_v2(
+                &mut context,
+                name,
+                symbol,
+                uri,
+                None,
+                10,
+                false,
+                None,
+                Some(collection.clone()),
+                uses.to_owned(),
+            )
+            .await
+            .expect("Failed to create test metadata.");
+
+        let incorrect_update_authority = Keypair::new();
+
+        // ACT
+
+        // Fund invalid update authority.
+        airdrop(
+            &mut context,
+            &incorrect_update_authority.pubkey(),
+            10000000000,
+        )
+        .await
+        .expect("Airdrop failed");
+
+        let metadata = test_metadata.get_data(&mut context).await;
+
+        // Try to reset v2 metadata using incorrect update authority.
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::reset_v2_metadata(
+                id(),
+                test_metadata.pubkey,
+                incorrect_update_authority.pubkey(),
+            )],
+            Some(&incorrect_update_authority.pubkey()),
+            &[&incorrect_update_authority],
+            context.last_blockhash,
+        );
+
+        let err = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
+
+        let post_metadata = test_metadata.get_data(&mut context).await;
+
+        // ASSERT
+        assert_custom_error!(err, MetadataError::UpdateAuthorityIncorrect);
+
+        // Post metadata should continue to have old values.
+        assert_eq!(post_metadata.token_standard, metadata.token_standard);
+        assert_eq!(post_metadata.collection, Some(collection));
+        assert_eq!(post_metadata.uses, uses);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "Transaction::sign failed with error KeypairPubkeyMismatch")]
+    async fn update_authority_not_a_signer_fails() {
+        // ARRANGE
+        let mut context = program_test().start_with_context().await;
+
+        let payer = Keypair::new();
+        let fake_signer = Keypair::new();
+
+        // Create a test collection to use in our metadata.
+        let test_collection = Metadata::new();
+        test_collection
+            .create_v2(
+                &mut context,
+                "Test Collection".to_string(),
+                "".to_string(),
+                "uri".to_string(),
+                None,
+                0,
+                false,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to create test collection.");
+        let collection_master_edition_account = MasterEditionV2::new(&test_collection);
+        collection_master_edition_account
+            .create_v3(&mut context, Some(0))
+            .await
+            .unwrap();
+
+        let collection = Collection {
+            key: test_collection.mint.pubkey(),
+            verified: false,
+        };
+
+        // Create metadata to test clearing v2 data.
+        let test_metadata = Metadata::new();
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+
+        let uses = Some(Uses {
+            total: 1,
+            remaining: 1,
+            use_method: UseMethod::Single,
+        });
+        test_metadata
+            .create_v2(
+                &mut context,
+                name,
+                symbol,
+                uri,
+                None,
+                10,
+                false,
+                None,
+                Some(collection.clone()),
+                uses.to_owned(),
+            )
+            .await
+            .expect("Failed to create test metadata.");
+
+        let update_authority_pubkey = context.payer.pubkey();
+
+        // ACT
+
+        let metadata = test_metadata.get_data(&mut context).await;
+
+        // Fund payer account
+        airdrop(&mut context, &payer.pubkey(), 10000000000)
+            .await
+            .expect("Airdrop failed");
+
+        // Try to reset v2 metadata using the correct update authority but which is not a signer.
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::reset_v2_metadata(
+                id(),
+                test_metadata.pubkey,
+                update_authority_pubkey,
+            )],
+            Some(&payer.pubkey()),
+            &[&payer, &fake_signer],
+            context.last_blockhash,
+        );
+
+        let err = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
+
+        let post_metadata = test_metadata.get_data(&mut context).await;
+
+        // ASSERT
+        // Post metadata should continue to have old values.
+        assert_eq!(post_metadata.token_standard, metadata.token_standard);
+        assert_eq!(post_metadata.collection, Some(collection));
+        assert_eq!(post_metadata.uses, uses);
+    }
+}

--- a/token-metadata/program/tests/reset_v2_metadata.rs
+++ b/token-metadata/program/tests/reset_v2_metadata.rs
@@ -12,7 +12,6 @@ use solana_program_test::*;
 use solana_sdk::{
     instruction::InstructionError,
     signature::{Keypair, Signer},
-    signer::SignerError,
     transaction::{Transaction, TransactionError},
     transport::TransportError,
 };
@@ -117,7 +116,18 @@ mod reset_v2_metadata {
         // Metadata has correct use values.
         assert_eq!(metadata.uses, uses.to_owned());
 
-        // Post metadata has new values cleared.
+        // Post metadata has new values cleared but other data is untouched.
+        assert_eq!(post_metadata.key, Key::MetadataV1);
+        assert_eq!(post_metadata.update_authority, context.payer.pubkey());
+        assert_eq!(post_metadata.mint, test_metadata.mint.pubkey());
+        assert_eq!(post_metadata.data.name, puffed_name);
+        assert_eq!(post_metadata.data.symbol, puffed_symbol);
+        assert_eq!(post_metadata.data.uri, puffed_uri);
+        assert_eq!(post_metadata.data.seller_fee_basis_points, 10);
+        assert_eq!(post_metadata.data.creators, None);
+        assert_eq!(post_metadata.primary_sale_happened, false);
+        assert_eq!(post_metadata.is_mutable, false);
+
         assert_eq!(post_metadata.token_standard, None);
         assert_eq!(post_metadata.collection, None);
         assert_eq!(post_metadata.uses, None);
@@ -314,11 +324,7 @@ mod reset_v2_metadata {
             context.last_blockhash,
         );
 
-        let err = context
-            .banks_client
-            .process_transaction(tx)
-            .await
-            .unwrap_err();
+        context.banks_client.process_transaction(tx).await.unwrap();
 
         let post_metadata = test_metadata.get_data(&mut context).await;
 

--- a/token-metadata/program/tests/utils/metadata.rs
+++ b/token-metadata/program/tests/utils/metadata.rs
@@ -106,7 +106,13 @@ impl Metadata {
         collection: Option<Collection>,
         uses: Option<Uses>,
     ) -> transport::Result<()> {
-        create_mint(context, &self.mint, &context.payer.pubkey(), freeze_authority).await?;
+        create_mint(
+            context,
+            &self.mint,
+            &context.payer.pubkey(),
+            freeze_authority,
+        )
+        .await?;
         create_token_account(
             context,
             &self.token,
@@ -317,6 +323,25 @@ impl Metadata {
             )],
             Some(&context.payer.pubkey()),
             &[&context.payer, &collection_authority],
+            context.last_blockhash,
+        );
+
+        Ok(context.banks_client.process_transaction(tx).await?)
+    }
+
+    pub async fn reset_v2_metadata(
+        &self,
+        context: &mut ProgramTestContext,
+        update_authority: Keypair,
+    ) -> transport::Result<()> {
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::reset_v2_metadata(
+                id(),
+                self.pubkey,
+                update_authority.pubkey(),
+            )],
+            Some(&update_authority.pubkey()),
+            &[&context.payer, &update_authority],
             context.last_blockhash,
         );
 

--- a/token-metadata/program/tests/utils/mod.rs
+++ b/token-metadata/program/tests/utils/mod.rs
@@ -12,8 +12,14 @@ pub use master_edition_v2::MasterEditionV2;
 pub use metadata::Metadata;
 use solana_program_test::*;
 use solana_sdk::{
-    account::Account, program_pack::Pack, pubkey::Pubkey, signature::Signer,
-    signer::keypair::Keypair, system_instruction, transaction::Transaction, transport::{self, TransportError},
+    account::Account,
+    program_pack::Pack,
+    pubkey::Pubkey,
+    signature::Signer,
+    signer::keypair::Keypair,
+    system_instruction,
+    transaction::Transaction,
+    transport::{self, TransportError},
 };
 use spl_token::state::Mint;
 pub use vault::Vault;
@@ -147,4 +153,9 @@ pub async fn create_mint(
     );
 
     context.banks_client.process_transaction(tx).await
+}
+
+pub fn clone_keypair(keypair: &Keypair) -> Keypair {
+    let kp_bytes = keypair.to_bytes();
+    Keypair::from_bytes(&kp_bytes).unwrap()
 }


### PR DESCRIPTION
Some unknown number of NFTs have corrupted V2 Metadata (fields after `edition_nonce`). Examples:

https://explorer.solana.com/address/DFR3KjTso6PFCyUtq48a2aPZQpMMoaFgtbdxtaLxF2TR/metadata
https://explorer.solana.com/address/BgKXVz2HZpro3tqo67WqMt93gt9iMGptu3yinrQ3Qs8V/metadata

This causes deserialization to fail in on-chain programs and client side Rust programs. 

This WIP PR shows a possible solution to solve the issue but needs discussion and review by the Metaplex protocol team. 