### PR TITLE
Chore: Bump Token Vault integration test version to 1.9.14

### DIFF
--- a/.github/workflows/integration-token-vault.yml
+++ b/.github/workflows/integration-token-vault.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.8.5
+  SOLANA_VERSION: 1.9.14
   RUST_TOOLCHAIN: stable
 
 jobs:


### PR DESCRIPTION
Bumping version so PR validation can pass again.