### PR TITLE
Fix: prevent WL token burn before punish bot calls

### DIFF
--- a/candy-machine/program/Cargo.toml
+++ b/candy-machine/program/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 name = "mpl-candy-machine"
-version = "3.2.1"
+version = "3.2.2"
 description = "NFT Candy Machine v2: programmatic and trustless NFT drops."
 authors = ["Jordan Prince", "Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/metaplex-program-library"


### PR DESCRIPTION
This PR reorders the checks on the WL token burn ix to after the go live date checks. This should prevent WL tokens from being burned if a txn "fails" from the bot punish function. 