### PR TITLE
Reduce Gateway Compute (candy machine)

### DIFF
--- a/candy-machine/program/Cargo.lock
+++ b/candy-machine/program/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-candy-machine"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -1144,9 +1144,8 @@ dependencies = [
 
 [[package]]
 name = "solana-gateway"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6959300f6f428ee036e9b20d227f45b8908ebe9c7decf9d6c559d713de02ac55"
+version = "0.1.2"
+source = "git+https://github.com/identity-com/on-chain-identity-gateway.git?rev=f58a874ce1e435063e091392dfe4b4874f5a71cb#f58a874ce1e435063e091392dfe4b4874f5a71cb"
 dependencies = [
  "bitflags",
  "borsh",

--- a/candy-machine/program/Cargo.toml
+++ b/candy-machine/program/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 name = "mpl-candy-machine"
-version = "3.1.3"
+version = "3.1.4"
 description = "NFT Candy Machine v2: programmatic and trustless NFT drops."
 authors = ["Jordan Prince", "Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/metaplex-program-library"
@@ -28,4 +28,4 @@ spl-associated-token-account = { version = "1.0.3", features = [
 ] }
 anchor-spl = "=0.21.0"
 solana-program = "1.9.6"
-solana-gateway = "0.1.1"
+solana-gateway = { git = "https://github.com/identity-com/on-chain-identity-gateway.git", rev = "f58a874ce1e435063e091392dfe4b4874f5a71cb" }

--- a/candy-machine/program/src/lib.rs
+++ b/candy-machine/program/src/lib.rs
@@ -36,6 +36,7 @@ use {
     std::{cell::RefMut, ops::Deref, str::FromStr},
 };
 anchor_lang::declare_id!("cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ");
+// 10 minutes
 const EXPIRE_OFFSET: i64 = 10 * 60;
 const PREFIX: &str = "candy_machine";
 // here just in case solana removes the var
@@ -93,6 +94,8 @@ pub mod candy_machine {
             let gateway_token_info = &ctx.remaining_accounts[remaining_accounts_counter];
             remaining_accounts_counter += 1;
 
+            // Date passed in CPI to check if the token was created before candy machine go live date.
+            // Expire offset is 10 minutes since gatekeeper expires tokens after that long
             let min_go_live_date = if let Some(val) = &candy_machine.data.go_live_date {
                 if !candy_machine
                     .data
@@ -136,6 +139,7 @@ pub mod candy_machine {
                             }
                         },
                     )?,
+                    // If none, no need to verify go live date
                     None => ::solana_gateway::Gateway::verify_and_expire_token(
                         gateway_app.clone(),
                         gateway_token_info.clone(),
@@ -160,6 +164,7 @@ pub mod candy_machine {
                             }
                         },
                     )?,
+                    // If none, no need to verify go live date
                     None => ::solana_gateway::Gateway::verify_gateway_token_account_info(
                         gateway_token_info,
                         &payer.key(),

--- a/candy-machine/program/src/lib.rs
+++ b/candy-machine/program/src/lib.rs
@@ -93,9 +93,12 @@ pub mod candy_machine {
             }
             let gateway_token_info = &ctx.remaining_accounts[remaining_accounts_counter];
             remaining_accounts_counter += 1;
-            
+
             // Eval function used in the gateway CPI
-            let eval_function = |token: &InPlaceGatewayToken<&[u8]>| match (&candy_machine.data, token.expire_time()) {
+            let eval_function = |token: &InPlaceGatewayToken<&[u8]>| match (
+                &candy_machine.data,
+                token.expire_time(),
+            ) {
                 (
                     CandyMachineData {
                         go_live_date: Some(go_live_date),


### PR DESCRIPTION
Removes deserialization in favor of new CPI with eval into gateway. Should save ~6k compute