### PR TITLE
chore: upgrade shank + solita and regen token-metadata with optional accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,18 +3182,18 @@ dependencies = [
 
 [[package]]
 name = "shank"
-version = "0.0.0"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca46ffd371862f5eb24546958882c77b1326e22c8630a324a4df00e11b233ce"
+checksum = "241e2bc30cdc50633ec58dafea6841a3764f5efca9dc17c9604d9e4c45288167"
 dependencies = [
  "shank_macro",
 ]
 
 [[package]]
 name = "shank_macro"
-version = "0.0.0"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c348d9feb9e17132ffb54f0625e1ebac575108879d036809fef86edea050dd1"
+checksum = "4860f0c3bf7db32960c5e1d75166782b0b096a2e04e2580001e2e9993a7060ef"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -3203,9 +3203,9 @@ dependencies = [
 
 [[package]]
 name = "shank_macro_impl"
-version = "0.0.0"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40b580c5b227fe9962b87649898289afaa1582470a143d43c48ac3d587ca404"
+checksum = "3c2dae9df9e062c7bbb482667f75ffcec1fb435d55d2e9b6454d32fc1612daa0"
 dependencies = [
  "anyhow",
  "proc-macro2 1.0.36",

--- a/auction-house/js/package.json
+++ b/auction-house/js/package.json
@@ -46,7 +46,7 @@
     "bn.js": "^5.2.0"
   },
   "devDependencies": {
-    "@metaplex-foundation/solita": "^0.1.0",
+    "@metaplex-foundation/solita": "^0.2.0",
     "@types/tape": "^4.13.2",
     "eslint": "^8.3.0",
     "prettier": "^2.5.1",

--- a/auction-house/js/package.json
+++ b/auction-house/js/package.json
@@ -39,8 +39,8 @@
   "author": "Metaplex Maintainers <contact@metaplex.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.0.8",
-    "@metaplex-foundation/beet-solana": "^0.0.6",
+    "@metaplex-foundation/beet": "^0.1.0",
+    "@metaplex-foundation/beet-solana": "^0.1.1",
     "@metaplex-foundation/mpl-core": "^0.0.5",
     "@solana/web3.js": "^1.35.1",
     "bn.js": "^5.2.0"

--- a/fixed-price-sale/js/package.json
+++ b/fixed-price-sale/js/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@metaplex-foundation/amman": "^0.1.0",
     "@metaplex-foundation/mpl-token-metadata": "1.1.0",
-    "@metaplex-foundation/solita": "^0.1.0",
+    "@metaplex-foundation/solita": "^0.2.0",
     "@types/debug": "^4.1.7",
     "@types/tape": "^4.13.2",
     "debug": "^4.3.3",

--- a/fixed-price-sale/js/package.json
+++ b/fixed-price-sale/js/package.json
@@ -38,8 +38,8 @@
   "author": "Metaplex Maintainers <contact@metaplex.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.0.8",
-    "@metaplex-foundation/beet-solana": "^0.0.6",
+    "@metaplex-foundation/beet": "^0.1.0",
+    "@metaplex-foundation/beet-solana": "^0.1.1",
     "@metaplex-foundation/mpl-core": "^0.0.5",
     "@solana/spl-token": "^0.2.0",
     "@solana/web3.js": "^1.35.1"

--- a/gumdrop/js/package.json
+++ b/gumdrop/js/package.json
@@ -38,8 +38,8 @@
   "author": "Metaplex Maintainers <contact@metaplex.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.0.8",
-    "@metaplex-foundation/beet-solana": "^0.0.6",
+    "@metaplex-foundation/beet": "^0.1.0",
+    "@metaplex-foundation/beet-solana": "^0.1.1",
     "@solana/web3.js": "^1.35.1"
   },
   "devDependencies": {

--- a/gumdrop/js/package.json
+++ b/gumdrop/js/package.json
@@ -43,7 +43,7 @@
     "@solana/web3.js": "^1.35.1"
   },
   "devDependencies": {
-    "@metaplex-foundation/solita": "^0.1.0",
+    "@metaplex-foundation/solita": "^0.2.0",
     "@types/tape": "^4.13.2",
     "eslint": "^8.3.0",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
-    "@metaplex-foundation/solita": "0.1.1",
     "@project-serum/anchor": "^0.19.0",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
@@ -40,8 +39,5 @@
     "eslint-plugin-prettier": "^4.0.0",
     "lerna": "^4.0.0",
     "prettier": "^2.4.1"
-  },
-  "resolutions": {
-    "@metaplex-foundation/solita": "portal:/Volumes/d/dev/mp/metaplex/metaplex-foundation/solita"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "eslint-plugin-prettier": "^4.0.0",
     "lerna": "^4.0.0",
     "prettier": "^2.4.1"
+  },
+  "resolutions": {
+    "@metaplex-foundation/solita": "portal:/Volumes/d/dev/mp/metaplex/metaplex-foundation/solita"
   }
 }

--- a/token-entangler/js/package.json
+++ b/token-entangler/js/package.json
@@ -38,8 +38,8 @@
   "author": "Metaplex Maintainers <contact@metaplex.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.0.8",
-    "@metaplex-foundation/beet-solana": "^0.0.6",
+    "@metaplex-foundation/beet": "^0.1.0",
+    "@metaplex-foundation/beet-solana": "^0.1.1",
     "@solana/web3.js": "^1.35.1"
   },
   "devDependencies": {

--- a/token-entangler/js/package.json
+++ b/token-entangler/js/package.json
@@ -43,7 +43,7 @@
     "@solana/web3.js": "^1.35.1"
   },
   "devDependencies": {
-    "@metaplex-foundation/solita": "^0.1.0",
+    "@metaplex-foundation/solita": "^0.2.0",
     "@types/tape": "^4.13.2",
     "eslint": "^8.3.0",
     "rimraf": "^3.0.2",

--- a/token-metadata/Cargo.lock
+++ b/token-metadata/Cargo.lock
@@ -2322,18 +2322,18 @@ dependencies = [
 
 [[package]]
 name = "shank"
-version = "0.0.0"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca46ffd371862f5eb24546958882c77b1326e22c8630a324a4df00e11b233ce"
+checksum = "241e2bc30cdc50633ec58dafea6841a3764f5efca9dc17c9604d9e4c45288167"
 dependencies = [
  "shank_macro",
 ]
 
 [[package]]
 name = "shank_macro"
-version = "0.0.0"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c348d9feb9e17132ffb54f0625e1ebac575108879d036809fef86edea050dd1"
+checksum = "4860f0c3bf7db32960c5e1d75166782b0b096a2e04e2580001e2e9993a7060ef"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -2343,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "shank_macro_impl"
-version = "0.0.0"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40b580c5b227fe9962b87649898289afaa1582470a143d43c48ac3d587ca404"
+checksum = "3c2dae9df9e062c7bbb482667f75ffcec1fb435d55d2e9b6454d32fc1612daa0"
 dependencies = [
  "anyhow",
  "proc-macro2 1.0.36",

--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -282,7 +282,8 @@
           "name": "reservationList",
           "isMut": true,
           "isSigner": false,
-          "desc": "(Optional) Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list."
+          "desc": "Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list.",
+          "optional": true
         }
       ],
       "args": [],
@@ -1165,13 +1166,15 @@
           "name": "useAuthorityRecord",
           "isMut": true,
           "isSigner": false,
-          "desc": "(Optional) Use Authority Record PDA If present the program Assumes a delegated use authority"
+          "desc": "Use Authority Record PDA If present the program Assumes a delegated use authority",
+          "optional": true
         },
         {
           "name": "burner",
           "isMut": false,
           "isSigner": false,
-          "desc": "(Optional) Program As Signer (Burner)"
+          "desc": "Program As Signer (Burner)",
+          "optional": true
         }
       ],
       "args": [
@@ -1371,7 +1374,8 @@
           "name": "collectionAuthorityRecord",
           "isMut": false,
           "isSigner": false,
-          "desc": "(Optional) Collection Authority Record PDA"
+          "desc": "Collection Authority Record PDA",
+          "optional": true
         }
       ],
       "args": [],
@@ -1521,7 +1525,8 @@
           "name": "collectionAuthorityRecord",
           "isMut": false,
           "isSigner": false,
