### PR TITLE
Allow Metadata updates when it contains a Verified Collection

### DIFF
--- a/token-metadata/program/src/assertions/collection.rs
+++ b/token-metadata/program/src/assertions/collection.rs
@@ -8,10 +8,19 @@ use crate::{
 
 pub fn assert_collection_update_is_valid(
     edition: bool,
-    _existing: &Option<Collection>,
+    existing: &Option<Collection>,
     incoming: &Option<Collection>,
 ) -> Result<(), ProgramError> {
-    if incoming.is_some() && incoming.as_ref().unwrap().verified == true && !edition {
+    let is_incoming_verified_true =
+        incoming.is_some() && incoming.as_ref().unwrap().verified == true;
+
+    // If incoming verified is true. Confirm incoming and existing are identical
+    let is_incoming_data_valid = !is_incoming_verified_true
+        || (existing.is_some()
+            && incoming.as_ref().unwrap().verified == existing.as_ref().unwrap().verified
+            && incoming.as_ref().unwrap().key == existing.as_ref().unwrap().key);
+
+    if !is_incoming_data_valid && !edition {
         // Never allow a collection to be verified outside of verify_collection instruction
         return Err(MetadataError::CollectionCannotBeVerifiedInThisInstruction.into());
     }
@@ -42,8 +51,7 @@ pub fn assert_has_collection_authority(
             collection_authority_info.key,
             mint,
         )?;
-        let data = collection_authority_record
-            .try_borrow_data()?;
+        let data = collection_authority_record.try_borrow_data()?;
         if data.len() == 0 {
             return Err(MetadataError::InvalidCollectionUpdateAuthority.into());
         }

--- a/token-metadata/program/tests/verify_collection.rs
+++ b/token-metadata/program/tests/verify_collection.rs
@@ -20,7 +20,7 @@ use solana_sdk::{
 use utils::*;
 mod verify_collection {
 
-    use mpl_token_metadata::state::{COLLECTION_AUTHORITY_RECORD_SIZE, CollectionAuthorityRecord};
+    use mpl_token_metadata::state::{CollectionAuthorityRecord, COLLECTION_AUTHORITY_RECORD_SIZE};
     use solana_program::borsh::try_from_slice_unchecked;
     use solana_sdk::transaction::Transaction;
 
@@ -142,7 +142,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
-                None
+                None,
             )
             .await
             .unwrap();
@@ -164,7 +164,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
-                None
+                None,
             )
             .await
             .unwrap();
@@ -777,7 +777,7 @@ mod verify_collection {
                 false,
                 None,
                 None,
-                None
+                None,
             )
             .await
             .unwrap();
@@ -792,7 +792,18 @@ mod verify_collection {
         let uri = "uri".to_string();
         let test_metadata = Metadata::new();
         test_metadata
-            .create_v2(&mut context, name, symbol, uri, None, 10, false, None, None, None)
+            .create_v2(
+                &mut context,
+                name,
+                symbol,
+                uri,
+                None,
+                10,
+                false,
+                None,
+                None,
+                None,
+            )
             .await
             .unwrap();
 
@@ -860,7 +871,6 @@ mod verify_collection {
             .unwrap();
         let metadata_after_unverify = test_metadata.get_data(&mut context).await;
         assert_eq!(metadata_after_unverify.collection.unwrap().verified, false);
-        
     }
 
     #[tokio::test]
@@ -946,7 +956,12 @@ mod verify_collection {
 
         context.banks_client.process_transaction(tx).await.unwrap();
 
-        let account_before = context.banks_client.get_account(record).await.unwrap().unwrap();
+        let account_before = context
+            .banks_client
+            .get_account(record)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(account_before.data.len(), COLLECTION_AUTHORITY_RECORD_SIZE);
 
         let ixrevoke = mpl_token_metadata::instruction::revoke_collection_authority(
@@ -971,7 +986,12 @@ mod verify_collection {
             .await
             .unwrap();
 
-        let account_after_none = context.banks_client.get_account(record).await.unwrap().is_none();
+        let account_after_none = context
+            .banks_client
+            .get_account(record)
+            .await
+            .unwrap()
+            .is_none();
         assert_eq!(account_after_none, true);
 
         let err = test_metadata


### PR DESCRIPTION
Updating `Metadata` accounts with a `verified` collection requires that users "un verify" their collection to properly update. This fix allows for updates, as long as you maintain the verified collection state.