### PR TITLE
chore: token-metadata upgraded to cor@e0.6

### DIFF
--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -41,7 +41,7 @@
     "@metaplex-foundation/beet": "^0.1.0",
     "@metaplex-foundation/beet-solana": "^0.1.1",
     "@metaplex-foundation/cusper": "^0.0.2",
-    "@metaplex-foundation/mpl-core": "^0.0.5",
+    "@metaplex-foundation/mpl-core": "^0.6.0",
     "@solana/spl-token": "^0.2.0",
     "@solana/web3.js": "^1.35.1",
     "bn.js": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1053,6 +1053,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metaplex-foundation/mpl-core@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@metaplex-foundation/mpl-core@npm:0.6.0"
+  dependencies:
+    "@solana/web3.js": ^1.35.1
+    bs58: ^4.0.1
+  checksum: 7c5e6cc3a0b970696f531494e68fe8c016585c394d9667ecf3b00026e172eba0818a0117a9e9712358ded85c7d841d122d9ecb6c5c60112d5d2be7d278422f6d
+  languageName: node
+  linkType: hard
+
 "@metaplex-foundation/mpl-core@workspace:core/js":
   version: 0.0.0-use.local
   resolution: "@metaplex-foundation/mpl-core@workspace:core/js"
@@ -1172,7 +1182,7 @@ __metadata:
     "@metaplex-foundation/beet": ^0.1.0
     "@metaplex-foundation/beet-solana": ^0.1.1
     "@metaplex-foundation/cusper": ^0.0.2
-    "@metaplex-foundation/mpl-core": ^0.0.5
+    "@metaplex-foundation/mpl-core": ^0.6.0
     "@metaplex-foundation/solita": ^0.2.0
     "@solana/spl-token": ^0.2.0
     "@solana/web3.js": ^1.35.1


### PR DESCRIPTION
This is necessary since `0.6` of `mpl-core` removed the dependency to `spl-token` which is
causing issues.