-          "desc": "(Optional) Collection Authority Record PDA"
+          "desc": "Collection Authority Record PDA",
+          "optional": true
         }
       ],
       "args": [],

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -48,7 +48,7 @@
     "debug": "^4.3.3"
   },
   "devDependencies": {
-    "@metaplex-foundation/solita": "0.1.0",
+    "@metaplex-foundation/solita": "^0.2.0",
     "@solana/spl-token": "0.1.8",
     "@types/bn.js": "^5.1.0",
     "@types/debug": "^4.1.7",

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -49,7 +49,6 @@
   },
   "devDependencies": {
     "@metaplex-foundation/solita": "^0.2.0",
-    "@solana/spl-token": "0.1.8",
     "@types/bn.js": "^5.1.0",
     "@types/debug": "^4.1.7",
     "eslint": "^8.3.0",

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -12,7 +12,7 @@
     "postpublish": "git push origin && git push origin --tags",
     "build:docs": "typedoc",
     "build": "rimraf dist && tsc -p tsconfig.json",
-    "api:gen": "node scripts/api-gen-ts.js && prettier --write ./src/**/*.ts",
+    "api:gen": "node scripts/api-gen-ts.js && yarn fix:prettier && yarn fix:lint",
     "test": "echo 'Not testing generated code, please run program tests instead'",
     "lint": "eslint \"{src,test}/**/*.ts\" --format stylish",
     "fix:lint": "yarn lint --fix",

--- a/token-metadata/js/src/generated/accounts/CollectionAuthorityRecord.ts
+++ b/token-metadata/js/src/generated/accounts/CollectionAuthorityRecord.ts
@@ -5,9 +5,9 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import { Key, keyBeet } from '../types/Key';
 
 /**
  * Arguments used to create {@link CollectionAuthorityRecord}
@@ -15,7 +15,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type CollectionAuthorityRecordArgs = {
-  key: definedTypes.Key;
+  key: Key;
   bump: number;
 };
 /**
@@ -26,7 +26,7 @@ export type CollectionAuthorityRecordArgs = {
  * @category generated
  */
 export class CollectionAuthorityRecord implements CollectionAuthorityRecordArgs {
-  private constructor(readonly key: definedTypes.Key, readonly bump: number) {}
+  private constructor(readonly key: Key, readonly bump: number) {}
 
   /**
    * Creates a {@link CollectionAuthorityRecord} instance from the provided args.
@@ -117,7 +117,7 @@ export class CollectionAuthorityRecord implements CollectionAuthorityRecordArgs 
    */
   pretty() {
     return {
-      key: 'Key.' + definedTypes.Key[this.key],
+      key: 'Key.' + Key[this.key],
       bump: this.bump,
     };
   }
@@ -132,7 +132,7 @@ export const collectionAuthorityRecordBeet = new beet.BeetStruct<
   CollectionAuthorityRecordArgs
 >(
   [
-    ['key', definedTypes.keyBeet],
+    ['key', keyBeet],
     ['bump', beet.u8],
   ],
   CollectionAuthorityRecord.fromArgs,

--- a/token-metadata/js/src/generated/accounts/Edition.ts
+++ b/token-metadata/js/src/generated/accounts/Edition.ts
@@ -5,10 +5,10 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as web3 from '@solana/web3.js';
 import * as beet from '@metaplex-foundation/beet';
 import * as beetSolana from '@metaplex-foundation/beet-solana';
+import { Key, keyBeet } from '../types/Key';
 
 /**
  * Arguments used to create {@link Edition}
@@ -16,7 +16,7 @@ import * as beetSolana from '@metaplex-foundation/beet-solana';
  * @category generated
  */
 export type EditionArgs = {
-  key: definedTypes.Key;
+  key: Key;
   parent: web3.PublicKey;
   edition: beet.bignum;
 };
@@ -29,7 +29,7 @@ export type EditionArgs = {
  */
 export class Edition implements EditionArgs {
   private constructor(
-    readonly key: definedTypes.Key,
+    readonly key: Key,
     readonly parent: web3.PublicKey,
     readonly edition: beet.bignum,
   ) {}
@@ -117,7 +117,7 @@ export class Edition implements EditionArgs {
    */
   pretty() {
     return {
-      key: 'Key.' + definedTypes.Key[this.key],
+      key: 'Key.' + Key[this.key],
       parent: this.parent.toBase58(),
       edition: this.edition,
     };
@@ -130,7 +130,7 @@ export class Edition implements EditionArgs {
  */
 export const editionBeet = new beet.BeetStruct<Edition, EditionArgs>(
   [
-    ['key', definedTypes.keyBeet],
+    ['key', keyBeet],
     ['parent', beetSolana.publicKey],
     ['edition', beet.u64],
   ],

--- a/token-metadata/js/src/generated/accounts/EditionMarker.ts
+++ b/token-metadata/js/src/generated/accounts/EditionMarker.ts
@@ -5,9 +5,9 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import { Key, keyBeet } from '../types/Key';
 
 /**
  * Arguments used to create {@link EditionMarker}
@@ -15,7 +15,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type EditionMarkerArgs = {
-  key: definedTypes.Key;
+  key: Key;
   ledger: number[] /* size: 31 */;
 };
 /**
@@ -26,7 +26,7 @@ export type EditionMarkerArgs = {
  * @category generated
  */
 export class EditionMarker implements EditionMarkerArgs {
-  private constructor(readonly key: definedTypes.Key, readonly ledger: number[] /* size: 31 */) {}
+  private constructor(readonly key: Key, readonly ledger: number[] /* size: 31 */) {}
 
   /**
    * Creates a {@link EditionMarker} instance from the provided args.
@@ -114,7 +114,7 @@ export class EditionMarker implements EditionMarkerArgs {
    */
   pretty() {
     return {
-      key: 'Key.' + definedTypes.Key[this.key],
+      key: 'Key.' + Key[this.key],
       ledger: this.ledger,
     };
   }
@@ -126,7 +126,7 @@ export class EditionMarker implements EditionMarkerArgs {
  */
 export const editionMarkerBeet = new beet.BeetStruct<EditionMarker, EditionMarkerArgs>(
   [
-    ['key', definedTypes.keyBeet],
+    ['key', keyBeet],
     ['ledger', beet.uniformFixedSizeArray(beet.u8, 31)],
   ],
   EditionMarker.fromArgs,

--- a/token-metadata/js/src/generated/accounts/MasterEditionV1.ts
+++ b/token-metadata/js/src/generated/accounts/MasterEditionV1.ts
@@ -5,10 +5,10 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
 import * as beetSolana from '@metaplex-foundation/beet-solana';
+import { Key, keyBeet } from '../types/Key';
 
 /**
  * Arguments used to create {@link MasterEditionV1}
@@ -16,7 +16,7 @@ import * as beetSolana from '@metaplex-foundation/beet-solana';
  * @category generated
  */
 export type MasterEditionV1Args = {
-  key: definedTypes.Key;
+  key: Key;
   supply: beet.bignum;
   maxSupply: beet.COption<beet.bignum>;
   printingMint: web3.PublicKey;
@@ -31,7 +31,7 @@ export type MasterEditionV1Args = {
  */
 export class MasterEditionV1 implements MasterEditionV1Args {
   private constructor(
-    readonly key: definedTypes.Key,
+    readonly key: Key,
     readonly supply: beet.bignum,
     readonly maxSupply: beet.COption<beet.bignum>,
     readonly printingMint: web3.PublicKey,
@@ -129,7 +129,7 @@ export class MasterEditionV1 implements MasterEditionV1Args {
    */
   pretty() {
     return {
-      key: 'Key.' + definedTypes.Key[this.key],
+      key: 'Key.' + Key[this.key],
       supply: this.supply,
       maxSupply: this.maxSupply,
       printingMint: this.printingMint.toBase58(),
@@ -144,7 +144,7 @@ export class MasterEditionV1 implements MasterEditionV1Args {
  */
 export const masterEditionV1Beet = new beet.FixableBeetStruct<MasterEditionV1, MasterEditionV1Args>(
   [
-    ['key', definedTypes.keyBeet],
+    ['key', keyBeet],
     ['supply', beet.u64],
     ['maxSupply', beet.coption(beet.u64)],
     ['printingMint', beetSolana.publicKey],

--- a/token-metadata/js/src/generated/accounts/MasterEditionV2.ts
+++ b/token-metadata/js/src/generated/accounts/MasterEditionV2.ts
@@ -5,9 +5,9 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import { Key, keyBeet } from '../types/Key';
 
 /**
  * Arguments used to create {@link MasterEditionV2}
@@ -15,7 +15,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type MasterEditionV2Args = {
-  key: definedTypes.Key;
+  key: Key;
   supply: beet.bignum;
   maxSupply: beet.COption<beet.bignum>;
 };
@@ -28,7 +28,7 @@ export type MasterEditionV2Args = {
  */
 export class MasterEditionV2 implements MasterEditionV2Args {
   private constructor(
-    readonly key: definedTypes.Key,
+    readonly key: Key,
     readonly supply: beet.bignum,
     readonly maxSupply: beet.COption<beet.bignum>,
   ) {}
@@ -118,7 +118,7 @@ export class MasterEditionV2 implements MasterEditionV2Args {
    */
   pretty() {
     return {
-      key: 'Key.' + definedTypes.Key[this.key],
+      key: 'Key.' + Key[this.key],
       supply: this.supply,
       maxSupply: this.maxSupply,
     };
@@ -131,7 +131,7 @@ export class MasterEditionV2 implements MasterEditionV2Args {
  */
 export const masterEditionV2Beet = new beet.FixableBeetStruct<MasterEditionV2, MasterEditionV2Args>(
   [
-    ['key', definedTypes.keyBeet],
+    ['key', keyBeet],
     ['supply', beet.u64],
     ['maxSupply', beet.coption(beet.u64)],
   ],

--- a/token-metadata/js/src/generated/accounts/Metadata.ts
+++ b/token-metadata/js/src/generated/accounts/Metadata.ts
@@ -5,10 +5,14 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as web3 from '@solana/web3.js';
 import * as beet from '@metaplex-foundation/beet';
 import * as beetSolana from '@metaplex-foundation/beet-solana';
+import { Key, keyBeet } from '../types/Key';
+import { Data, dataBeet } from '../types/Data';
+import { TokenStandard, tokenStandardBeet } from '../types/TokenStandard';
+import { Collection, collectionBeet } from '../types/Collection';
+import { Uses, usesBeet } from '../types/Uses';
 
 /**
  * Arguments used to create {@link Metadata}
@@ -16,16 +20,16 @@ import * as beetSolana from '@metaplex-foundation/beet-solana';
  * @category generated
  */
 export type MetadataArgs = {
-  key: definedTypes.Key;
+  key: Key;
   updateAuthority: web3.PublicKey;
   mint: web3.PublicKey;
-  data: definedTypes.Data;
+  data: Data;
   primarySaleHappened: boolean;
   isMutable: boolean;
   editionNonce: beet.COption<number>;
-  tokenStandard: beet.COption<definedTypes.TokenStandard>;
-  collection: beet.COption<definedTypes.Collection>;
-  uses: beet.COption<definedTypes.Uses>;
+  tokenStandard: beet.COption<TokenStandard>;
+  collection: beet.COption<Collection>;
+  uses: beet.COption<Uses>;
 };
 /**
  * Holds the data for the {@link Metadata} Account and provides de/serialization
@@ -36,16 +40,16 @@ export type MetadataArgs = {
  */
 export class Metadata implements MetadataArgs {
   private constructor(
-    readonly key: definedTypes.Key,
+    readonly key: Key,
     readonly updateAuthority: web3.PublicKey,
     readonly mint: web3.PublicKey,
-    readonly data: definedTypes.Data,
+    readonly data: Data,
     readonly primarySaleHappened: boolean,
     readonly isMutable: boolean,
     readonly editionNonce: beet.COption<number>,
-    readonly tokenStandard: beet.COption<definedTypes.TokenStandard>,
-    readonly collection: beet.COption<definedTypes.Collection>,
-    readonly uses: beet.COption<definedTypes.Uses>,
+    readonly tokenStandard: beet.COption<TokenStandard>,
+    readonly collection: beet.COption<Collection>,
+    readonly uses: beet.COption<Uses>,
   ) {}
 
   /**
@@ -141,7 +145,7 @@ export class Metadata implements MetadataArgs {
    */
   pretty() {
     return {
-      key: 'Key.' + definedTypes.Key[this.key],
+      key: 'Key.' + Key[this.key],
       updateAuthority: this.updateAuthority.toBase58(),
       mint: this.mint.toBase58(),
       data: this.data,
@@ -161,16 +165,16 @@ export class Metadata implements MetadataArgs {
  */
 export const metadataBeet = new beet.FixableBeetStruct<Metadata, MetadataArgs>(
   [
-    ['key', definedTypes.keyBeet],
+    ['key', keyBeet],
     ['updateAuthority', beetSolana.publicKey],
     ['mint', beetSolana.publicKey],
-    ['data', definedTypes.dataBeet],
+    ['data', dataBeet],
     ['primarySaleHappened', beet.bool],
     ['isMutable', beet.bool],
     ['editionNonce', beet.coption(beet.u8)],
-    ['tokenStandard', beet.coption(definedTypes.tokenStandardBeet)],
-    ['collection', beet.coption(definedTypes.collectionBeet)],
-    ['uses', beet.coption(definedTypes.usesBeet)],
+    ['tokenStandard', beet.coption(tokenStandardBeet)],
+    ['collection', beet.coption(collectionBeet)],
+    ['uses', beet.coption(usesBeet)],
   ],
   Metadata.fromArgs,
   'Metadata',

--- a/token-metadata/js/src/generated/accounts/ReservationListV1.ts
+++ b/token-metadata/js/src/generated/accounts/ReservationListV1.ts
@@ -5,10 +5,11 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as web3 from '@solana/web3.js';
 import * as beet from '@metaplex-foundation/beet';
 import * as beetSolana from '@metaplex-foundation/beet-solana';
+import { Key, keyBeet } from '../types/Key';
+import { ReservationV1, reservationV1Beet } from '../types/ReservationV1';
 
 /**
  * Arguments used to create {@link ReservationListV1}
@@ -16,10 +17,10 @@ import * as beetSolana from '@metaplex-foundation/beet-solana';
  * @category generated
  */
 export type ReservationListV1Args = {
-  key: definedTypes.Key;
+  key: Key;
   masterEdition: web3.PublicKey;
   supplySnapshot: beet.COption<beet.bignum>;
-  reservations: definedTypes.ReservationV1[];
+  reservations: ReservationV1[];
 };
 /**
  * Holds the data for the {@link ReservationListV1} Account and provides de/serialization
@@ -30,10 +31,10 @@ export type ReservationListV1Args = {
  */
 export class ReservationListV1 implements ReservationListV1Args {
   private constructor(
-    readonly key: definedTypes.Key,
+    readonly key: Key,
     readonly masterEdition: web3.PublicKey,
     readonly supplySnapshot: beet.COption<beet.bignum>,
-    readonly reservations: definedTypes.ReservationV1[],
+    readonly reservations: ReservationV1[],
   ) {}
 
   /**
@@ -129,7 +130,7 @@ export class ReservationListV1 implements ReservationListV1Args {
    */
   pretty() {
     return {
-      key: 'Key.' + definedTypes.Key[this.key],
+      key: 'Key.' + Key[this.key],
       masterEdition: this.masterEdition.toBase58(),
       supplySnapshot: this.supplySnapshot,
       reservations: this.reservations,
@@ -146,10 +147,10 @@ export const reservationListV1Beet = new beet.FixableBeetStruct<
   ReservationListV1Args
 >(
   [
-    ['key', definedTypes.keyBeet],
+    ['key', keyBeet],
     ['masterEdition', beetSolana.publicKey],
     ['supplySnapshot', beet.coption(beet.u64)],
-    ['reservations', beet.array(definedTypes.reservationV1Beet)],
+    ['reservations', beet.array(reservationV1Beet)],
   ],
   ReservationListV1.fromArgs,
   'ReservationListV1',

--- a/token-metadata/js/src/generated/accounts/ReservationListV2.ts
+++ b/token-metadata/js/src/generated/accounts/ReservationListV2.ts
@@ -5,10 +5,11 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as web3 from '@solana/web3.js';
 import * as beet from '@metaplex-foundation/beet';
 import * as beetSolana from '@metaplex-foundation/beet-solana';
+import { Key, keyBeet } from '../types/Key';
+import { Reservation, reservationBeet } from '../types/Reservation';
 
 /**
  * Arguments used to create {@link ReservationListV2}
@@ -16,10 +17,10 @@ import * as beetSolana from '@metaplex-foundation/beet-solana';
  * @category generated
  */
 export type ReservationListV2Args = {
-  key: definedTypes.Key;
+  key: Key;
   masterEdition: web3.PublicKey;
   supplySnapshot: beet.COption<beet.bignum>;
-  reservations: definedTypes.Reservation[];
+  reservations: Reservation[];
   totalReservationSpots: beet.bignum;
   currentReservationSpots: beet.bignum;
 };
@@ -32,10 +33,10 @@ export type ReservationListV2Args = {
  */
 export class ReservationListV2 implements ReservationListV2Args {
   private constructor(
-    readonly key: definedTypes.Key,
+    readonly key: Key,
     readonly masterEdition: web3.PublicKey,
     readonly supplySnapshot: beet.COption<beet.bignum>,
-    readonly reservations: definedTypes.Reservation[],
+    readonly reservations: Reservation[],
     readonly totalReservationSpots: beet.bignum,
     readonly currentReservationSpots: beet.bignum,
   ) {}
@@ -135,7 +136,7 @@ export class ReservationListV2 implements ReservationListV2Args {
    */
   pretty() {
     return {
-      key: 'Key.' + definedTypes.Key[this.key],
+      key: 'Key.' + Key[this.key],
       masterEdition: this.masterEdition.toBase58(),
       supplySnapshot: this.supplySnapshot,
       reservations: this.reservations,
@@ -154,10 +155,10 @@ export const reservationListV2Beet = new beet.FixableBeetStruct<
   ReservationListV2Args
 >(
   [
-    ['key', definedTypes.keyBeet],
+    ['key', keyBeet],
     ['masterEdition', beetSolana.publicKey],
     ['supplySnapshot', beet.coption(beet.u64)],
-    ['reservations', beet.array(definedTypes.reservationBeet)],
+    ['reservations', beet.array(reservationBeet)],
     ['totalReservationSpots', beet.u64],
     ['currentReservationSpots', beet.u64],
   ],

--- a/token-metadata/js/src/generated/accounts/UseAuthorityRecord.ts
+++ b/token-metadata/js/src/generated/accounts/UseAuthorityRecord.ts
@@ -5,9 +5,9 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import { Key, keyBeet } from '../types/Key';
 
 /**
  * Arguments used to create {@link UseAuthorityRecord}
@@ -15,7 +15,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type UseAuthorityRecordArgs = {
-  key: definedTypes.Key;
+  key: Key;
   allowedUses: beet.bignum;
   bump: number;
 };
@@ -28,7 +28,7 @@ export type UseAuthorityRecordArgs = {
  */
 export class UseAuthorityRecord implements UseAuthorityRecordArgs {
   private constructor(
-    readonly key: definedTypes.Key,
+    readonly key: Key,
     readonly allowedUses: beet.bignum,
     readonly bump: number,
   ) {}
@@ -119,7 +119,7 @@ export class UseAuthorityRecord implements UseAuthorityRecordArgs {
    */
   pretty() {
     return {
-      key: 'Key.' + definedTypes.Key[this.key],
+      key: 'Key.' + Key[this.key],
       allowedUses: this.allowedUses,
       bump: this.bump,
     };
@@ -135,7 +135,7 @@ export const useAuthorityRecordBeet = new beet.BeetStruct<
   UseAuthorityRecordArgs
 >(
   [
-    ['key', definedTypes.keyBeet],
+    ['key', keyBeet],
     ['allowedUses', beet.u64],
     ['bump', beet.u8],
   ],

--- a/token-metadata/js/src/generated/instructions/ApproveUseAuthority.ts
+++ b/token-metadata/js/src/generated/instructions/ApproveUseAuthority.ts
@@ -6,9 +6,12 @@
  */
 
 import * as splToken from '@solana/spl-token';
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  ApproveUseAuthorityArgs,
+  approveUseAuthorityArgsBeet,
+} from '../types/ApproveUseAuthorityArgs';
 
 /**
  * @category Instructions
@@ -16,7 +19,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type ApproveUseAuthorityInstructionArgs = {
-  approveUseAuthorityArgs: definedTypes.ApproveUseAuthorityArgs;
+  approveUseAuthorityArgs: ApproveUseAuthorityArgs;
 };
 /**
  * @category Instructions
@@ -30,7 +33,7 @@ const ApproveUseAuthorityStruct = new beet.BeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['approveUseAuthorityArgs', definedTypes.approveUseAuthorityArgsBeet],
+    ['approveUseAuthorityArgs', approveUseAuthorityArgsBeet],
   ],
   'ApproveUseAuthorityInstructionArgs',
 );

--- a/token-metadata/js/src/generated/instructions/CreateMasterEdition.ts
+++ b/token-metadata/js/src/generated/instructions/CreateMasterEdition.ts
@@ -6,9 +6,12 @@
  */
 
 import * as splToken from '@solana/spl-token';
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  CreateMasterEditionArgs,
+  createMasterEditionArgsBeet,
+} from '../types/CreateMasterEditionArgs';
 
 /**
  * @category Instructions
@@ -16,7 +19,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type CreateMasterEditionInstructionArgs = {
-  createMasterEditionArgs: definedTypes.CreateMasterEditionArgs;
+  createMasterEditionArgs: CreateMasterEditionArgs;
 };
 /**
  * @category Instructions
@@ -30,7 +33,7 @@ const CreateMasterEditionStruct = new beet.FixableBeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['createMasterEditionArgs', definedTypes.createMasterEditionArgsBeet],
+    ['createMasterEditionArgs', createMasterEditionArgsBeet],
   ],
   'CreateMasterEditionInstructionArgs',
 );

--- a/token-metadata/js/src/generated/instructions/CreateMasterEditionV3.ts
+++ b/token-metadata/js/src/generated/instructions/CreateMasterEditionV3.ts
@@ -6,9 +6,12 @@
  */
 
 import * as splToken from '@solana/spl-token';
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  CreateMasterEditionArgs,
+  createMasterEditionArgsBeet,
+} from '../types/CreateMasterEditionArgs';
 
 /**
  * @category Instructions
@@ -16,7 +19,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type CreateMasterEditionV3InstructionArgs = {
-  createMasterEditionArgs: definedTypes.CreateMasterEditionArgs;
+  createMasterEditionArgs: CreateMasterEditionArgs;
 };
 /**
  * @category Instructions
@@ -30,7 +33,7 @@ const CreateMasterEditionV3Struct = new beet.FixableBeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['createMasterEditionArgs', definedTypes.createMasterEditionArgsBeet],
+    ['createMasterEditionArgs', createMasterEditionArgsBeet],
   ],
   'CreateMasterEditionV3InstructionArgs',
 );

--- a/token-metadata/js/src/generated/instructions/CreateMetadataAccount.ts
+++ b/token-metadata/js/src/generated/instructions/CreateMetadataAccount.ts
@@ -5,9 +5,12 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  CreateMetadataAccountArgs,
+  createMetadataAccountArgsBeet,
+} from '../types/CreateMetadataAccountArgs';
 
 /**
  * @category Instructions
@@ -15,7 +18,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type CreateMetadataAccountInstructionArgs = {
-  createMetadataAccountArgs: definedTypes.CreateMetadataAccountArgs;
+  createMetadataAccountArgs: CreateMetadataAccountArgs;
 };
 /**
  * @category Instructions
@@ -29,7 +32,7 @@ const CreateMetadataAccountStruct = new beet.FixableBeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['createMetadataAccountArgs', definedTypes.createMetadataAccountArgsBeet],
+    ['createMetadataAccountArgs', createMetadataAccountArgsBeet],
   ],
   'CreateMetadataAccountInstructionArgs',
 );

--- a/token-metadata/js/src/generated/instructions/CreateMetadataAccountV2.ts
+++ b/token-metadata/js/src/generated/instructions/CreateMetadataAccountV2.ts
@@ -5,9 +5,12 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  CreateMetadataAccountArgsV2,
+  createMetadataAccountArgsV2Beet,
+} from '../types/CreateMetadataAccountArgsV2';
 
 /**
  * @category Instructions
@@ -15,7 +18,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type CreateMetadataAccountV2InstructionArgs = {
-  createMetadataAccountArgsV2: definedTypes.CreateMetadataAccountArgsV2;
+  createMetadataAccountArgsV2: CreateMetadataAccountArgsV2;
 };
 /**
  * @category Instructions
@@ -29,7 +32,7 @@ const CreateMetadataAccountV2Struct = new beet.FixableBeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['createMetadataAccountArgsV2', definedTypes.createMetadataAccountArgsV2Beet],
+    ['createMetadataAccountArgsV2', createMetadataAccountArgsV2Beet],
   ],
   'CreateMetadataAccountV2InstructionArgs',
 );

--- a/token-metadata/js/src/generated/instructions/DeprecatedCreateMasterEdition.ts
+++ b/token-metadata/js/src/generated/instructions/DeprecatedCreateMasterEdition.ts
@@ -6,9 +6,12 @@
  */
 
 import * as splToken from '@solana/spl-token';
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  CreateMasterEditionArgs,
+  createMasterEditionArgsBeet,
+} from '../types/CreateMasterEditionArgs';
 
 /**
  * @category Instructions
@@ -16,7 +19,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type DeprecatedCreateMasterEditionInstructionArgs = {
-  createMasterEditionArgs: definedTypes.CreateMasterEditionArgs;
+  createMasterEditionArgs: CreateMasterEditionArgs;
 };
 /**
  * @category Instructions
@@ -30,7 +33,7 @@ const DeprecatedCreateMasterEditionStruct = new beet.FixableBeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['createMasterEditionArgs', definedTypes.createMasterEditionArgsBeet],
+    ['createMasterEditionArgs', createMasterEditionArgsBeet],
   ],
   'DeprecatedCreateMasterEditionInstructionArgs',
 );

--- a/token-metadata/js/src/generated/instructions/DeprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
+++ b/token-metadata/js/src/generated/instructions/DeprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
@@ -35,7 +35,7 @@ const DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenStruct = new beet
  * @property [**signer**] payer payer
  * @property [] masterUpdateAuthority update authority info for new metadata account
  * @property [] masterMetadata Master record metadata account
- * @property [_writable_] reservationList (Optional) Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list.
+ * @property [_writable_] reservationList (optional) Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list.
  * @category Instructions
  * @category DeprecatedMintNewEditionFromMasterEditionViaPrintingToken
  * @category generated
@@ -53,7 +53,7 @@ export type DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstruction
   payer: web3.PublicKey;
   masterUpdateAuthority: web3.PublicKey;
   masterMetadata: web3.PublicKey;
-  reservationList: web3.PublicKey;
+  reservationList?: web3.PublicKey;
 };
 
 const deprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDiscriminator = 3;
@@ -166,12 +166,15 @@ export function createDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenI
       isWritable: false,
       isSigner: false,
     },
-    {
+  ];
+
+  if (reservationList != null) {
+    keys.push({
       pubkey: reservationList,
       isWritable: true,
       isSigner: false,
-    },
-  ];
+    });
+  }
 
   const ix = new web3.TransactionInstruction({
     programId: new web3.PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),

--- a/token-metadata/js/src/generated/instructions/DeprecatedMintPrintingTokens.ts
+++ b/token-metadata/js/src/generated/instructions/DeprecatedMintPrintingTokens.ts
@@ -6,9 +6,12 @@
  */
 
 import * as splToken from '@solana/spl-token';
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  MintPrintingTokensViaTokenArgs,
+  mintPrintingTokensViaTokenArgsBeet,
+} from '../types/MintPrintingTokensViaTokenArgs';
 
 /**
  * @category Instructions
@@ -16,7 +19,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type DeprecatedMintPrintingTokensInstructionArgs = {
-  mintPrintingTokensViaTokenArgs: definedTypes.MintPrintingTokensViaTokenArgs;
+  mintPrintingTokensViaTokenArgs: MintPrintingTokensViaTokenArgs;
 };
 /**
  * @category Instructions
@@ -30,7 +33,7 @@ const DeprecatedMintPrintingTokensStruct = new beet.BeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['mintPrintingTokensViaTokenArgs', definedTypes.mintPrintingTokensViaTokenArgsBeet],
+    ['mintPrintingTokensViaTokenArgs', mintPrintingTokensViaTokenArgsBeet],
   ],
   'DeprecatedMintPrintingTokensInstructionArgs',
 );

--- a/token-metadata/js/src/generated/instructions/DeprecatedMintPrintingTokensViaToken.ts
+++ b/token-metadata/js/src/generated/instructions/DeprecatedMintPrintingTokensViaToken.ts
@@ -6,9 +6,12 @@
  */
 
 import * as splToken from '@solana/spl-token';
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  MintPrintingTokensViaTokenArgs,
+  mintPrintingTokensViaTokenArgsBeet,
+} from '../types/MintPrintingTokensViaTokenArgs';
 
 /**
  * @category Instructions
@@ -16,7 +19,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type DeprecatedMintPrintingTokensViaTokenInstructionArgs = {
-  mintPrintingTokensViaTokenArgs: definedTypes.MintPrintingTokensViaTokenArgs;
+  mintPrintingTokensViaTokenArgs: MintPrintingTokensViaTokenArgs;
 };
 /**
  * @category Instructions
@@ -30,7 +33,7 @@ const DeprecatedMintPrintingTokensViaTokenStruct = new beet.BeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['mintPrintingTokensViaTokenArgs', definedTypes.mintPrintingTokensViaTokenArgsBeet],
+    ['mintPrintingTokensViaTokenArgs', mintPrintingTokensViaTokenArgsBeet],
   ],
   'DeprecatedMintPrintingTokensViaTokenInstructionArgs',
 );

--- a/token-metadata/js/src/generated/instructions/DeprecatedSetReservationList.ts
+++ b/token-metadata/js/src/generated/instructions/DeprecatedSetReservationList.ts
@@ -5,9 +5,12 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  SetReservationListArgs,
+  setReservationListArgsBeet,
+} from '../types/SetReservationListArgs';
 
 /**
  * @category Instructions
@@ -15,7 +18,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type DeprecatedSetReservationListInstructionArgs = {
-  setReservationListArgs: definedTypes.SetReservationListArgs;
+  setReservationListArgs: SetReservationListArgs;
 };
 /**
  * @category Instructions
@@ -29,7 +32,7 @@ const DeprecatedSetReservationListStruct = new beet.FixableBeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['setReservationListArgs', definedTypes.setReservationListArgsBeet],
+    ['setReservationListArgs', setReservationListArgsBeet],
   ],
   'DeprecatedSetReservationListInstructionArgs',
 );

--- a/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaToken.ts
+++ b/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaToken.ts
@@ -6,9 +6,12 @@
  */
 
 import * as splToken from '@solana/spl-token';
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  MintNewEditionFromMasterEditionViaTokenArgs,
+  mintNewEditionFromMasterEditionViaTokenArgsBeet,
+} from '../types/MintNewEditionFromMasterEditionViaTokenArgs';
 
 /**
  * @category Instructions
@@ -16,7 +19,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type MintNewEditionFromMasterEditionViaTokenInstructionArgs = {
-  mintNewEditionFromMasterEditionViaTokenArgs: definedTypes.MintNewEditionFromMasterEditionViaTokenArgs;
+  mintNewEditionFromMasterEditionViaTokenArgs: MintNewEditionFromMasterEditionViaTokenArgs;
 };
 /**
  * @category Instructions
@@ -32,7 +35,7 @@ const MintNewEditionFromMasterEditionViaTokenStruct = new beet.BeetArgsStruct<
     ['instructionDiscriminator', beet.u8],
     [
       'mintNewEditionFromMasterEditionViaTokenArgs',
-      definedTypes.mintNewEditionFromMasterEditionViaTokenArgsBeet,
+      mintNewEditionFromMasterEditionViaTokenArgsBeet,
     ],
   ],
   'MintNewEditionFromMasterEditionViaTokenInstructionArgs',

--- a/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaVaultProxy.ts
+++ b/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaVaultProxy.ts
@@ -6,9 +6,12 @@
  */
 
 import * as splToken from '@solana/spl-token';
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  MintNewEditionFromMasterEditionViaTokenArgs,
+  mintNewEditionFromMasterEditionViaTokenArgsBeet,
+} from '../types/MintNewEditionFromMasterEditionViaTokenArgs';
 
 /**
  * @category Instructions
@@ -16,7 +19,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs = {
-  mintNewEditionFromMasterEditionViaTokenArgs: definedTypes.MintNewEditionFromMasterEditionViaTokenArgs;
+  mintNewEditionFromMasterEditionViaTokenArgs: MintNewEditionFromMasterEditionViaTokenArgs;
 };
 /**
  * @category Instructions
@@ -32,7 +35,7 @@ const MintNewEditionFromMasterEditionViaVaultProxyStruct = new beet.BeetArgsStru
     ['instructionDiscriminator', beet.u8],
     [
       'mintNewEditionFromMasterEditionViaTokenArgs',
-      definedTypes.mintNewEditionFromMasterEditionViaTokenArgsBeet,
+      mintNewEditionFromMasterEditionViaTokenArgsBeet,
     ],
   ],
   'MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs',

--- a/token-metadata/js/src/generated/instructions/SetAndVerifyCollection.ts
+++ b/token-metadata/js/src/generated/instructions/SetAndVerifyCollection.ts
@@ -26,7 +26,7 @@ const SetAndVerifyCollectionStruct = new beet.BeetArgsStruct<{
  * @property [] collectionMint Mint of the Collection
  * @property [] collection Metadata Account of the Collection
  * @property [] collectionMasterEditionAccount MasterEdition2 Account of the Collection Token
- * @property [] collectionAuthorityRecord (Optional) Collection Authority Record PDA
+ * @property [] collectionAuthorityRecord (optional) Collection Authority Record PDA
  * @category Instructions
  * @category SetAndVerifyCollection
  * @category generated
@@ -39,7 +39,7 @@ export type SetAndVerifyCollectionInstructionAccounts = {
   collectionMint: web3.PublicKey;
   collection: web3.PublicKey;
   collectionMasterEditionAccount: web3.PublicKey;
-  collectionAuthorityRecord: web3.PublicKey;
+  collectionAuthorityRecord?: web3.PublicKey;
 };
 
 const setAndVerifyCollectionInstructionDiscriminator = 25;
@@ -106,12 +106,15 @@ export function createSetAndVerifyCollectionInstruction(
       isWritable: false,
       isSigner: false,
     },
-    {
+  ];
+
+  if (collectionAuthorityRecord != null) {
+    keys.push({
       pubkey: collectionAuthorityRecord,
       isWritable: false,
       isSigner: false,
-    },
-  ];
+    });
+  }
 
   const ix = new web3.TransactionInstruction({
     programId: new web3.PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),

--- a/token-metadata/js/src/generated/instructions/UnverifyCollection.ts
+++ b/token-metadata/js/src/generated/instructions/UnverifyCollection.ts
@@ -24,7 +24,7 @@ const UnverifyCollectionStruct = new beet.BeetArgsStruct<{
  * @property [] collectionMint Mint of the Collection
  * @property [] collection Metadata Account of the Collection
  * @property [] collectionMasterEditionAccount MasterEdition2 Account of the Collection Token
- * @property [] collectionAuthorityRecord (Optional) Collection Authority Record PDA
+ * @property [] collectionAuthorityRecord (optional) Collection Authority Record PDA
  * @category Instructions
  * @category UnverifyCollection
  * @category generated
@@ -35,7 +35,7 @@ export type UnverifyCollectionInstructionAccounts = {
   collectionMint: web3.PublicKey;
   collection: web3.PublicKey;
   collectionMasterEditionAccount: web3.PublicKey;
-  collectionAuthorityRecord: web3.PublicKey;
+  collectionAuthorityRecord?: web3.PublicKey;
 };
 
 const unverifyCollectionInstructionDiscriminator = 22;
@@ -90,12 +90,15 @@ export function createUnverifyCollectionInstruction(
       isWritable: false,
       isSigner: false,
     },
-    {
+  ];
+
+  if (collectionAuthorityRecord != null) {
+    keys.push({
       pubkey: collectionAuthorityRecord,
       isWritable: false,
       isSigner: false,
-    },
-  ];
+    });
+  }
 
   const ix = new web3.TransactionInstruction({
     programId: new web3.PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),

--- a/token-metadata/js/src/generated/instructions/UpdateMetadataAccount.ts
+++ b/token-metadata/js/src/generated/instructions/UpdateMetadataAccount.ts
@@ -5,9 +5,12 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  UpdateMetadataAccountArgs,
+  updateMetadataAccountArgsBeet,
+} from '../types/UpdateMetadataAccountArgs';
 
 /**
  * @category Instructions
@@ -15,7 +18,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type UpdateMetadataAccountInstructionArgs = {
-  updateMetadataAccountArgs: definedTypes.UpdateMetadataAccountArgs;
+  updateMetadataAccountArgs: UpdateMetadataAccountArgs;
 };
 /**
  * @category Instructions
@@ -29,7 +32,7 @@ const UpdateMetadataAccountStruct = new beet.FixableBeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['updateMetadataAccountArgs', definedTypes.updateMetadataAccountArgsBeet],
+    ['updateMetadataAccountArgs', updateMetadataAccountArgsBeet],
   ],
   'UpdateMetadataAccountInstructionArgs',
 );

--- a/token-metadata/js/src/generated/instructions/UpdateMetadataAccountV2.ts
+++ b/token-metadata/js/src/generated/instructions/UpdateMetadataAccountV2.ts
@@ -5,9 +5,12 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import {
+  UpdateMetadataAccountArgsV2,
+  updateMetadataAccountArgsV2Beet,
+} from '../types/UpdateMetadataAccountArgsV2';
 
 /**
  * @category Instructions
@@ -15,7 +18,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type UpdateMetadataAccountV2InstructionArgs = {
-  updateMetadataAccountArgsV2: definedTypes.UpdateMetadataAccountArgsV2;
+  updateMetadataAccountArgsV2: UpdateMetadataAccountArgsV2;
 };
 /**
  * @category Instructions
@@ -29,7 +32,7 @@ const UpdateMetadataAccountV2Struct = new beet.FixableBeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['updateMetadataAccountArgsV2', definedTypes.updateMetadataAccountArgsV2Beet],
+    ['updateMetadataAccountArgsV2', updateMetadataAccountArgsV2Beet],
   ],
   'UpdateMetadataAccountV2InstructionArgs',
 );

--- a/token-metadata/js/src/generated/instructions/Utilize.ts
+++ b/token-metadata/js/src/generated/instructions/Utilize.ts
@@ -6,9 +6,9 @@
  */
 
 import * as splToken from '@solana/spl-token';
-import * as definedTypes from '../types';
 import * as beet from '@metaplex-foundation/beet';
 import * as web3 from '@solana/web3.js';
+import { UtilizeArgs, utilizeArgsBeet } from '../types/UtilizeArgs';
 
 /**
  * @category Instructions
@@ -16,7 +16,7 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type UtilizeInstructionArgs = {
-  utilizeArgs: definedTypes.UtilizeArgs;
+  utilizeArgs: UtilizeArgs;
 };
 /**
  * @category Instructions
@@ -30,7 +30,7 @@ const UtilizeStruct = new beet.BeetArgsStruct<
 >(
   [
     ['instructionDiscriminator', beet.u8],
-    ['utilizeArgs', definedTypes.utilizeArgsBeet],
+    ['utilizeArgs', utilizeArgsBeet],
   ],
   'UtilizeInstructionArgs',
 );
@@ -42,8 +42,8 @@ const UtilizeStruct = new beet.BeetArgsStruct<
  * @property [_writable_] mint Mint of the Metadata
  * @property [**signer**] useAuthority A Use Authority / Can be the current Owner of the NFT
  * @property [] owner Owner
- * @property [_writable_] useAuthorityRecord (Optional) Use Authority Record PDA If present the program Assumes a delegated use authority
- * @property [] burner (Optional) Program As Signer (Burner)
+ * @property [_writable_] useAuthorityRecord (optional) Use Authority Record PDA If present the program Assumes a delegated use authority
+ * @property [] burner (optional) Program As Signer (Burner)
  * @category Instructions
  * @category Utilize
  * @category generated
@@ -54,8 +54,8 @@ export type UtilizeInstructionAccounts = {
   mint: web3.PublicKey;
   useAuthority: web3.PublicKey;
   owner: web3.PublicKey;
-  useAuthorityRecord: web3.PublicKey;
-  burner: web3.PublicKey;
+  useAuthorityRecord?: web3.PublicKey;
+  burner?: web3.PublicKey;
 };
 
 const utilizeInstructionDiscriminator = 19;
@@ -127,17 +127,28 @@ export function createUtilizeInstruction(
       isWritable: false,
       isSigner: false,
     },
-    {
+  ];
+
+  if (useAuthorityRecord != null) {
+    keys.push({
       pubkey: useAuthorityRecord,
       isWritable: true,
       isSigner: false,
-    },
-    {
+    });
+  }
+
+  if (burner != null) {
+    if (useAuthorityRecord == null) {
+      throw new Error(
+        "When providing 'burner' then 'useAuthorityRecord' need(s) to be provided as well.",
+      );
+    }
+    keys.push({
       pubkey: burner,
       isWritable: false,
       isSigner: false,
-    },
-  ];
+    });
+  }
 
   const ix = new web3.TransactionInstruction({
     programId: new web3.PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),

--- a/token-metadata/js/src/generated/types/DataV2.ts
+++ b/token-metadata/js/src/generated/types/DataV2.ts
@@ -6,9 +6,9 @@
  */
 
 import * as beet from '@metaplex-foundation/beet';
-import { Uses, usesBeet } from './Uses';
 import { Creator, creatorBeet } from './Creator';
 import { Collection, collectionBeet } from './Collection';
+import { Uses, usesBeet } from './Uses';
 export type DataV2 = {
   name: string;
   symbol: string;

--- a/token-metadata/js/src/generated/types/Uses.ts
+++ b/token-metadata/js/src/generated/types/Uses.ts
@@ -6,7 +6,7 @@
  */
 
 import * as beet from '@metaplex-foundation/beet';
-import { useMethodBeet, UseMethod } from '../types/UseMethod';
+import { UseMethod, useMethodBeet } from './UseMethod';
 export type Uses = {
   useMethod: UseMethod;
   remaining: beet.bignum;

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -24,7 +24,7 @@ spl-token = { version="~3.2.0", features = [ "no-entrypoint" ] }
 spl-associated-token-account = { version = "~1.0.3", features = ["no-entrypoint"] }
 thiserror = "~1.0"
 borsh = "~0.9.2"
-shank = "~0.0.0" 
+shank = { version = "~0.0.1" }
 
 [dev-dependencies]
 solana-sdk = "~1.9.5"

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -76,6 +76,7 @@ pub struct UtilizeArgs {
 
 /// Instructions supported by the Metadata program.
 #[derive(BorshSerialize, BorshDeserialize, Clone, ShankInstruction)]
+#[rustfmt::skip]
 pub enum MetadataInstruction {
     /// Create Metadata object.
     #[account(0, writable, name="metadata", desc="Metadata key (pda of ['metadata', program id, mint id])")]
@@ -127,7 +128,7 @@ pub enum MetadataInstruction {
     #[account(12, name="token_program", desc="Token program")]
     #[account(13, name="system_program", desc="System program")]
     #[account(14, name="rent", desc="Rent info")]
-    #[account(15, writable, name="reservation_list", desc="(Optional) Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list.")]
+    #[account(15, optional, writable, name="reservation_list", desc="Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list.")]
     DeprecatedMintNewEditionFromMasterEditionViaPrintingToken,
 
     /// Allows updating the primary sale boolean on Metadata solely through owning an account
@@ -310,8 +311,8 @@ pub enum MetadataInstruction {
     #[account(6, name="ata_program", desc="Associated Token program")]
     #[account(7, name="system_program", desc="System program")]
     #[account(8, name="rent", desc="Rent info")]
-    #[account(9, writable, name="use_authority_record", desc="(Optional) Use Authority Record PDA If present the program Assumes a delegated use authority")]
-    #[account(10, name="burner", desc="(Optional) Program As Signer (Burner)")]
+    #[account(9, optional, writable, name="use_authority_record", desc="Use Authority Record PDA If present the program Assumes a delegated use authority")]
+    #[account(10, optional, name="burner", desc="Program As Signer (Burner)")]
     Utilize(UtilizeArgs),
 
     /// Approve another account to call [utilize] on this NFT.
@@ -346,7 +347,7 @@ pub enum MetadataInstruction {
     #[account(2, name="collection_mint", desc="Mint of the Collection")]
     #[account(3, name="collection", desc="Metadata Account of the Collection")]
     #[account(4, name="collection_master_edition_account", desc="MasterEdition2 Account of the Collection Token")]
-    #[account(5, name="collection_authority_record", desc="(Optional) Collection Authority Record PDA")]
+    #[account(5, optional, name="collection_authority_record", desc="Collection Authority Record PDA")]
     UnverifyCollection,
 
     /// Approve another account to verify NFTs belonging to a collection, [verify_collection] on the collection NFT.
@@ -376,7 +377,7 @@ pub enum MetadataInstruction {
     #[account(4, name="collection_mint", desc="Mint of the Collection")]
     #[account(5, name="collection", desc="Metadata Account of the Collection")]
     #[account(6, name="collection_master_edition_account", desc="MasterEdition2 Account of the Collection Token")]
-    #[account(7, name="collection_authority_record", desc="(Optional) Collection Authority Record PDA")]
+    #[account(7, optional, name="collection_authority_record", desc="Collection Authority Record PDA")]
     SetAndVerifyCollection,
 
     /// Allow freezing of an NFT if this user is the delegate of the NFT.
@@ -715,14 +716,20 @@ pub fn sign_metadata(program_id: Pubkey, metadata: Pubkey, creator: Pubkey) -> I
 
 /// Remove Creator Verificaton
 #[allow(clippy::too_many_arguments)]
-pub fn remove_creator_verification(program_id: Pubkey, metadata: Pubkey, creator: Pubkey) -> Instruction {
+pub fn remove_creator_verification(
+    program_id: Pubkey,
+    metadata: Pubkey,
+    creator: Pubkey,
+) -> Instruction {
     Instruction {
         program_id,
         accounts: vec![
             AccountMeta::new(metadata, false),
             AccountMeta::new_readonly(creator, true),
         ],
-        data: MetadataInstruction::RemoveCreatorVerification.try_to_vec().unwrap(),
+        data: MetadataInstruction::RemoveCreatorVerification
+            .try_to_vec()
+            .unwrap(),
     }
 }
 
@@ -839,7 +846,7 @@ pub fn verify_collection(
     }
     Instruction {
         program_id,
-        accounts: accounts,
+        accounts,
         data: MetadataInstruction::VerifyCollection.try_to_vec().unwrap(),
     }
 }
@@ -882,7 +889,7 @@ pub fn unverify_collection(
     }
     Instruction {
         program_id,
-        accounts: accounts,
+        accounts,
         data: MetadataInstruction::UnverifyCollection
             .try_to_vec()
             .unwrap(),

--- a/token-vault/js/package.json
+++ b/token-vault/js/package.json
@@ -47,8 +47,8 @@
   "author": "Metaplex Maintainers <contact@metaplex.com>",
   "license": "MIT",
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.0.8",
-    "@metaplex-foundation/beet-solana": "^0.0.6",
+    "@metaplex-foundation/beet": "^0.1.0",
+    "@metaplex-foundation/beet-solana": "^0.1.1",
     "@metaplex-foundation/cusper": "^0.0.2",
     "@metaplex-foundation/mpl-core": "^0.0.5",
     "@solana/spl-token": "^0.2.0",

--- a/token-vault/program/Cargo.toml
+++ b/token-vault/program/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "~0.3"
 num-traits = "~0.2"
 solana-program = "~1.9.5"
 spl-token = { version="~3.2.0", features = [ "no-entrypoint" ] }
-shank="~0.0.0"
+shank="~0.0.1"
 thiserror = "~1.0"
 borsh = "~0.9.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1010,8 +1010,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metaplex-foundation/mpl-auction-house@workspace:auction-house/js"
   dependencies:
-    "@metaplex-foundation/beet": ^0.0.8
-    "@metaplex-foundation/beet-solana": ^0.0.6
+    "@metaplex-foundation/beet": ^0.1.0
+    "@metaplex-foundation/beet-solana": ^0.1.1
     "@metaplex-foundation/mpl-core": ^0.0.5
     "@metaplex-foundation/solita": ^0.1.0
     "@solana/web3.js": ^1.35.1
@@ -1093,8 +1093,8 @@ __metadata:
   resolution: "@metaplex-foundation/mpl-fixed-price-sale@workspace:fixed-price-sale/js"
   dependencies:
     "@metaplex-foundation/amman": ^0.1.0
-    "@metaplex-foundation/beet": ^0.0.8
-    "@metaplex-foundation/beet-solana": ^0.0.6
+    "@metaplex-foundation/beet": ^0.1.0
+    "@metaplex-foundation/beet-solana": ^0.1.1
     "@metaplex-foundation/mpl-core": ^0.0.5
     "@metaplex-foundation/mpl-token-metadata": 1.1.0
     "@metaplex-foundation/solita": ^0.1.0
@@ -1116,8 +1116,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metaplex-foundation/mpl-gumdrop@workspace:gumdrop/js"
   dependencies:
-    "@metaplex-foundation/beet": ^0.0.8
-    "@metaplex-foundation/beet-solana": ^0.0.6
+    "@metaplex-foundation/beet": ^0.1.0
+    "@metaplex-foundation/beet-solana": ^0.1.1
     "@metaplex-foundation/solita": ^0.1.0
     "@solana/web3.js": ^1.35.1
     "@types/tape": ^4.13.2
@@ -1153,8 +1153,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metaplex-foundation/mpl-token-entangler@workspace:token-entangler/js"
   dependencies:
-    "@metaplex-foundation/beet": ^0.0.8
-    "@metaplex-foundation/beet-solana": ^0.0.6
+    "@metaplex-foundation/beet": ^0.1.0
+    "@metaplex-foundation/beet-solana": ^0.1.1
     "@metaplex-foundation/solita": ^0.1.0
     "@solana/web3.js": ^1.35.1
     "@types/tape": ^4.13.2
@@ -1214,8 +1214,8 @@ __metadata:
   resolution: "@metaplex-foundation/mpl-token-vault@workspace:token-vault/js"
   dependencies:
     "@metaplex-foundation/amman": ^0.1.0
-    "@metaplex-foundation/beet": ^0.0.8
-    "@metaplex-foundation/beet-solana": ^0.0.6
+    "@metaplex-foundation/beet": ^0.1.0
+    "@metaplex-foundation/beet-solana": ^0.1.1
     "@metaplex-foundation/cusper": ^0.0.2
     "@metaplex-foundation/mpl-core": ^0.0.5
     "@solana/spl-token": ^0.2.0
@@ -1233,7 +1233,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metaplex-foundation/solita@npm:0.1.0, @metaplex-foundation/solita@npm:^0.1.0":
+"@metaplex-foundation/solita@npm:0.1.0":
   version: 0.1.0
   resolution: "@metaplex-foundation/solita@npm:0.1.0"
   dependencies:
@@ -1250,7 +1250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metaplex-foundation/solita@npm:0.1.1":
+"@metaplex-foundation/solita@npm:0.1.1, @metaplex-foundation/solita@npm:^0.1.0":
   version: 0.1.1
   resolution: "@metaplex-foundation/solita@npm:0.1.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,16 +940,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metaplex-foundation/beet-solana@npm:^0.0.6":
-  version: 0.0.6
-  resolution: "@metaplex-foundation/beet-solana@npm:0.0.6"
-  dependencies:
-    "@metaplex-foundation/beet": ">0.0.5"
-    "@solana/web3.js": ^1.31.0
-  checksum: c79581a433fb24b932c336635e350726d860897d60d3858cced6b3760ee61cc61a345820d224eddfab5edc983c7ceee3d3689e6f59d9d08f965976427eb431e9
-  languageName: node
-  linkType: hard
-
 "@metaplex-foundation/beet-solana@npm:^0.1.1":
   version: 0.1.1
   resolution: "@metaplex-foundation/beet-solana@npm:0.1.1"
@@ -960,7 +950,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metaplex-foundation/beet@npm:>0.0.5, @metaplex-foundation/beet@npm:>=0.1.0, @metaplex-foundation/beet@npm:^0.1.0":
+"@metaplex-foundation/beet@npm:>=0.1.0, @metaplex-foundation/beet@npm:^0.1.0":
   version: 0.1.0
   resolution: "@metaplex-foundation/beet@npm:0.1.0"
   dependencies:
@@ -968,17 +958,6 @@ __metadata:
     bn.js: ^5.2.0
     debug: ^4.3.3
   checksum: 3ed1bfce55f9649cae837998a245b57450f4a324cfaa7f51afdc1672a49acfa36e35120ee6c48bf6804bb110e07827f5b141ef9452518c518af75ac60d3f11aa
-  languageName: node
-  linkType: hard
-
-"@metaplex-foundation/beet@npm:^0.0.8":
-  version: 0.0.8
-  resolution: "@metaplex-foundation/beet@npm:0.0.8"
-  dependencies:
-    ansicolors: ^0.3.2
-    bn.js: ^5.2.0
-    debug: ^4.3.3
-  checksum: 0dc0816abed44248e9df2988974710049e915775fbced52b8b4ce431e76b98db703233d567af528d894a07b0ff42776bf3cb79ef056f4a40d922a5661b406352
   languageName: node
   linkType: hard
 
@@ -1233,26 +1212,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metaplex-foundation/solita@npm:0.1.0":
-  version: 0.1.0
-  resolution: "@metaplex-foundation/solita@npm:0.1.0"
-  dependencies:
-    "@metaplex-foundation/beet": ^0.0.8
-    "@metaplex-foundation/beet-solana": ^0.0.6
-    "@solana/web3.js": ^1.35.0
-    camelcase: ^6.2.1
-    debug: ^4.3.3
-    js-sha256: ^0.9.0
-    prettier: ^2.5.1
-    snake-case: ^3.0.4
-    spok: ^1.4.3
-  checksum: 0d8f52c8754400d28d0d44d8ba90b886e7706fa2a1c550c1644fefadf11a74eae9feecf942b377a89285f342a28061d82c30e852be877abfe3444be6ee60a09a
-  languageName: node
-  linkType: hard
-
-"@metaplex-foundation/solita@npm:0.1.1, @metaplex-foundation/solita@npm:^0.1.0":
-  version: 0.1.1
-  resolution: "@metaplex-foundation/solita@npm:0.1.1"
+"@metaplex-foundation/solita@portal:/Volumes/d/dev/mp/metaplex/metaplex-foundation/solita::locator=%40metaplex-foundation%2Fmetaplex-program-library%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@metaplex-foundation/solita@portal:/Volumes/d/dev/mp/metaplex/metaplex-foundation/solita::locator=%40metaplex-foundation%2Fmetaplex-program-library%40workspace%3A."
   dependencies:
     "@metaplex-foundation/beet": ^0.1.0
     "@metaplex-foundation/beet-solana": ^0.1.1
@@ -1263,9 +1225,8 @@ __metadata:
     prettier: ^2.5.1
     snake-case: ^3.0.4
     spok: ^1.4.3
-  checksum: 5a9a550bab7a47cd21859445b672b4688f9c3e6ab5f8fa713b7ba2a229b3685cd332b1784333ce686928cb5a275f9858199f5919d70689217e3fae86f1d26b7a
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,7 +972,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metaplex-foundation/metaplex-program-library@workspace:."
   dependencies:
-    "@metaplex-foundation/solita": 0.1.1
     "@project-serum/anchor": ^0.19.0
     "@typescript-eslint/eslint-plugin": ^5.4.0
     "@typescript-eslint/parser": ^5.4.0
@@ -992,7 +991,7 @@ __metadata:
     "@metaplex-foundation/beet": ^0.1.0
     "@metaplex-foundation/beet-solana": ^0.1.1
     "@metaplex-foundation/mpl-core": ^0.0.5
-    "@metaplex-foundation/solita": ^0.1.0
+    "@metaplex-foundation/solita": ^0.2.0
     "@solana/web3.js": ^1.35.1
     "@types/tape": ^4.13.2
     bn.js: ^5.2.0
@@ -1076,7 +1075,7 @@ __metadata:
     "@metaplex-foundation/beet-solana": ^0.1.1
     "@metaplex-foundation/mpl-core": ^0.0.5
     "@metaplex-foundation/mpl-token-metadata": 1.1.0
-    "@metaplex-foundation/solita": ^0.1.0
+    "@metaplex-foundation/solita": ^0.2.0
     "@solana/spl-token": ^0.2.0
     "@solana/web3.js": ^1.35.1
     "@types/debug": ^4.1.7
@@ -1097,7 +1096,7 @@ __metadata:
   dependencies:
     "@metaplex-foundation/beet": ^0.1.0
     "@metaplex-foundation/beet-solana": ^0.1.1
-    "@metaplex-foundation/solita": ^0.1.0
+    "@metaplex-foundation/solita": ^0.2.0
     "@solana/web3.js": ^1.35.1
     "@types/tape": ^4.13.2
     eslint: ^8.3.0
@@ -1134,7 +1133,7 @@ __metadata:
   dependencies:
     "@metaplex-foundation/beet": ^0.1.0
     "@metaplex-foundation/beet-solana": ^0.1.1
-    "@metaplex-foundation/solita": ^0.1.0
+    "@metaplex-foundation/solita": ^0.2.0
     "@solana/web3.js": ^1.35.1
     "@types/tape": ^4.13.2
     eslint: ^8.3.0
@@ -1174,7 +1173,7 @@ __metadata:
     "@metaplex-foundation/beet-solana": ^0.1.1
     "@metaplex-foundation/cusper": ^0.0.2
     "@metaplex-foundation/mpl-core": ^0.0.5
-    "@metaplex-foundation/solita": 0.1.0
+    "@metaplex-foundation/solita": ^0.2.0
     "@solana/spl-token": 0.1.8
     "@solana/web3.js": ^1.35.1
     "@types/bn.js": ^5.1.0
@@ -1212,9 +1211,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metaplex-foundation/solita@portal:/Volumes/d/dev/mp/metaplex/metaplex-foundation/solita::locator=%40metaplex-foundation%2Fmetaplex-program-library%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@metaplex-foundation/solita@portal:/Volumes/d/dev/mp/metaplex/metaplex-foundation/solita::locator=%40metaplex-foundation%2Fmetaplex-program-library%40workspace%3A."
+"@metaplex-foundation/solita@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@metaplex-foundation/solita@npm:0.2.0"
   dependencies:
     "@metaplex-foundation/beet": ^0.1.0
     "@metaplex-foundation/beet-solana": ^0.1.1
@@ -1225,8 +1224,9 @@ __metadata:
     prettier: ^2.5.1
     snake-case: ^3.0.4
     spok: ^1.4.3
+  checksum: a84d744e1a4f2c156d7fc39877d5608c966a8ca9bae4e0f89061302edca238a748e5e0e427c1ea06f0801fa67ff7900f6b385a25c6b1aa0df351bcd998d77fd9
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,7 +1174,7 @@ __metadata:
     "@metaplex-foundation/cusper": ^0.0.2
     "@metaplex-foundation/mpl-core": ^0.0.5
     "@metaplex-foundation/solita": ^0.2.0
-    "@solana/spl-token": 0.1.8
+    "@solana/spl-token": ^0.2.0
     "@solana/web3.js": ^1.35.1
     "@types/bn.js": ^5.1.0
     "@types/debug": ^4.1.7
@@ -1572,7 +1572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solana/spl-token@npm:0.1.8, @solana/spl-token@npm:^0.1.8":
+"@solana/spl-token@npm:^0.1.8":
   version: 0.1.8
   resolution: "@solana/spl-token@npm:0.1.8"
   dependencies:


### PR DESCRIPTION
## Summary 

Adding latest shank and solita versions which support optional accounts and regenerated
token-metadata SDK to account for optional accounts.

## Steps

Pulled in latest shank + solita which support optional accounts.

Updated token-metadata rust code to add `optional` attribute to optional instruction accounts.

Renerated SDK.

## Side Effects

Since solita code generation overall improved especially around avoidance of circular imports
those changes were applied as part of the code regeneration.

## Optional Account Example

The [Utilize](token-metadata/js/src/generated/instructions/Utilize.ts) instruction now respects the fact that `useAuthorityRecord` and `burner` are optional accounts.

```ts
if (useAuthorityRecord != null) {
  keys.push({
    pubkey: useAuthorityRecord,
    isWritable: true,
    isSigner: false,
  });
}

if (burner != null) {
  if (useAuthorityRecord == null) {
    throw new Error(
      "When providing 'burner' then 'useAuthorityRecord' need(s) to be provided as well.",
    );
  }
  keys.push({
    pubkey: burner,
    isWritable: false,
    isSigner: false,
  });
}
```

## Repo Wide Chores

Solita and beet tooling deps were updated across the workspace in order to keep those versions as much in sync as possible.
