### PR TITLE
updates Metadata.ts

### DIFF
--- a/token-metadata/js/src/deprecated/accounts/Metadata.ts
+++ b/token-metadata/js/src/deprecated/accounts/Metadata.ts
@@ -238,7 +238,9 @@ export class Metadata extends Account<MetadataData> {
         .flat()
         .map((account) => Metadata.from(account));
     } else {
-      return (await MetadataProgram.getProgramAccounts(connection, { filters: baseFilters })).map(
+      let accounts = await MetadataProgram.getProgramAccounts(connection, { filters: baseFilters });
+      accounts = accounts || [];
+      return accounts.map(
         (account) => Metadata.from(account),
       );
     }


### PR DESCRIPTION
error responses are getting trapped (ex. below), adds default empty array to avoid `TypeError: Cannot read property 'map' of null ...  at Function.<anonymous> ../mpl-core/dist/src/Program.js:50:18`

```js
{
  jsonrpc: '2.0',
  result: null,
  error: { code: -32602, message: 'Too many filters provided; max 4' },
  id: 'd899f230-f5e9-42f6-9446-03b06b9720d7'
}
```