### PR TITLE
fix: getMultipleAccounts returning mismatched key-value pairs Closes …

### DIFF
--- a/core/js/src/accounts/Account.ts
+++ b/core/js/src/accounts/Account.ts
@@ -84,14 +84,14 @@ export class Account<T = unknown> {
       throw new Error('failed to get info about accounts ' + unsafeRes.error.message);
     }
     if (!unsafeRes.result.value) return;
-    const infos = (unsafeRes.result.value as AccountInfo<string[]>[])
-      .filter(Boolean)
-      .map((info) => ({
-        ...info,
-        data: Buffer.from(info.data[0], 'base64'),
-      })) as AccountInfo<Buffer>[];
-    return infos.reduce((acc, info, index) => {
-      acc.set(pubkeys[index], info);
+    const unsafeInfos = unsafeRes.result.value as (AccountInfo<string[]> | null)[];
+    return unsafeInfos.reduce((acc, unsafeInfo, index) => {
+      if (unsafeInfo) {
+        acc.set(pubkeys[index], {
+          ...unsafeInfo,
+          data: Buffer.from(unsafeInfo.data[0], 'base64'),
+        } as AccountInfo<Buffer>);
+      }
       return acc;
     }, new Map<AnyPublicKey, AccountInfo<Buffer>>());
   }


### PR DESCRIPTION
…#250

Fixes #250 

https://github.com/metaplex-foundation/metaplex-program-library/blob/ddb247622dcfd7501f6811007fbbb88b1bce1483/core/js/src/accounts/Account.ts#L73-L97

This map doesnt work properly because `getMultipleAccounts` can return null / undefined and then it uses `      .filter(Boolean)` to filter those out but assumes the same order when getting the keys in the final reduce
      `acc.set(pubkeys[index], info);`

I think it probably could be rewritten like this PR so that it iterates the accounts and the pubkeys together and skips botth if the account if null. The filter is what messses up the order by removing accounts but not pubkeys