### PR TITLE
chore: expose full API including errors

### DIFF
--- a/candy-machine/js/package.json
+++ b/candy-machine/js/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@metaplex-foundation/beet": "^0.1.0",
     "@metaplex-foundation/beet-solana": "^0.1.1",
+    "@metaplex-foundation/cusper": "^0.0.2",
     "@metaplex-foundation/mpl-core": "^0.0.5",
     "@solana/web3.js": "^1.35.1"
   },

--- a/candy-machine/js/src/errors.ts
+++ b/candy-machine/js/src/errors.ts
@@ -1,0 +1,4 @@
+import { initCusper } from '@metaplex-foundation/cusper';
+import { errorFromCode } from './generated';
+
+export const cusper = initCusper(errorFromCode);

--- a/candy-machine/js/src/generated/index.ts
+++ b/candy-machine/js/src/generated/index.ts
@@ -1,5 +1,6 @@
 import { PublicKey } from '@solana/web3.js';
 export * from './accounts';
+export * from './errors';
 export * from './instructions';
 export * from './types';
 

--- a/candy-machine/js/src/mpl-candy-machine.ts
+++ b/candy-machine/js/src/mpl-candy-machine.ts
@@ -1,1 +1,2 @@
 export * from './CandyMachineProgram';
+export * from './generated';

--- a/candy-machine/js/src/mpl-candy-machine.ts
+++ b/candy-machine/js/src/mpl-candy-machine.ts
@@ -1,2 +1,3 @@
 export * from './CandyMachineProgram';
+export * from './errors';
 export * from './generated';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,6 +1023,7 @@ __metadata:
   dependencies:
     "@metaplex-foundation/beet": ^0.1.0
     "@metaplex-foundation/beet-solana": ^0.1.1
+    "@metaplex-foundation/cusper": ^0.0.2
     "@metaplex-foundation/mpl-core": ^0.0.5
     "@solana/web3.js": ^1.35.1
     eslint: ^8.3.0


### PR DESCRIPTION
## Expose generated API

- currently all hangs off `CandyMachineProgram` which makes less sense
  since we also export types + classes here
- also this fixes the issues of `./generated/types` not being
  exposed at all
- I kept `CandyMachineProgram` around for now, but ideally we'd remove
  that as well and switch to the approach that token-metadata uses

## Errors

- deps: add cusper dep
- api: expose errors and cusper based error API
