### PR TITLE
Feat: Enforce Candy Machine w/ Collections

### DIFF
--- a/candy-machine/program/Cargo.lock
+++ b/candy-machine/program/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-candy-machine"
-version = "3.1.3"
+version = "3.2.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/candy-machine/program/Cargo.toml
+++ b/candy-machine/program/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 name = "mpl-candy-machine"
-version = "3.1.3"
+version = "3.2.0"
 description = "NFT Candy Machine v2: programmatic and trustless NFT drops."
 authors = ["Jordan Prince", "Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/metaplex-program-library"

--- a/candy-machine/program/src/lib.rs
+++ b/candy-machine/program/src/lib.rs
@@ -37,6 +37,7 @@ use {
 anchor_lang::declare_id!("cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ");
 const EXPIRE_OFFSET: i64 = 10 * 60;
 const PREFIX: &str = "candy_machine";
+const COLLECTIONS_UUID: &str = "000000";
 // here just in case solana removes the var
 const BLOCK_HASHES: &str = "SysvarRecentB1ockHashes11111111111111111111";
 #[program]
@@ -425,7 +426,7 @@ pub mod candy_machine {
             }
         }
 
-        if candy_machine.data.uuid == "000000" {
+        if candy_machine.data.uuid == COLLECTIONS_UUID {
             let next_instruction = get_instruction_relative(1, &ixs)?;
             if &next_instruction.program_id != &candy_machine::id() {
                 msg!(


### PR DESCRIPTION
Uses the UUID (a formerly unused field) to check if a collection should be set. Paired with a cli change to set the UUID to "000000" when a collection is set, frontends that do not add a set_collection_during_mint ix to the end of the mint txn will cause the transaction to fail. 

CLI PR: https://github.com/metaplex-foundation/metaplex/pull/1986