### PR TITLE
token-entangler, create entanglement "A seeds constraint was violated."

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,11 +83,11 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5be76607b9625327c7491daedb99706d8eb68cec67e3c2fe4bdbbe303a0d6c3"
+checksum = "a9b75d05b6b4ac9d95bb6e3b786b27d3a708c4c5a87c92ffaa25bbe9ae4c5d91"
 dependencies = [
- "anchor-syn 0.24.1",
+ "anchor-syn 0.24.2",
  "anyhow",
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -127,11 +127,11 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ba761139de778852b0bf86e3857d988cd135c15fb4d8ee75b925b9646b5a84"
+checksum = "485351a6d8157750d10d88c8e256f1bf8339262b2220ae9125aed3471309b5de"
 dependencies = [
- "anchor-syn 0.24.1",
+ "anchor-syn 0.24.2",
  "anyhow",
  "bs58 0.4.0",
  "proc-macro2 1.0.36",
@@ -164,11 +164,11 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e59bb75c94133e1ffeb688144456b572c9ff08120c0c03235c02d7048ca294"
+checksum = "dc632c540913dd051a78b00587cc47f57013d303163ddfaf4fa18717f7ccc1e0"
 dependencies = [
- "anchor-syn 0.24.1",
+ "anchor-syn 0.24.2",
  "proc-macro2 1.0.36",
  "syn 1.0.86",
 ]
@@ -199,11 +199,11 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51537dfabe3b50d56c412ff01a3ed9bc76dccd7d6d3991a8ee298258fd37f2ee"
+checksum = "3b5bd1dcfa7f3bc22dacef233d70a9e0bee269c4ac484510662f257cba2353a1"
 dependencies = [
- "anchor-syn 0.24.1",
+ "anchor-syn 0.24.2",
  "proc-macro2 1.0.36",
  "quote 1.0.15",
  "syn 1.0.86",
@@ -237,11 +237,11 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9260684556a09bca3dc8c3b5388c322707ee56b34846498d219979d013fedfa6"
+checksum = "6c6f9e6ce551ac9a177a45c99a65699a860c9e95fac68675138af1246e2591b0"
 dependencies = [
- "anchor-syn 0.24.1",
+ "anchor-syn 0.24.2",
  "anyhow",
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -278,11 +278,11 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-interface"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70262c877203f2716f10cc36d88b777425c0bc8953629934fe729f9cad707d09"
+checksum = "d104aa17418cb329ed7418b227e083d5f326a27f26ce98f5d92e33da62a5f459"
 dependencies = [
- "anchor-syn 0.24.1",
+ "anchor-syn 0.24.2",
  "anyhow",
  "heck",
  "proc-macro2 1.0.36",
@@ -318,11 +318,11 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3291238f560a2d51c255df4e10269be99c64d4e611d53428b33abbeb642b9db8"
+checksum = "b6831b920b173c004ddf7ae1167d1d25e9f002ffcb1773bbc5c7ce532a4441e1"
 dependencies = [
- "anchor-syn 0.24.1",
+ "anchor-syn 0.24.2",
  "anyhow",
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -357,11 +357,11 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-state"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c51579b76c0ec6f03f0f581dd32fd52698f065da3d8c5176d84730164c1e2f0"
+checksum = "cde147b10c71d95dc679785db0b5f3abac0091f789167aa62ac0135e2f54e8b9"
 dependencies = [
- "anchor-syn 0.24.1",
+ "anchor-syn 0.24.2",
  "anyhow",
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -391,7 +391,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604285a05df356c2e9e9774b4c2593b3dd472378e8d8f467fd7cf41daf9c8910"
 dependencies = [
- "anchor-lang 0.24.1",
+ "anchor-lang 0.24.2",
  "anyhow",
  "regex",
  "serde",
@@ -430,11 +430,11 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c6cceba2f29b42b0fd8d84f9a27bbc732749c4c49d2b25fcecb89be9fd2d8e"
+checksum = "9cde98a0e1a56046b040ff591dfda391f88917af2b6487d02b45093c05be3514"
 dependencies = [
- "anchor-syn 0.24.1",
+ "anchor-syn 0.24.2",
  "anyhow",
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -490,19 +490,19 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a524cf43a3859d0715bca53fdfbcb75b0b0028952499bbafd52deaef9df271f4"
+checksum = "a85dd2c5e29e20c7f4701a43724d6cd5406d0ee5694705522e43da0f26542a84"
 dependencies = [
- "anchor-attribute-access-control 0.24.1",
- "anchor-attribute-account 0.24.1",
- "anchor-attribute-constant 0.24.1",
- "anchor-attribute-error 0.24.1",
- "anchor-attribute-event 0.24.1",
- "anchor-attribute-interface 0.24.1",
- "anchor-attribute-program 0.24.1",
- "anchor-attribute-state 0.24.1",
- "anchor-derive-accounts 0.24.1",
+ "anchor-attribute-access-control 0.24.2",
+ "anchor-attribute-account 0.24.2",
+ "anchor-attribute-constant 0.24.2",
+ "anchor-attribute-error 0.24.2",
+ "anchor-attribute-event 0.24.2",
+ "anchor-attribute-interface 0.24.2",
+ "anchor-attribute-program 0.24.2",
+ "anchor-attribute-state 0.24.2",
+ "anchor-derive-accounts 0.24.2",
  "arrayref",
  "base64 0.13.0",
  "bincode",
@@ -538,11 +538,11 @@ dependencies = [
 
 [[package]]
 name = "anchor-spl"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383035b6eed94be902577947cb1ffc305786a55c965503143f2306554942b3c1"
+checksum = "0188c33b4a3c124c4e593f2b440415aaea70a7650fac6ba0772395385d71c003"
 dependencies = [
- "anchor-lang 0.24.1",
+ "anchor-lang 0.24.2",
  "solana-program",
  "spl-associated-token-account",
  "spl-token",
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-syn"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f501db049fbf4e6284413f5b97dddd647f9e8581dd6a31114516b5c8d49b3a1"
+checksum = "03549dc2eae0b20beba6333b14520e511822a6321cdb1760f841064a69347316"
 dependencies = [
  "anyhow",
  "bs58 0.3.1",
@@ -2244,8 +2244,8 @@ dependencies = [
 name = "mpl-token-entangler"
 version = "0.1.2"
 dependencies = [
- "anchor-lang 0.24.1",
- "anchor-spl 0.24.1",
+ "anchor-lang 0.24.2",
+ "anchor-spl 0.24.2",
  "arrayref",
  "mpl-token-metadata 1.2.7",
  "solana-program-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,6 +2248,8 @@ dependencies = [
  "anchor-spl 0.24.1",
  "arrayref",
  "mpl-token-metadata 1.2.7",
+ "solana-program-test",
+ "solana-sdk",
  "spl-associated-token-account",
  "spl-token",
  "thiserror",

--- a/token-entangler/program/Cargo.toml
+++ b/token-entangler/program/Cargo.toml
@@ -17,8 +17,8 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "~0.24.1"
-anchor-spl = "~0.24.1"
+anchor-lang = "~0.24.2"
+anchor-spl = "~0.24.2"
 spl-token = { version = "~3.2",  features = ["no-entrypoint"] }
 spl-associated-token-account = {version = "~1.0.3", features = ["no-entrypoint"]}
 mpl-token-metadata = { version="~1.2.7", features = [ "no-entrypoint" ], path="../../token-metadata/program" }

--- a/token-entangler/program/Cargo.toml
+++ b/token-entangler/program/Cargo.toml
@@ -26,8 +26,5 @@ thiserror = "~1.0"
 arrayref = "~0.3.6"
 
 [dev-dependencies]
-# anchor-client = "~0.22"
 solana-program-test = "~1.9.5"
-# solana-program = "~1.9.5"
 solana-sdk = "~1.9.5"
-# spl-associated-token-account = "~1.0.3"

--- a/token-entangler/program/Cargo.toml
+++ b/token-entangler/program/Cargo.toml
@@ -24,3 +24,10 @@ spl-associated-token-account = {version = "~1.0.3", features = ["no-entrypoint"]
 mpl-token-metadata = { version="~1.2.7", features = [ "no-entrypoint" ], path="../../token-metadata/program" }
 thiserror = "~1.0"
 arrayref = "~0.3.6"
+
+[dev-dependencies]
+# anchor-client = "~0.22"
+solana-program-test = "~1.9.5"
+# solana-program = "~1.9.5"
+solana-sdk = "~1.9.5"
+# spl-associated-token-account = "~1.0.3"

--- a/token-entangler/program/src/lib.rs
+++ b/token-entangler/program/src/lib.rs
@@ -157,6 +157,7 @@ pub mod token_entangler {
                 transfer_authority.to_account_info(),
             ],
         )?;
+
         Ok(())
     }
 
@@ -307,20 +308,20 @@ pub mod token_entangler {
 }
 
 #[derive(Accounts)]
-#[instruction(reverse_bump: u8, token_a_escrow_bump: u8, token_b_escrow_bump: u8)]
+#[instruction(bump: u8, reverse_bump: u8, token_a_escrow_bump: u8, token_b_escrow_bump: u8)]
 pub struct CreateEntangledPair<'info> {
-    treasury_mint: Box<Account<'info, Mint>>,
+    treasury_mint: UncheckedAccount<'info>,
     #[account(mut)]
     payer: Signer<'info>,
     transfer_authority: Signer<'info>,
     /// CHECK: Verified through CPI
     authority: UncheckedAccount<'info>,
-    mint_a: Box<Account<'info, Mint>>,
+    mint_a: UncheckedAccount<'info>,
     /// CHECK: Verified through CPI
     metadata_a: UncheckedAccount<'info>,
     /// CHECK: Verified through CPI
     edition_a: UncheckedAccount<'info>,
-    mint_b: Box<Account<'info, Mint>>,
+    mint_b: UncheckedAccount<'info>,
     /// CHECK: Verified through CPI
     metadata_b: UncheckedAccount<'info>,
     /// CHECK: Verified through CPI

--- a/token-entangler/program/src/lib.rs
+++ b/token-entangler/program/src/lib.rs
@@ -157,7 +157,6 @@ pub mod token_entangler {
                 transfer_authority.to_account_info(),
             ],
         )?;
-
         Ok(())
     }
 

--- a/token-entangler/program/src/lib.rs
+++ b/token-entangler/program/src/lib.rs
@@ -310,18 +310,18 @@ pub mod token_entangler {
 #[derive(Accounts)]
 #[instruction(bump: u8, reverse_bump: u8, token_a_escrow_bump: u8, token_b_escrow_bump: u8)]
 pub struct CreateEntangledPair<'info> {
-    treasury_mint: UncheckedAccount<'info>,
+    treasury_mint: Box<Account<'info, Mint>>,
     #[account(mut)]
     payer: Signer<'info>,
     transfer_authority: Signer<'info>,
     /// CHECK: Verified through CPI
     authority: UncheckedAccount<'info>,
-    mint_a: UncheckedAccount<'info>,
+    mint_a: Box<Account<'info, Mint>>,
     /// CHECK: Verified through CPI
     metadata_a: UncheckedAccount<'info>,
     /// CHECK: Verified through CPI
     edition_a: UncheckedAccount<'info>,
-    mint_b: UncheckedAccount<'info>,
+    mint_b: Box<Account<'info, Mint>>,
     /// CHECK: Verified through CPI
     metadata_b: UncheckedAccount<'info>,
     /// CHECK: Verified through CPI

--- a/token-entangler/program/tests/entangler_lifecycle_test.rs
+++ b/token-entangler/program/tests/entangler_lifecycle_test.rs
@@ -3,7 +3,7 @@ use anchor_lang::{
     InstructionData, ToAccountMetas,
 };
 use mpl_token_metadata::{instruction::create_metadata_accounts, pda::find_metadata_account};
-use solana_program_test::{tokio, ProgramTest};
+use solana_program_test::ProgramTest;
 use solana_sdk::{
     instruction::Instruction, program_pack::Pack, signature::Keypair, signer::Signer,
     system_instruction::create_account, transaction::Transaction,
@@ -18,13 +18,12 @@ use test_utils::{
     instructions_to_mint_an_nft,
 };
 
-const TREASURY_MINT: &str = "So11111111111111111111111111111111111111112";
-const RENT_SYSVAR_ADDRESS: &str = "SysvarRent111111111111111111111111111111111";
-const SYSTEM_PROGRAM_ADDRESS: &str = "11111111111111111111111111111111";
+// #[tokio::test]
+async fn _lifecycle_test() {
+    const TREASURY_MINT: &str = "So11111111111111111111111111111111111111112";
+    const RENT_SYSVAR_ADDRESS: &str = "SysvarRent111111111111111111111111111111111";
+    const SYSTEM_PROGRAM_ADDRESS: &str = "11111111111111111111111111111111";
 
-#[tokio::test]
-async fn lifecycle_test() {
-    #[allow(unused_mut)]
     let mut program_test = ProgramTest::default();
     program_test.add_program("mpl_token_metadata", mpl_token_metadata::id(), None);
     program_test.add_program("mpl_token_entangler", mpl_token_entangler::id(), None);
@@ -254,6 +253,7 @@ async fn lifecycle_test() {
     }
 }
 
+#[allow(unused)]
 mod test_utils {
     use mpl_token_metadata::instruction::create_master_edition_v3;
 

--- a/token-entangler/program/tests/entangler_lifecycle_test.rs
+++ b/token-entangler/program/tests/entangler_lifecycle_test.rs
@@ -21,6 +21,10 @@ use test_utils::{
     instructions_to_mint_an_nft,
 };
 
+const TREASURY_MINT: &str = "So11111111111111111111111111111111111111112";
+const RENT_SYSVAR_ADDRESS: &str = "SysvarRent111111111111111111111111111111111";
+const SYSTEM_PROGRAM_ADDRESS: &str = "11111111111111111111111111111111";
+
 #[tokio::test]
 async fn lifecycle_test() {
     #[allow(unused_mut)]
@@ -53,31 +57,26 @@ async fn lifecycle_test() {
 
     // CreateEntangledPair (marathon)
     let transfer_authority = Keypair::new();
+
     let accounts = mpl_token_entangler::accounts::CreateEntangledPair {
-        treasury_mint: "So11111111111111111111111111111111111111112"
-            .parse()
-            .unwrap(),
+        treasury_mint: TREASURY_MINT.parse().unwrap(),
         authority: payer.pubkey(),
         transfer_authority: transfer_authority.pubkey(),
+        entangled_pair: find_entangled_pair(mint_a.pubkey(), mint_b.pubkey()).0,
+        reverse_entangled_pair: find_entangled_pair(mint_b.pubkey(), mint_a.pubkey()).0,
         mint_a: mint_a.pubkey(),
         mint_b: mint_b.pubkey(),
-        token_a_escrow: find_escrow_b(mint_a.pubkey(), mint_b.pubkey()).0,
-        token_b: get_associated_token_address(&payer.pubkey(), &mint_b.pubkey()),
+        token_a_escrow: find_escrow_a(mint_a.pubkey(), mint_b.pubkey()).0,
         token_b_escrow: find_escrow_b(mint_a.pubkey(), mint_b.pubkey()).0,
         metadata_a: find_metadata_account(&mint_a.pubkey()).0,
         metadata_b: find_metadata_account(&mint_b.pubkey()).0,
         edition_a: find_master_edition_address(mint_a.pubkey()),
         edition_b: find_master_edition_address(mint_b.pubkey()),
-        entangled_pair: find_entangled_pair(mint_a.pubkey(), mint_b.pubkey()).0,
-        reverse_entangled_pair: find_entangled_pair(mint_b.pubkey(), mint_a.pubkey()).0,
+        token_b: get_associated_token_address(&payer.pubkey(), &mint_b.pubkey()),
         payer: payer.pubkey(),
-        rent: "SysvarRent111111111111111111111111111111111"
-            .parse()
-            .unwrap(),
-        token_program: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-            .parse()
-            .unwrap(),
-        system_program: "11111111111111111111111111111111".parse().unwrap(),
+        rent: RENT_SYSVAR_ADDRESS.parse().unwrap(),
+        token_program: spl_token::id(),
+        system_program: SYSTEM_PROGRAM_ADDRESS.parse().unwrap(),
     }
     .to_account_metas(None);
 
@@ -86,7 +85,7 @@ async fn lifecycle_test() {
         _reverse_bump: find_entangled_pair(mint_b.pubkey(), mint_a.pubkey()).1,
         token_a_escrow_bump: find_escrow_a(mint_a.pubkey(), mint_b.pubkey()).1,
         token_b_escrow_bump: find_escrow_b(mint_a.pubkey(), mint_b.pubkey()).1,
-        price: 0,
+        price: 1,
         pays_every_time: false,
     }
     .data();

--- a/token-entangler/program/tests/entangler_lifecycle_test.rs
+++ b/token-entangler/program/tests/entangler_lifecycle_test.rs
@@ -2,10 +2,7 @@ use anchor_lang::{
     prelude::{Pubkey, Rent},
     InstructionData, ToAccountMetas,
 };
-use mpl_token_metadata::{
-    instruction::{create_master_edition, create_metadata_accounts},
-    pda::find_metadata_account,
-};
+use mpl_token_metadata::{instruction::create_metadata_accounts, pda::find_metadata_account};
 use solana_program_test::{tokio, ProgramTest};
 use solana_sdk::{
     instruction::Instruction, program_pack::Pack, signature::Keypair, signer::Signer,
@@ -113,6 +110,8 @@ async fn lifecycle_test() {
 }
 
 mod test_utils {
+    use mpl_token_metadata::instruction::create_master_edition_v3;
+
     use crate::*;
 
     pub fn instructions_to_mint_an_nft(
@@ -154,7 +153,7 @@ mod test_utils {
                 1,
             )
             .unwrap(),
-            create_master_edition(
+            create_master_edition_v3(
                 mpl_token_metadata::id(),
                 find_master_edition_address(mint),
                 mint,


### PR DESCRIPTION
The token-entangler is on the struggle-bus -- in particular, the create entanglement instruction fails frequently. I'm not sure what the root cause is yet, but this fork contains a test that reproduces the issue (which is intermittent, but frequent)