### PR TITLE
fix(auction-house): use metaplex-token-metadata lib for Metadata struct

### DIFF
--- a/auction-house/program/Cargo.lock
+++ b/auction-house/program/Cargo.lock
@@ -1652,6 +1652,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "metaplex-token-metadata"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abcc939f0afdc6db054b9998a1292d0a016244b382462e61cfc7c570624982cb"
+dependencies = [
+ "arrayref",
+ "borsh",
+ "metaplex-token-vault",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
+name = "metaplex-token-vault"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5211991ba3273df89cd5e0f6f558bc8d7453c87c0546f915b4a319e1541df33"
+dependencies = [
+ "borsh",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,13 +1721,14 @@ dependencies = [
 
 [[package]]
 name = "mpl-auction-house"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anchor-client",
  "anchor-lang",
  "anchor-spl",
  "arrayref",
  "env_logger",
+ "metaplex-token-metadata",
  "mpl-testing-utils",
  "mpl-token-metadata",
  "serde_json",

--- a/auction-house/program/Cargo.toml
+++ b/auction-house/program/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 name = "mpl-auction-house"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2018"
 description = "Decentralized Sales Protocol for Solana Tokens"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
@@ -27,6 +27,7 @@ anchor-spl = "~0.20.1"
 spl-token = { version = "~3.2",  features = ["no-entrypoint"] }
 spl-associated-token-account = {version = "~1.0.3", features = ["no-entrypoint"]}
 mpl-token-metadata = { version="~1.2.4", features = [ "no-entrypoint" ] }
+metaplex-token-metadata = { version = "0.0.1", features = [ "no-entrypoint" ] }
 thiserror = "~1.0"
 arrayref = "~0.3.6"
 

--- a/auction-house/program/src/utils.rs
+++ b/auction-house/program/src/utils.rs
@@ -10,7 +10,7 @@ use anchor_lang::{
 };
 use anchor_spl::token::{Mint, Token, TokenAccount};
 use arrayref::array_ref;
-use mpl_token_metadata::state::Metadata;
+use metaplex_token_metadata::state::Metadata;
 use spl_associated_token_account::get_associated_token_address;
 use spl_token::{instruction::initialize_account2, state::Account as SplAccount};
 use std::{convert::TryInto, slice::Iter};


### PR DESCRIPTION
This PR replaces the `mpl-token-metadata` lib with the older version `metaplex-token-metadata` for importing the Metadata struct to avoid deserialization issues with NFTs that have corrupted metadata. 

There are a number of NFTs in the wild that have corrupted metadata in the "v2" metadata (fields after the `edition_nonce`). This causes issues with deserialization in client-side Rust tools and in Solana programs which use strict typing to do Borsh deserialization. 

I'm working on a long term fix, which requires a change to the `token-metadata` program, but that will take some time to implement. This is a very minimal change which will fix `auction-house`'s deserialization problems in the near term and which will be easy to roll back when the data is solved externally. 