### PR TITLE
[DRAFT] Mints per wallet + exp punishment

### DIFF
--- a/candy-machine/program/src/utils.rs
+++ b/candy-machine/program/src/utils.rs
@@ -75,22 +75,22 @@ pub struct TokenTransferParams<'a: 'b, 'b> {
 }
 
 pub fn punish_curve(base_fee: u64, price: u64, allowed: u64, failed: u64) -> u64 {
-    let exp = failed - allowed;
+    let exp = (failed - allowed).div(10);
     let coefficient = (base_fee + (base_fee - price)) as f64;
     (coefficient * (2u64 as f64).pow(-exp)).round() as u64
 }
 
 pub fn punish_bots<'a>(
     err: ErrorCode,
-    mint_memory: AccountInfo<'a>,
     bot_account: AccountInfo<'a>,
     payment_account: AccountInfo<'a>,
     system_program: AccountInfo<'a>,
     fee: u64,
     price: u64,
     allowed: u64,
+    failed: u64,
 ) -> Result<(), ProgramError> {
-    let exp_fee = punish_curve(fee, price, allowed, mint_memory.failed);
+    let exp_fee = punish_curve(fee, price, allowed, failed);
     let final_fee = exp_fee.min(bot_account.lamports());
 
     msg!(


### PR DESCRIPTION
Punishment curve = `BaseFee + (BaseFee - MintPrice) * exp( - (failed - allowed)/Slope)` .

Which looks like this in case of `BaseFee = 0.1` , `MintPrice = 2` and `Slope = 10`. 

This will also enforce `mints per wallet`, but will require API change.

![image](https://user-images.githubusercontent.com/20769037/166136952-d2a7df3b-fb58-4153-a62b-c7bf5b974c16.png)

(https://www.desmos.com/calculator/3fisjexbvp)