### PR TITLE
Its time we did something about bots

### DIFF
--- a/candy-machine/program/Cargo.lock
+++ b/candy-machine/program/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-candy-machine"
-version = "3.1.4"
+version = "3.2.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/candy-machine/program/Cargo.toml
+++ b/candy-machine/program/Cargo.toml
@@ -1,13 +1,16 @@
 [workspace]
 [package]
 name = "mpl-candy-machine"
-version = "3.1.4"
+version = "3.2.0"
 description = "NFT Candy Machine v2: programmatic and trustless NFT drops."
 authors = ["Jordan Prince", "Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/metaplex-program-library"
 license = "AGPL-3.0"
 edition = "2018"
 readme = "README.md"
+
+[profile.release]
+overflow-checks = true
 
 [lib]
 crate-type = ["cdylib", "lib"]
@@ -17,6 +20,7 @@ no-entrypoint = []
 no-idl = []
 cpi = ["no-entrypoint"]
 default = []
+
 
 [dependencies]
 anchor-lang = "=0.21.0"

--- a/candy-machine/program/src/utils.rs
+++ b/candy-machine/program/src/utils.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use anchor_lang::prelude::{Signer, Sysvar};
 
 use {
@@ -5,6 +6,7 @@ use {
     anchor_lang::{
         prelude::{Account, AccountInfo, Clock, ProgramError, ProgramResult, Pubkey},
         solana_program::{
+            msg,
             program::invoke_signed,
             program_pack::{IsInitialized, Pack},
         },
@@ -69,6 +71,18 @@ pub struct TokenTransferParams<'a: 'b, 'b> {
     /// token_program
     /// CHECK: account checked in CPI
     pub token_program: AccountInfo<'a>,
+}
+
+pub fn punish_bots(err: ErrorCode, bot_account: &AccountInfo, payment_account: &AccountInfo, fee: u64) -> Result<(), ProgramError> {
+    msg!("Error: {}, Candy Machine Botting is taxed at {:?} lamports", err.to_string(), fee);
+    let bot_lamp = bot_account.lamports();
+    let mut final_fee = fee;
+    if bot_lamp < fee {
+        final_fee = bot_lamp;
+    }
+    **bot_account.try_borrow_mut_lamports()? = bot_account.lamports() - final_fee;
+    **payment_account.try_borrow_mut_lamports()? = payment_account.lamports() + final_fee;
+    Ok(())
 }
 
 #[inline(always)]

--- a/candy-machine/program/src/utils.rs
+++ b/candy-machine/program/src/utils.rs
@@ -75,11 +75,7 @@ pub struct TokenTransferParams<'a: 'b, 'b> {
 
 pub fn punish_bots(err: ErrorCode, bot_account: &AccountInfo, payment_account: &AccountInfo, fee: u64) -> Result<(), ProgramError> {
     msg!("Error: {}, Candy Machine Botting is taxed at {:?} lamports", err.to_string(), fee);
-    let bot_lamp = bot_account.lamports();
-    let mut final_fee = fee;
-    if bot_lamp < fee {
-        final_fee = bot_lamp;
-    }
+    let final_fee = fee.min(bot_account.lamports());
     **bot_account.try_borrow_mut_lamports()? = bot_account.lamports() - final_fee;
     **payment_account.try_borrow_mut_lamports()? = payment_account.lamports() + final_fee;
     Ok(())


### PR DESCRIPTION
# Step 0.1 of bot destruction:

TLDR; CHARGE BOTs .01 SOL (could increase)

This is not the end solution but it will be effective in discouraging bots.

## Rationale
Candymachine has one of the lowest success rates for programs on solana
![image](https://user-images.githubusercontent.com/4331331/166085688-5a81a3cd-0691-48ee-81a0-6d3030bfd727.png)

A very high number of those transactions are clear cases where a bot is doing something bad, trying to mint before the mint is open, minting after the candy machine is empty, minting without a WL token 
Example: 

This is an image of a CandyMachineNotLive error.
![image](https://user-images.githubusercontent.com/4331331/166087422-4186daca-bc7b-43ec-b994-3887004a0829.png)

## Content

This PR adds a hard-coded bot tax of 0.01 sol (we may increase this) and it will charge the wallet this amount or all of their funds whatever is higher under the following conditions:
The funds are sent to the Token Metadata program account, this is to avoid any client changes needed to adopt this change. More pervasive changes are needed to fully and more accurately solve this. 
If a bot wallet does not contain enough for the bot fee and hits a failure mode from above we drain their wallet entirely. Then its up to the efficient Solana TXN system to kick out unfunded transactions.

### Specific Fee Charging Cases

1. Trying to mint when the candy machine is not live before or after
2. Trying to mint when there are no items left in the candy machine
3. Calling Candy Machine via CPI when not using gumdrop
4. Crafting a transaction where mint or set collection is not the last ix
5. Using the wrong collection id than the configured one for the candy machine
6. Setting Collection IX with a mismatched mint than what was just minted
7. Signer Payer mismatch with collection set and mint ix
8. Suspicious Transactions where disallowed programs are used
9. Trying to mint on an AllowList candy machine with no allow list token

### Cons

There is a chance that a real user could hit one of these cases, especially in # 2. But we think these will not be frequent.
This is not a fool proof fix, and it will not completely stop congestion but we belive it has a substantial enough impact to attempt it.

## Request for Feedback

Please give us feedback below, especially if you have data from your platform regarding the regularity of # 2 or if you are valid CPI user of candy machine.
