### PR TITLE
Fixing test in fixed-price-sale

### DIFF
--- a/fixed-price-sale/program/src/processor/claim_resource.rs
+++ b/fixed-price-sale/program/src/processor/claim_resource.rs
@@ -1,10 +1,4 @@
-use crate::{
-    error::ErrorCode,
-    id,
-    state::{MarketState, PrimaryMetadataCreators},
-    utils::*,
-    ClaimResource,
-};
+use crate::{error::ErrorCode, state::MarketState, utils::*, ClaimResource};
 use anchor_lang::{prelude::*, solana_program::program_pack::Pack, System};
 use anchor_spl::token;
 

--- a/fixed-price-sale/program/src/processor/save_primary_metadata_creators.rs
+++ b/fixed-price-sale/program/src/processor/save_primary_metadata_creators.rs
@@ -4,7 +4,7 @@ use anchor_lang::prelude::*;
 impl<'info> SavePrimaryMetadataCreators<'info> {
     pub fn process(
         &mut self,
-        primary_metadata_creators_bump: u8,
+        _primary_metadata_creators_bump: u8,
         creators: Vec<mpl_token_metadata::state::Creator>,
     ) -> Result<()> {
         let metadata = &self.metadata;

--- a/fixed-price-sale/program/tests/buy.rs
+++ b/fixed-price-sale/program/tests/buy.rs
@@ -12,7 +12,9 @@ mod buy {
             setup_functions::{setup_selling_resource, setup_store},
         },
     };
-    use anchor_lang::{AccountDeserialize, InstructionData, ToAccountMetas};
+    use anchor_lang::{
+        error::ERROR_CODE_OFFSET, AccountDeserialize, InstructionData, ToAccountMetas,
+    };
     use mpl_fixed_price_sale::{
         accounts as mpl_fixed_price_sale_accounts,
         error::ErrorCode,
@@ -2452,7 +2454,7 @@ mod buy {
         let price = 1_000_000;
         let pieces_in_one_wallet = Some(1);
 
-        let (collection_mint, collection_token_acc) =
+        let (collection_mint, _collection_token_acc) =
             create_collection(&mut context, &admin_wallet).await;
 
         // CreateMarket
@@ -2615,15 +2617,6 @@ mod buy {
             &mpl_token_metadata::id(),
         );
 
-        let (collection_metadata, _) = Pubkey::find_program_address(
-            &[
-                mpl_token_metadata::state::PREFIX.as_bytes(),
-                mpl_token_metadata::id().as_ref(),
-                collection_mint.as_ref(),
-            ],
-            &mpl_token_metadata::id(),
-        );
-
         // Buy
         let mut accounts = mpl_fixed_price_sale_accounts::Buy {
             market: market_keypair.pubkey(),
@@ -2773,7 +2766,7 @@ mod buy {
         let price = 1_000_000;
         let pieces_in_one_wallet = Some(1);
 
-        let (collection_mint, collection_token_acc) =
+        let (collection_mint, _collection_token_acc) =
             create_collection(&mut context, &admin_wallet).await;
 
         // CreateMarket
@@ -2932,15 +2925,6 @@ mod buy {
                 mpl_token_metadata::id().as_ref(),
                 new_mint_keypair.pubkey().as_ref(),
                 mpl_token_metadata::state::EDITION.as_bytes(),
-            ],
-            &mpl_token_metadata::id(),
-        );
-
-        let (collection_metadata, _) = Pubkey::find_program_address(
-            &[
-                mpl_token_metadata::state::PREFIX.as_bytes(),
-                mpl_token_metadata::id().as_ref(),
-                collection_mint.as_ref(),
             ],
             &mpl_token_metadata::id(),
         );
@@ -3094,7 +3078,7 @@ mod buy {
         let price = 1_000_000;
         let pieces_in_one_wallet = Some(1);
 
-        let (collection_mint, collection_token_acc) =
+        let (collection_mint, _collection_token_acc) =
             create_collection(&mut context, &admin_wallet).await;
 
         // CreateMarket
@@ -3257,15 +3241,6 @@ mod buy {
             &mpl_token_metadata::id(),
         );
 
-        let (collection_metadata, _) = Pubkey::find_program_address(
-            &[
-                mpl_token_metadata::state::PREFIX.as_bytes(),
-                mpl_token_metadata::id().as_ref(),
-                collection_mint.as_ref(),
-            ],
-            &mpl_token_metadata::id(),
-        );
-
         // Buy
         let mut accounts = mpl_fixed_price_sale_accounts::Buy {
             market: market_keypair.pubkey(),
@@ -3332,13 +3307,16 @@ mod buy {
             .await
             .unwrap_err();
 
-        let err_code = ErrorCode::WrongGatingMetadataAccount as u32;
-
         match err {
             TransportError::TransactionError(TransactionError::InstructionError(
                 0,
                 InstructionError::Custom(err_code),
-            )) => assert!(true),
+            )) => {
+                assert_eq!(
+                    err_code,
+                    ERROR_CODE_OFFSET + ErrorCode::WrongGatingMetadataAccount as u32
+                );
+            }
             _ => assert!(false),
         }
     }

--- a/fixed-price-sale/program/tests/claim_resource.rs
+++ b/fixed-price-sale/program/tests/claim_resource.rs
@@ -432,9 +432,6 @@ mod claim_resource {
         )
         .await;
 
-        let (_primary_metadata_creators, primary_metadata_creators_bump) =
-            mpl_fixed_price_sale::utils::find_primary_metadata_creators(&metadata);
-
         let accounts = mpl_fixed_price_sale_accounts::ClaimResource {
             market: market_keypair.pubkey(),
             treasury_holder: treasury_holder_keypair.pubkey(),
@@ -774,8 +771,6 @@ mod claim_resource {
             &primary_royalties_receiver.pubkey(),
         );
 
-        let destination = selling_resource_owner_keypair.pubkey();
-
         let (metadata, _) = Pubkey::find_program_address(
             &[
                 mpl_token_metadata::state::PREFIX.as_bytes(),
@@ -835,9 +830,6 @@ mod claim_resource {
             &admin_wallet.pubkey(),
         )
         .await;
-
-        let (_primary_metadata_creators, primary_metadata_creators_bump) =
-            mpl_fixed_price_sale::utils::find_primary_metadata_creators(&metadata);
 
         let accounts = mpl_fixed_price_sale_accounts::ClaimResource {
             market: market_keypair.pubkey(),
@@ -1221,9 +1213,6 @@ mod claim_resource {
             &admin_wallet.pubkey(),
         )
         .await;
-
-        let (_primary_metadata_creators, primary_metadata_creators_bump) =
-            mpl_fixed_price_sale::utils::find_primary_metadata_creators(&metadata);
 
         let accounts = mpl_fixed_price_sale_accounts::ClaimResource {
             market: market_keypair.pubkey(),


### PR DESCRIPTION
* Corrected match statement in `err_gated_unverified_nft`, that would
  match on any `err_code`.

* Marked `primary_metadata_creators_bump` as unused in
  `SavePrimaryMetadataCreators` to remove compile warning.

* Fixed other unused variable compiler warnings for program and tests.

* Testing: `cargo test-bpf --bpf-out-dir ../../target/deploy` passes,
  although even before this change, sometimes some buy tests will time
  out.