### PR TITLE
[Linting] Adding Fmt and Clippy Requirements to Token Metadata

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 12

--- a/.github/actions/verify-rust/action.yml
+++ b/.github/actions/verify-rust/action.yml
@@ -13,4 +13,4 @@ runs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --no-deps -- -D warnings
+        args: --all-targets --all-features --no-deps -- -D warnings

--- a/.github/actions/verify-rust/action.yml
+++ b/.github/actions/verify-rust/action.yml
@@ -1,5 +1,10 @@
 name: Verify Rust
 
+inputs:
+  crate:
+    description: The crate you want to verify
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -13,4 +18,4 @@ runs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all-targets --all-features --no-deps -- -D warnings
+        args: -p ${{ inputs.crate }} --all-features --no-deps -- -D warnings

--- a/.github/actions/verify-rust/action.yml
+++ b/.github/actions/verify-rust/action.yml
@@ -10,14 +10,12 @@ runs:
   steps:
     - name: Run cargo fmt
       uses: actions-rs/cargo@v1
-      working-directory: ${{ inputs.working-directory }}
       with:
         command: fmt
         args: --all -- --check
 
     - name: Run cargo clippy
       uses: actions-rs/cargo@v1
-      working-directory: ${{ inputs.working-directory }}
       with:
         command: clippy
-        args: --all-features --no-deps -- -D warnings
+        args: -all-features --no-deps --manifest-path ${{ inputs.working-directory }}/Cargo.toml -- -D warnings

--- a/.github/actions/verify-rust/action.yml
+++ b/.github/actions/verify-rust/action.yml
@@ -18,4 +18,4 @@ runs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: -all-features --no-deps --manifest-path ${{ inputs.working-directory }}/Cargo.toml -- -D warnings
+        args: --all-features --no-deps --manifest-path ${{ inputs.working-directory }}/Cargo.toml -- -D warnings

--- a/.github/actions/verify-rust/action.yml
+++ b/.github/actions/verify-rust/action.yml
@@ -12,7 +12,7 @@ runs:
       uses: actions-rs/cargo@v1
       with:
         command: fmt
-        args: --all -- --check
+        args: --all --manifest-path ${{ inputs.working-directory }}/Cargo.toml -- --check
 
     - name: Run cargo clippy
       uses: actions-rs/cargo@v1

--- a/.github/actions/verify-rust/action.yml
+++ b/.github/actions/verify-rust/action.yml
@@ -1,8 +1,8 @@
 name: Verify Rust
 
 inputs:
-  crate:
-    description: The crate you want to verify
+  working-directory:
+    description: The program directory you're trying to verify
     required: true
 
 runs:
@@ -10,12 +10,14 @@ runs:
   steps:
     - name: Run cargo fmt
       uses: actions-rs/cargo@v1
+      working-directory: ${{ inputs.working-directory }}
       with:
         command: fmt
         args: --all -- --check
 
     - name: Run cargo clippy
       uses: actions-rs/cargo@v1
+      working-directory: ${{ inputs.working-directory }}
       with:
         command: clippy
-        args: -p ${{ inputs.crate }} --all-features --no-deps -- -D warnings
+        args: --all-features --no-deps -- -D warnings

--- a/.github/actions/verify-rust/action.yml
+++ b/.github/actions/verify-rust/action.yml
@@ -1,0 +1,16 @@
+name: Verify Rust
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run cargo fmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+
+    - name: Run cargo clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --no-deps -- -D warnings

--- a/.github/workflows/program-token-metadata.yml
+++ b/.github/workflows/program-token-metadata.yml
@@ -62,6 +62,8 @@ jobs:
 
       # Run format and lint checks
       - uses: ./.github/actions/verify-rust
+        with: 
+          crate: mpl-token-metadata
 
       # Build deps
       - uses: ./.github/actions/build-token-vault

--- a/.github/workflows/program-token-metadata.yml
+++ b/.github/workflows/program-token-metadata.yml
@@ -63,7 +63,7 @@ jobs:
       # Run format and lint checks
       - uses: ./.github/actions/verify-rust
         with: 
-          crate: mpl-token-metadata
+          working-directory: ./token-metadata/program
 
       # Build deps
       - uses: ./.github/actions/build-token-vault

--- a/.github/workflows/program-token-metadata.yml
+++ b/.github/workflows/program-token-metadata.yml
@@ -60,7 +60,7 @@ jobs:
             ${{ env.cache_id }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{
             env.RUSTC_HASH }}
 
-      # Run format and lint checks
+      # Run lint checks
       - uses: ./.github/actions/verify-rust
         with: 
           working-directory: ./token-metadata/program

--- a/.github/workflows/program-token-metadata.yml
+++ b/.github/workflows/program-token-metadata.yml
@@ -60,6 +60,9 @@ jobs:
             ${{ env.cache_id }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{
             env.RUSTC_HASH }}
 
+      # Run format and lint checks
+      - uses: ./.github/actions/verify-rust
+
       # Build deps
       - uses: ./.github/actions/build-token-vault
 

--- a/fixed-price-sale/program/src/processor/create_market.rs
+++ b/fixed-price-sale/program/src/processor/create_market.rs
@@ -73,7 +73,9 @@ impl<'info> CreateMarket<'info> {
 
             let collection_mint = &remaining_accounts[0];
 
-            if collection_mint.key != &gating_data.collection || collection_mint.owner != &spl_token::id() {
+            if collection_mint.key != &gating_data.collection
+                || collection_mint.owner != &spl_token::id()
+            {
                 return Err(ErrorCode::WrongCollectionMintKey.into());
             }
         }

--- a/fixed-price-sale/program/src/processor/create_market.rs
+++ b/fixed-price-sale/program/src/processor/create_market.rs
@@ -73,9 +73,7 @@ impl<'info> CreateMarket<'info> {
 
             let collection_mint = &remaining_accounts[0];
 
-            if collection_mint.key != &gating_data.collection
-                || collection_mint.owner != &spl_token::id()
-            {
+            if collection_mint.key != &gating_data.collection || collection_mint.owner != &spl_token::id() {
                 return Err(ErrorCode::WrongCollectionMintKey.into());
             }
         }

--- a/token-metadata/program/src/assertions/collection.rs
+++ b/token-metadata/program/src/assertions/collection.rs
@@ -11,8 +11,7 @@ pub fn assert_collection_update_is_valid(
     existing: &Option<Collection>,
     incoming: &Option<Collection>,
 ) -> Result<(), ProgramError> {
-    let is_incoming_verified_true =
-        incoming.is_some() && incoming.as_ref().unwrap().verified == true;
+    let is_incoming_verified_true = incoming.is_some() && incoming.as_ref().unwrap().verified;
 
     // If incoming verified is true. Confirm incoming and existing are identical
     let is_incoming_data_valid = !is_incoming_verified_true
@@ -59,10 +58,8 @@ pub fn assert_has_collection_authority(
         if bump_match.bump != bump {
             return Err(MetadataError::InvalidCollectionUpdateAuthority.into());
         }
-    } else {
-        if collection_data.update_authority != *collection_authority_info.key {
-            return Err(MetadataError::InvalidCollectionUpdateAuthority.into());
-        }
+    } else if collection_data.update_authority != *collection_authority_info.key {
+        return Err(MetadataError::InvalidCollectionUpdateAuthority.into());
     }
     Ok(())
 }

--- a/token-metadata/program/src/assertions/uses.rs
+++ b/token-metadata/program/src/assertions/uses.rs
@@ -19,7 +19,7 @@ pub fn assert_valid_use(
             return Err(MetadataError::InvalidUseMethod.into());
         }
     }
-    return match (incoming_use, current_use) {
+    match (incoming_use, current_use) {
         (Some(incoming), Some(current)) => {
             if incoming.use_method != current.use_method && current.total != current.remaining {
                 return Err(MetadataError::CannotChangeUseMethodAfterFirstUse.into());
@@ -33,13 +33,13 @@ pub fn assert_valid_use(
             Ok(())
         }
         _ => Ok(()),
-    };
+    }
 }
 
 pub fn assert_burner(program_as_burner: &Pubkey) -> Result<u8, MetadataError> {
     let (canon_burn, b) = pda::find_program_as_burner_account();
     if &canon_burn != program_as_burner {
-        return Err(MetadataError::DerivedKeyInvalid.into());
+        return Err(MetadataError::DerivedKeyInvalid);
     }
     Ok(b)
 }
@@ -63,11 +63,11 @@ pub fn assert_use_authority_derivation(
     let use_authority_seeds = [
         PREFIX.as_bytes(),
         program_id.as_ref(),
-        &mint_info.key.as_ref(),
+        mint_info.key.as_ref(),
         USER.as_bytes(),
-        &user_info.key.as_ref(),
+        user_info.key.as_ref(),
     ];
-    assert_derivation(&program_id, use_authority_record_info, &use_authority_seeds)
+    assert_derivation(program_id, use_authority_record_info, &use_authority_seeds)
 }
 
 pub fn process_use_authority_validation(
@@ -79,10 +79,8 @@ pub fn process_use_authority_validation(
         if !record_info_empty {
             return Err(MetadataError::UseAuthorityRecordAlreadyExists.into());
         }
-    } else {
-        if record_info_empty {
-            return Err(MetadataError::UseAuthorityRecordAlreadyRevoked.into());
-        }
+    } else if record_info_empty {
+        return Err(MetadataError::UseAuthorityRecordAlreadyRevoked.into());
     }
     Ok(())
 }

--- a/token-metadata/program/src/deprecated_processor.rs
+++ b/token-metadata/program/src/deprecated_processor.rs
@@ -31,7 +31,7 @@ pub fn process_deprecated_create_metadata_accounts<'a>(
     let rent_info = next_account_info(account_info_iter)?;
 
     process_create_metadata_accounts_logic(
-        &program_id,
+        program_id,
         CreateMetadataAccountsLogicArgs {
             metadata_account_info,
             mint_info,

--- a/token-metadata/program/src/deser.rs
+++ b/token-metadata/program/src/deser.rs
@@ -22,11 +22,9 @@ pub fn meta_deser(buf: &mut &[u8]) -> Result<Metadata, borsh::maybestd::io::Erro
     so to increase probability of catching errors If any of these deserializations fail, set all values to None.
     */
     let (token_standard, collection, uses) = match (token_standard_res, collection_res, uses_res) {
-        (Ok(token_standard_res), Ok(collection_res), Ok(uses_res)) => (
-            Some(token_standard_res.unwrap()),
-            Some(collection_res.unwrap()),
-            Some(uses_res.unwrap()),
-        ),
+        (Ok(token_standard_res), Ok(collection_res), Ok(uses_res)) => {
+            (token_standard_res, collection_res, uses_res)
+        }
         _ => {
             msg!("Corrupted metadata discovered: setting values to None");
             (None, None, None)

--- a/token-metadata/program/src/deser.rs
+++ b/token-metadata/program/src/deser.rs
@@ -21,17 +21,17 @@ pub fn meta_deser(buf: &mut &[u8]) -> Result<Metadata, borsh::maybestd::io::Erro
     /* We can have accidentally valid, but corrupted data, particularly on the Collection struct,
     so to increase probability of catching errors If any of these deserializations fail, set all values to None.
     */
-    let (token_standard, collection, uses) =
-        if token_standard_res.is_err() || collection_res.is_err() || uses_res.is_err() {
+    let (token_standard, collection, uses) = match (token_standard_res, collection_res, uses_res) {
+        (Ok(token_standard_res), Ok(collection_res), Ok(uses_res)) => (
+            Some(token_standard_res.unwrap()),
+            Some(collection_res.unwrap()),
+            Some(uses_res.unwrap()),
+        ),
+        _ => {
             msg!("Corrupted metadata discovered: setting values to None");
             (None, None, None)
-        } else {
-            (
-                token_standard_res.unwrap(),
-                collection_res.unwrap(),
-                uses_res.unwrap(),
-            )
-        };
+        }
+    };
 
     let metadata = Metadata {
         key,

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -838,12 +838,16 @@ pub fn verify_collection(
         AccountMeta::new_readonly(collection_master_edition_account, false),
     ];
 
-    if collection_authority_record.is_some() {
-        accounts.push(AccountMeta::new_readonly(
-            collection_authority_record.unwrap(),
-            false,
-        ));
+    match collection_authority_record {
+        Some(collection_authority_record) => {
+            accounts.push(AccountMeta::new_readonly(
+                collection_authority_record,
+                false,
+            ));
+        }
+        None => (),
     }
+
     Instruction {
         program_id,
         accounts,
@@ -881,12 +885,16 @@ pub fn unverify_collection(
         AccountMeta::new_readonly(collection_master_edition_account, false),
     ];
 
-    if collection_authority_record.is_some() {
-        accounts.push(AccountMeta::new_readonly(
-            collection_authority_record.unwrap(),
-            false,
-        ));
+    match collection_authority_record {
+        Some(collection_authority_record) => {
+            accounts.push(AccountMeta::new_readonly(
+                collection_authority_record,
+                false,
+            ));
+        }
+        None => (),
     }
+
     Instruction {
         program_id,
         accounts,
@@ -937,11 +945,18 @@ pub fn utilize(
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
     ];
-    if use_authority_record_pda.is_some() {
-        accounts.push(AccountMeta::new(use_authority_record_pda.unwrap(), false));
+    match use_authority_record_pda {
+        Some(use_authority_record_pda) => {
+            accounts.push(AccountMeta::new(use_authority_record_pda, false));
+        }
+        None => (),
     }
-    if burner.is_some() {
-        accounts.push(AccountMeta::new_readonly(burner.unwrap(), false));
+
+    match burner {
+        Some(burner) => {
+            accounts.push(AccountMeta::new_readonly(burner, false));
+        }
+        None => (),
     }
 
     Instruction {
@@ -1165,12 +1180,16 @@ pub fn set_and_verify_collection(
         AccountMeta::new_readonly(collection_master_edition_account, false),
     ];
 
-    if collection_authority_record.is_some() {
-        accounts.push(AccountMeta::new_readonly(
-            collection_authority_record.unwrap(),
-            false,
-        ));
+    match collection_authority_record {
+        Some(collection_authority_record) => {
+            accounts.push(AccountMeta::new_readonly(
+                collection_authority_record,
+                false,
+            ));
+        }
+        None => (),
     }
+
     Instruction {
         program_id,
         accounts,

--- a/token-metadata/program/src/state.rs
+++ b/token-metadata/program/src/state.rs
@@ -28,7 +28,7 @@ pub const MAX_URI_LENGTH: usize = 200;
 pub const MAX_METADATA_LEN: usize = 1 //key 
 + 32 // update auth pubkey
 + 32 // mint pubkey
-+ MAX_DATA_SIZE 
++ MAX_DATA_SIZE
 + 1 // primary sale
 + 1 // mutable
 + 9 // nonce (pretty sure this only needs to be 2)
@@ -187,7 +187,7 @@ impl UseAuthorityRecord {
     }
 
     pub fn bump_empty(&self) -> bool {
-        return self.bump == 0 && self.key == Key::UseAuthorityRecord;
+        self.bump == 0 && self.key == Key::UseAuthorityRecord
     }
 }
 
@@ -274,11 +274,13 @@ pub fn get_master_edition(account: &AccountInfo) -> Result<Box<dyn MasterEdition
     let version = account.data.borrow()[0];
 
     // For some reason when converting Key to u8 here, it becomes unreachable. Use direct constant instead.
-    match version {
-        2 => return Ok(Box::new(MasterEditionV1::from_account_info(account)?)),
-        6 => return Ok(Box::new(MasterEditionV2::from_account_info(account)?)),
-        _ => return Err(MetadataError::DataTypeMismatch.into()),
+    let master_edition_result: Result<Box<dyn MasterEdition>, ProgramError> = match version {
+        2 => Ok(Box::new(MasterEditionV1::from_account_info(account)?)),
+        6 => Ok(Box::new(MasterEditionV2::from_account_info(account)?)),
+        _ => Err(MetadataError::DataTypeMismatch.into()),
     };
+
+    master_edition_result
 }
 
 #[repr(C)]
@@ -446,11 +448,13 @@ pub fn get_reservation_list(
     let version = account.data.borrow()[0];
 
     // For some reason when converting Key to u8 here, it becomes unreachable. Use direct constant instead.
-    match version {
-        3 => return Ok(Box::new(ReservationListV1::from_account_info(account)?)),
-        5 => return Ok(Box::new(ReservationListV2::from_account_info(account)?)),
-        _ => return Err(MetadataError::DataTypeMismatch.into()),
+    let reservation_list_result: Result<Box<dyn ReservationList>, ProgramError> = match version {
+        3 => Ok(Box::new(ReservationListV1::from_account_info(account)?)),
+        5 => Ok(Box::new(ReservationListV2::from_account_info(account)?)),
+        _ => Err(MetadataError::DataTypeMismatch.into()),
     };
+
+    reservation_list_result
 }
 
 #[repr(C)]
@@ -760,7 +764,7 @@ impl EditionMarker {
     pub fn insert_edition(&mut self, edition: u64) -> ProgramResult {
         let (index, mask) = EditionMarker::get_index_and_mask(edition)?;
         // bitwise or a 1 into our position in that position
-        self.ledger[index] = self.ledger[index] | mask;
+        self.ledger[index] |= mask;
         Ok(())
     }
 }

--- a/token-metadata/program/src/utils_test.rs
+++ b/token-metadata/program/src/utils_test.rs
@@ -21,7 +21,7 @@ mod puff_out_test {
             ),
         ];
         for (s, size, puffed_out) in cases {
-            let result = puffed_out_string(&s.to_string(), *size);
+            let result = puffed_out_string(s, *size);
             assert_eq!(result, puffed_out.to_string(), "s: {:?}, size: {}", s, size,);
         }
     }

--- a/token-metadata/program/tests/bump_seed_migration.rs
+++ b/token-metadata/program/tests/bump_seed_migration.rs
@@ -80,7 +80,7 @@ mod bump_seed_migration {
         let (burner, _) = find_program_as_burner_account();
         let utilize_with_use_authority = mpl_token_metadata::instruction::utilize(
             mpl_token_metadata::id(),
-            test_metadata.pubkey.clone(),
+            test_metadata.pubkey,
             test_metadata.token.pubkey(),
             test_metadata.mint.pubkey(),
             Some(record),

--- a/token-metadata/program/tests/create_master_edition.rs
+++ b/token-metadata/program/tests/create_master_edition.rs
@@ -213,7 +213,7 @@ mod create_master_edition {
 
         let test_master_edition = MasterEditionV2::new(&Metadata {
             mint: fake_mint,
-            pubkey: test_metadata.pubkey.clone(),
+            pubkey: test_metadata.pubkey,
             token: fake_account,
         });
 
@@ -367,7 +367,7 @@ mod create_master_edition {
 
         let test_master_edition = MasterEditionV2::new(&Metadata {
             mint: fake_mint,
-            pubkey: test_metadata.pubkey.clone(),
+            pubkey: test_metadata.pubkey,
             token: fake_account,
         });
 

--- a/token-metadata/program/tests/create_metadata_account.rs
+++ b/token-metadata/program/tests/create_metadata_account.rs
@@ -137,11 +137,11 @@ mod create_meta_accounts {
 
         let ix = instruction::create_metadata_accounts(
             id(),
-            test_metadata.pubkey.clone(),
+            test_metadata.pubkey,
             test_metadata.mint.pubkey(),
             fake_mint_authority.pubkey(),
-            context.payer.pubkey().clone(),
-            context.payer.pubkey().clone(),
+            context.payer.pubkey(),
+            context.payer.pubkey(),
             "Test".to_string(),
             "TST".to_string(),
             "uri".to_string(),
@@ -168,11 +168,11 @@ mod create_meta_accounts {
 
         let ix2 = instruction::create_metadata_accounts_v2(
             id(),
-            test_metadata.pubkey.clone(),
+            test_metadata.pubkey,
             test_metadata.mint.pubkey(),
             fake_mint_authority.pubkey(),
-            context.payer.pubkey().clone(),
-            context.payer.pubkey().clone(),
+            context.payer.pubkey(),
+            context.payer.pubkey(),
             "Test".to_string(),
             "TST".to_string(),
             "uri".to_string(),

--- a/token-metadata/program/tests/create_metadata_account.rs
+++ b/token-metadata/program/tests/create_metadata_account.rs
@@ -46,8 +46,8 @@ mod create_meta_accounts {
         assert_eq!(metadata.data.seller_fee_basis_points, 10);
         assert_eq!(metadata.data.creators, None);
 
-        assert_eq!(metadata.primary_sale_happened, false);
-        assert_eq!(metadata.is_mutable, false);
+        assert!(!metadata.primary_sale_happened);
+        assert!(!metadata.is_mutable);
         assert_eq!(metadata.mint, test_metadata.mint.pubkey());
         assert_eq!(metadata.update_authority, context.payer.pubkey());
         assert_eq!(metadata.key, Key::MetadataV1);
@@ -99,8 +99,8 @@ mod create_meta_accounts {
         assert_eq!(metadata.data.creators, None);
         assert_eq!(metadata.uses, uses.to_owned());
 
-        assert_eq!(metadata.primary_sale_happened, false);
-        assert_eq!(metadata.is_mutable, false);
+        assert!(!metadata.primary_sale_happened);
+        assert!(!metadata.is_mutable);
         assert_eq!(metadata.mint, test_metadata.mint.pubkey());
         assert_eq!(metadata.update_authority, context.payer.pubkey());
         assert_eq!(metadata.key, Key::MetadataV1);

--- a/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -357,14 +357,14 @@ mod mint_new_edition_from_master_edition_via_vault_proxy {
 
         let seeds = &[
             PREFIX.as_bytes(),
-            &vault_pubkey.as_ref(),
-            &token_mint_pubkey.as_ref(),
+            vault_pubkey.as_ref(),
+            token_mint_pubkey.as_ref(),
         ];
         let (_, _) = Pubkey::find_program_address(seeds, &metaplex_token_vault_id);
         let seeds = &[
             PREFIX.as_bytes(),
-            &metaplex_token_vault_id.as_ref(),
-            &vault_pubkey.as_ref(),
+            metaplex_token_vault_id.as_ref(),
+            vault_pubkey.as_ref(),
         ];
         let (authority, _) = Pubkey::find_program_address(seeds, &metaplex_token_vault_id);
         create_token_account(&mut context, &store, &token_mint_pubkey, &authority)

--- a/token-metadata/program/tests/revoke_use_authority.rs
+++ b/token-metadata/program/tests/revoke_use_authority.rs
@@ -105,6 +105,6 @@ mod revoke_use_authority {
             .await
             .expect("account not found");
         println!("{:?}", accountafter);
-        assert_eq!(accountafter.is_none(), true);
+        assert!(accountafter.is_none());
     }
 }

--- a/token-metadata/program/tests/seralization.rs
+++ b/token-metadata/program/tests/seralization.rs
@@ -35,7 +35,7 @@ mod serialization {
 
         let account = get_account(context, &test_metadata.pubkey).await;
         let me_account = get_account(context, &test_master_edition.pubkey).await;
-        return (account.data, me_account.data);
+        (account.data, me_account.data)
     }
     #[tokio::test]
     async fn success() {

--- a/token-metadata/program/tests/sign_metadata.rs
+++ b/token-metadata/program/tests/sign_metadata.rs
@@ -20,7 +20,7 @@ mod sign_metadata {
     async fn success_verify_unverify_creator() {
         let mut context = program_test().start_with_context().await;
         let creator = Keypair::new();
-        let ua_creator = context.payer.pubkey().clone();
+        let ua_creator = context.payer.pubkey();
         let test_meta = Metadata::new();
         test_meta
             .create_v2(

--- a/token-metadata/program/tests/sign_metadata.rs
+++ b/token-metadata/program/tests/sign_metadata.rs
@@ -61,7 +61,7 @@ mod sign_metadata {
             .await
             .unwrap();
         let after_sign = test_meta.get_data(&mut context).await;
-        assert_eq!(after_sign.data.creators.unwrap()[1].verified, true);
+        assert!(after_sign.data.creators.unwrap()[1].verified);
 
         let remove_ix = remove_creator_verification(
             mpl_token_metadata::id(),
@@ -80,6 +80,6 @@ mod sign_metadata {
             .await
             .unwrap();
         let after_remove = test_meta.get_data(&mut context).await;
-        assert_eq!(after_remove.data.creators.unwrap()[1].verified, false);
+        assert!(!after_remove.data.creators.unwrap()[1].verified);
     }
 }

--- a/token-metadata/program/tests/update_metadata_account.rs
+++ b/token-metadata/program/tests/update_metadata_account.rs
@@ -60,8 +60,8 @@ mod update_metadata_account {
         assert_eq!(metadata.data.seller_fee_basis_points, 10);
         assert_eq!(metadata.data.creators, None);
 
-        assert_eq!(metadata.primary_sale_happened, false);
-        assert_eq!(metadata.is_mutable, true);
+        assert!(!metadata.primary_sale_happened);
+        assert!(metadata.is_mutable);
         assert_eq!(metadata.mint, test_metadata.mint.pubkey());
         assert_eq!(metadata.update_authority, context.payer.pubkey());
         assert_eq!(metadata.key, Key::MetadataV1);

--- a/token-metadata/program/tests/update_metadata_account_v2.rs
+++ b/token-metadata/program/tests/update_metadata_account_v2.rs
@@ -193,7 +193,7 @@ mod update_metadata_account_v2 {
             .await
             .unwrap();
 
-        let update_authority = context.payer.pubkey().clone();
+        let update_authority = context.payer.pubkey();
         let (record, _) = find_collection_authority_account(
             &test_collection.mint.pubkey(),
             &new_collection_authority.pubkey(),
@@ -236,7 +236,7 @@ mod update_metadata_account_v2 {
             &[instruction::update_metadata_accounts_v2(
                 id(),
                 test_metadata.pubkey,
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
                 None,
                 Some(DataV2 {
                     name: updated_name,
@@ -349,7 +349,7 @@ mod update_metadata_account_v2 {
             &[instruction::update_metadata_accounts_v2(
                 id(),
                 test_metadata.pubkey,
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
                 None,
                 None,
                 Some(true),
@@ -366,7 +366,7 @@ mod update_metadata_account_v2 {
             &[instruction::update_metadata_accounts_v2(
                 id(),
                 test_metadata.pubkey,
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
                 None,
                 None,
                 Some(false),
@@ -414,7 +414,7 @@ mod update_metadata_account_v2 {
             &[instruction::update_metadata_accounts_v2(
                 id(),
                 test_metadata.pubkey,
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
                 None,
                 None,
                 None,
@@ -482,7 +482,7 @@ mod update_metadata_account_v2 {
             &[instruction::update_metadata_accounts_v2(
                 id(),
                 test_metadata.pubkey,
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
                 None,
                 Some(DataV2 {
                     name: "Test".to_string(),
@@ -559,7 +559,7 @@ mod update_metadata_account_v2 {
             .await
             .unwrap();
 
-        let update_authority = context.payer.pubkey().clone();
+        let update_authority = context.payer.pubkey();
         let (record, _) = find_collection_authority_account(
             &test_collection.mint.pubkey(),
             &new_collection_authority.pubkey(),
@@ -600,7 +600,7 @@ mod update_metadata_account_v2 {
             &[instruction::update_metadata_accounts_v2(
                 id(),
                 test_metadata.pubkey,
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
                 None,
                 Some(DataV2 {
                     name: "Test".to_string(),

--- a/token-metadata/program/tests/update_metadata_account_v2.rs
+++ b/token-metadata/program/tests/update_metadata_account_v2.rs
@@ -75,8 +75,8 @@ mod update_metadata_account_v2 {
         assert_eq!(metadata.data.seller_fee_basis_points, 10);
         assert_eq!(metadata.data.creators, None);
 
-        assert_eq!(metadata.primary_sale_happened, false);
-        assert_eq!(metadata.is_mutable, false);
+        assert!(!metadata.primary_sale_happened);
+        assert!(!metadata.is_mutable);
         assert_eq!(metadata.mint, test_metadata.mint.pubkey());
         assert_eq!(metadata.update_authority, context.payer.pubkey());
         assert_eq!(metadata.key, Key::MetadataV1);
@@ -136,8 +136,8 @@ mod update_metadata_account_v2 {
         assert_eq!(metadata.data.seller_fee_basis_points, 10);
         assert_eq!(metadata.data.creators, None);
 
-        assert_eq!(metadata.primary_sale_happened, false);
-        assert_eq!(metadata.is_mutable, false);
+        assert!(!metadata.primary_sale_happened);
+        assert!(!metadata.is_mutable);
         assert_eq!(metadata.mint, test_metadata.mint.pubkey());
         assert_eq!(metadata.update_authority, context.payer.pubkey());
         assert_eq!(metadata.key, Key::MetadataV1);
@@ -268,8 +268,8 @@ mod update_metadata_account_v2 {
         assert_eq!(metadata.data.seller_fee_basis_points, 10);
         assert_eq!(metadata.data.creators, None);
 
-        assert_eq!(metadata.primary_sale_happened, false);
-        assert_eq!(metadata.is_mutable, false);
+        assert!(!metadata.primary_sale_happened);
+        assert!(!metadata.is_mutable);
         assert_eq!(metadata.mint, test_metadata.mint.pubkey());
         assert_eq!(metadata.update_authority, context.payer.pubkey());
         assert_eq!(metadata.key, Key::MetadataV1);

--- a/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
+++ b/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
@@ -50,8 +50,8 @@ mod update_primary_sale_happened_via_token {
         assert_eq!(metadata.data.seller_fee_basis_points, 10);
         assert_eq!(metadata.data.creators, None);
 
-        assert_eq!(metadata.primary_sale_happened, true);
-        assert_eq!(metadata.is_mutable, false);
+        assert!(metadata.primary_sale_happened);
+        assert!(!metadata.is_mutable,);
         assert_eq!(metadata.mint, test_metadata.mint.pubkey());
         assert_eq!(metadata.update_authority, context.payer.pubkey());
         assert_eq!(metadata.key, Key::MetadataV1);

--- a/token-metadata/program/tests/uses.rs
+++ b/token-metadata/program/tests/uses.rs
@@ -53,7 +53,7 @@ mod uses {
 
         let ix = mpl_token_metadata::instruction::utilize(
             mpl_token_metadata::id(),
-            test_metadata.pubkey.clone(),
+            test_metadata.pubkey,
             test_metadata.token.pubkey(),
             test_metadata.mint.pubkey(),
             None,
@@ -113,7 +113,7 @@ mod uses {
 
         let ix = mpl_token_metadata::instruction::utilize(
             mpl_token_metadata::id(),
-            test_metadata.pubkey.clone(),
+            test_metadata.pubkey,
             test_metadata.token.pubkey(),
             test_metadata.mint.pubkey(),
             None,
@@ -169,7 +169,7 @@ mod uses {
 
         let ix = mpl_token_metadata::instruction::utilize(
             mpl_token_metadata::id(),
-            test_metadata.pubkey.clone(),
+            test_metadata.pubkey,
             test_metadata.token.pubkey(),
             test_metadata.mint.pubkey(),
             None,
@@ -256,7 +256,7 @@ mod uses {
 
         let utilize_with_use_authority = mpl_token_metadata::instruction::utilize(
             mpl_token_metadata::id(),
-            test_metadata.pubkey.clone(),
+            test_metadata.pubkey,
             test_metadata.token.pubkey(),
             test_metadata.mint.pubkey(),
             Some(record),
@@ -342,7 +342,7 @@ mod uses {
 
         let utilize_with_use_authority = mpl_token_metadata::instruction::utilize(
             mpl_token_metadata::id(),
-            test_metadata.pubkey.clone(),
+            test_metadata.pubkey,
             test_metadata.token.pubkey(),
             test_metadata.mint.pubkey(),
             Some(record),
@@ -391,7 +391,7 @@ mod uses {
         context.warp_to_slot(100).unwrap();
         let utilize_with_use_authority_fail = mpl_token_metadata::instruction::utilize(
             mpl_token_metadata::id(),
-            test_metadata.pubkey.clone(),
+            test_metadata.pubkey,
             test_metadata.token.pubkey(),
             test_metadata.mint.pubkey(),
             Some(record),

--- a/token-metadata/program/tests/utils/edition_marker.rs
+++ b/token-metadata/program/tests/utils/edition_marker.rs
@@ -146,7 +146,7 @@ impl EditionMarker {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn create(&self, context: &mut ProgramTestContext) -> transport::Result<()> {
@@ -189,7 +189,7 @@ impl EditionMarker {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn create_with_invalid_token_program(
@@ -248,6 +248,6 @@ impl EditionMarker {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 }

--- a/token-metadata/program/tests/utils/external_price.rs
+++ b/token-metadata/program/tests/utils/external_price.rs
@@ -51,7 +51,7 @@ impl ExternalPrice {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn create(&self, context: &mut ProgramTestContext) -> transport::Result<()> {
@@ -77,6 +77,6 @@ impl ExternalPrice {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 }

--- a/token-metadata/program/tests/utils/external_price.rs
+++ b/token-metadata/program/tests/utils/external_price.rs
@@ -80,3 +80,9 @@ impl ExternalPrice {
         context.banks_client.process_transaction(tx).await
     }
 }
+
+impl Default for ExternalPrice {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/token-metadata/program/tests/utils/master_edition_v2.rs
+++ b/token-metadata/program/tests/utils/master_edition_v2.rs
@@ -41,7 +41,7 @@ impl MasterEditionV2 {
         MasterEditionV2 {
             pubkey,
             metadata_pubkey: metadata.pubkey,
-            mint_pubkey: mint_pubkey,
+            mint_pubkey,
         }
     }
 
@@ -93,7 +93,7 @@ impl MasterEditionV2 {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn create(
@@ -117,7 +117,7 @@ impl MasterEditionV2 {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn create_v3(
@@ -141,6 +141,6 @@ impl MasterEditionV2 {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 }

--- a/token-metadata/program/tests/utils/metadata.rs
+++ b/token-metadata/program/tests/utils/metadata.rs
@@ -329,3 +329,9 @@ impl Metadata {
         context.banks_client.process_transaction(tx).await
     }
 }
+
+impl Default for Metadata {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/token-metadata/program/tests/utils/metadata.rs
+++ b/token-metadata/program/tests/utils/metadata.rs
@@ -72,11 +72,11 @@ impl Metadata {
         let tx = Transaction::new_signed_with_payer(
             &[instruction::create_metadata_accounts(
                 id(),
-                self.pubkey.clone(),
+                self.pubkey,
                 self.mint.pubkey(),
-                context.payer.pubkey().clone(),
-                context.payer.pubkey().clone(),
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
+                context.payer.pubkey(),
+                context.payer.pubkey(),
                 name,
                 symbol,
                 uri,
@@ -90,7 +90,7 @@ impl Metadata {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn create_v2(
@@ -133,11 +133,11 @@ impl Metadata {
         let tx = Transaction::new_signed_with_payer(
             &[instruction::create_metadata_accounts_v2(
                 id(),
-                self.pubkey.clone(),
+                self.pubkey,
                 self.mint.pubkey(),
-                context.payer.pubkey().clone(),
-                context.payer.pubkey().clone(),
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
+                context.payer.pubkey(),
+                context.payer.pubkey(),
                 name,
                 symbol,
                 uri,
@@ -153,7 +153,7 @@ impl Metadata {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn update_primary_sale_happened_via_token(
@@ -172,7 +172,7 @@ impl Metadata {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn update(
@@ -188,7 +188,7 @@ impl Metadata {
             &[instruction::update_metadata_accounts(
                 id(),
                 self.pubkey,
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
                 None,
                 Some(Data {
                     name,
@@ -204,7 +204,7 @@ impl Metadata {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn update_v2(
@@ -223,7 +223,7 @@ impl Metadata {
             &[instruction::update_metadata_accounts_v2(
                 id(),
                 self.pubkey,
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
                 None,
                 Some(DataV2 {
                     name,
@@ -231,8 +231,8 @@ impl Metadata {
                     uri,
                     creators,
                     seller_fee_basis_points,
-                    collection: collection,
-                    uses: uses,
+                    collection,
+                    uses,
                 }),
                 None,
                 Some(is_mutable),
@@ -242,7 +242,7 @@ impl Metadata {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn verify_collection(
@@ -259,18 +259,18 @@ impl Metadata {
                 id(),
                 self.pubkey,
                 collection_authority.pubkey(),
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
                 collection_mint,
                 collection,
                 collection_master_edition_account,
                 collection_authority_record,
             )],
             Some(&context.payer.pubkey()),
-            &[&context.payer, &collection_authority],
+            &[&context.payer, collection_authority],
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn set_and_verify_collection(
@@ -288,7 +288,7 @@ impl Metadata {
                 id(),
                 self.pubkey,
                 collection_authority.pubkey(),
-                context.payer.pubkey().clone(),
+                context.payer.pubkey(),
                 nft_update_authority,
                 collection_mint,
                 collection,
@@ -296,10 +296,10 @@ impl Metadata {
                 collection_authority_record,
             )],
             Some(&context.payer.pubkey()),
-            &[&context.payer, &collection_authority],
+            &[&context.payer, collection_authority],
             context.last_blockhash,
         );
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn unverify_collection(
@@ -322,10 +322,10 @@ impl Metadata {
                 collection_authority_record,
             )],
             Some(&context.payer.pubkey()),
-            &[&context.payer, &collection_authority],
+            &[&context.payer, collection_authority],
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 }

--- a/token-metadata/program/tests/utils/mod.rs
+++ b/token-metadata/program/tests/utils/mod.rs
@@ -24,7 +24,7 @@ use solana_sdk::{
 use spl_token::state::Mint;
 pub use vault::Vault;
 
-pub fn program_test<'a>() -> ProgramTest {
+pub fn program_test() -> ProgramTest {
     ProgramTest::new("mpl_token_metadata", mpl_token_metadata::id(), None)
 }
 

--- a/token-metadata/program/tests/utils/mod.rs
+++ b/token-metadata/program/tests/utils/mod.rs
@@ -114,7 +114,7 @@ pub async fn create_token_account(
             .unwrap(),
         ],
         Some(&context.payer.pubkey()),
-        &[&context.payer, &account],
+        &[&context.payer, account],
         context.last_blockhash,
     );
 
@@ -141,14 +141,14 @@ pub async fn create_mint(
             spl_token::instruction::initialize_mint(
                 &spl_token::id(),
                 &mint.pubkey(),
-                &manager,
+                manager,
                 freeze_authority,
                 0,
             )
             .unwrap(),
         ],
         Some(&context.payer.pubkey()),
-        &[&context.payer, &mint],
+        &[&context.payer, mint],
         context.last_blockhash,
     );
 

--- a/token-metadata/program/tests/utils/vault.rs
+++ b/token-metadata/program/tests/utils/vault.rs
@@ -39,14 +39,14 @@ impl Vault {
 
         let seeds = &[
             PREFIX.as_bytes(),
-            &vault_pubkey.as_ref(),
-            &token_mint_pubkey.as_ref(),
+            vault_pubkey.as_ref(),
+            token_mint_pubkey.as_ref(),
         ];
         let (safety_deposit_box, _) = Pubkey::find_program_address(seeds, &metaplex_token_vault_id);
         let seeds = &[
             PREFIX.as_bytes(),
-            &metaplex_token_vault_id.as_ref(),
-            &vault_pubkey.as_ref(),
+            metaplex_token_vault_id.as_ref(),
+            vault_pubkey.as_ref(),
         ];
         let (authority, _) = Pubkey::find_program_address(seeds, &metaplex_token_vault_id);
         create_token_account(context, &store, &token_mint_pubkey, &authority).await?;
@@ -82,8 +82,8 @@ impl Vault {
 
         let seeds = &[
             PREFIX.as_bytes(),
-            &metaplex_token_vault_id.as_ref(),
-            &vault_pubkey.as_ref(),
+            metaplex_token_vault_id.as_ref(),
+            vault_pubkey.as_ref(),
         ];
         let (authority, _) = Pubkey::find_program_address(seeds, &metaplex_token_vault_id);
 
@@ -102,7 +102,7 @@ impl Vault {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn combine(
@@ -133,8 +133,8 @@ impl Vault {
 
         let seeds = &[
             PREFIX.as_bytes(),
-            &metaplex_token_vault_id.as_ref(),
-            &vault_pubkey.as_ref(),
+            metaplex_token_vault_id.as_ref(),
+            vault_pubkey.as_ref(),
         ];
         let (authority, _) = Pubkey::find_program_address(seeds, &metaplex_token_vault_id);
 
@@ -158,7 +158,7 @@ impl Vault {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 
     pub async fn create(
@@ -171,8 +171,8 @@ impl Vault {
 
         let seeds = &[
             PREFIX.as_bytes(),
-            &metaplex_token_vault_id.as_ref(),
-            &vault_pubkey.as_ref(),
+            metaplex_token_vault_id.as_ref(),
+            vault_pubkey.as_ref(),
         ];
         let (authority, _) = Pubkey::find_program_address(seeds, &metaplex_token_vault_id);
 
@@ -218,6 +218,6 @@ impl Vault {
             context.last_blockhash,
         );
 
-        Ok(context.banks_client.process_transaction(tx).await?)
+        context.banks_client.process_transaction(tx).await
     }
 }

--- a/token-metadata/program/tests/utils/vault.rs
+++ b/token-metadata/program/tests/utils/vault.rs
@@ -221,3 +221,9 @@ impl Vault {
         context.banks_client.process_transaction(tx).await
     }
 }
+
+impl Default for Vault {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/token-metadata/program/tests/verify_collection.rs
+++ b/token-metadata/program/tests/verify_collection.rs
@@ -809,7 +809,7 @@ mod verify_collection {
 
         let metadata = test_metadata.get_data(&mut context).await;
         assert_eq!(metadata.collection.is_none(), true);
-        let update_authority = context.payer.pubkey().clone();
+        let update_authority = context.payer.pubkey();
         let (record, _) = find_collection_authority_account(
             &test_collection.mint.pubkey(),
             &new_collection_authority.pubkey(),

--- a/token-metadata/program/tests/verify_collection.rs
+++ b/token-metadata/program/tests/verify_collection.rs
@@ -97,10 +97,10 @@ mod verify_collection {
             metadata.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata.collection.unwrap().verified, false);
+        assert!(!metadata.collection.unwrap().verified);
 
-        assert_eq!(metadata.primary_sale_happened, false);
-        assert_eq!(metadata.is_mutable, false);
+        assert!(!metadata.primary_sale_happened);
+        assert!(!metadata.is_mutable);
         assert_eq!(metadata.mint, test_metadata.mint.pubkey());
         assert_eq!(metadata.update_authority, context.payer.pubkey());
         assert_eq!(metadata.key, Key::MetadataV1);
@@ -123,7 +123,7 @@ mod verify_collection {
             metadata_after.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata_after.collection.unwrap().verified, true);
+        assert!(metadata_after.collection.unwrap().verified);
     }
 
     #[tokio::test]
@@ -220,10 +220,10 @@ mod verify_collection {
             metadata.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata.collection.unwrap().verified, false);
+        assert!(!metadata.collection.unwrap().verified);
 
-        assert_eq!(metadata.primary_sale_happened, false);
-        assert_eq!(metadata.is_mutable, false);
+        assert!(!metadata.primary_sale_happened);
+        assert!(!metadata.is_mutable);
         assert_eq!(metadata.mint, test_metadata.mint.pubkey());
         assert_eq!(metadata.update_authority, context.payer.pubkey());
         assert_eq!(metadata.key, Key::MetadataV1);
@@ -316,7 +316,7 @@ mod verify_collection {
             metadata_after.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata_after.collection.unwrap().verified, false);
+        assert!(!metadata_after.collection.unwrap().verified);
     }
 
     #[tokio::test]
@@ -392,7 +392,7 @@ mod verify_collection {
             metadata_after.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata_after.collection.unwrap().verified, false);
+        assert!(!metadata_after.collection.unwrap().verified);
     }
 
     #[tokio::test]
@@ -464,7 +464,7 @@ mod verify_collection {
             metadata_after.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata_after.collection.unwrap().verified, false);
+        assert!(!metadata_after.collection.unwrap().verified);
     }
 
     #[tokio::test]
@@ -540,7 +540,7 @@ mod verify_collection {
             metadata_after.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata_after.collection.unwrap().verified, false);
+        assert!(!metadata_after.collection.unwrap().verified);
     }
 
     #[tokio::test]
@@ -615,10 +615,10 @@ mod verify_collection {
             metadata.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata.collection.unwrap().verified, false);
+        assert!(!metadata.collection.unwrap().verified);
 
-        assert_eq!(metadata.primary_sale_happened, false);
-        assert_eq!(metadata.is_mutable, false);
+        assert!(!metadata.primary_sale_happened);
+        assert!(!metadata.is_mutable);
         assert_eq!(metadata.mint, test_metadata.mint.pubkey());
         assert_eq!(metadata.update_authority, context.payer.pubkey());
         assert_eq!(metadata.key, Key::MetadataV1);
@@ -641,7 +641,7 @@ mod verify_collection {
             metadata_after.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata_after.collection.unwrap().verified, true);
+        assert!(metadata_after.collection.unwrap().verified);
     }
 
     #[tokio::test]
@@ -698,7 +698,7 @@ mod verify_collection {
             metadata.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata.collection.unwrap().verified, false);
+        assert!(!metadata.collection.unwrap().verified);
         let (record, _) = find_collection_authority_account(
             &test_collection.mint.pubkey(),
             &new_collection_authority.pubkey(),
@@ -744,7 +744,7 @@ mod verify_collection {
             metadata_after.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata_after.collection.unwrap().verified, true);
+        assert!(metadata_after.collection.unwrap().verified);
 
         test_metadata
             .unverify_collection(
@@ -758,7 +758,7 @@ mod verify_collection {
             .await
             .unwrap();
         let metadata_after_unverify = test_metadata.get_data(&mut context).await;
-        assert_eq!(metadata_after_unverify.collection.unwrap().verified, false);
+        assert!(!metadata_after_unverify.collection.unwrap().verified);
     }
 
     #[tokio::test]
@@ -808,7 +808,7 @@ mod verify_collection {
             .unwrap();
 
         let metadata = test_metadata.get_data(&mut context).await;
-        assert_eq!(metadata.collection.is_none(), true);
+        assert!(metadata.collection.is_none());
         let update_authority = context.payer.pubkey();
         let (record, _) = find_collection_authority_account(
             &test_collection.mint.pubkey(),
@@ -856,7 +856,7 @@ mod verify_collection {
             metadata_after.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata_after.collection.unwrap().verified, true);
+        assert!(metadata_after.collection.unwrap().verified);
 
         test_metadata
             .unverify_collection(
@@ -870,7 +870,7 @@ mod verify_collection {
             .await
             .unwrap();
         let metadata_after_unverify = test_metadata.get_data(&mut context).await;
-        assert_eq!(metadata_after_unverify.collection.unwrap().verified, false);
+        assert!(!metadata_after_unverify.collection.unwrap().verified);
     }
 
     #[tokio::test]
@@ -932,7 +932,7 @@ mod verify_collection {
             metadata.collection.to_owned().unwrap().key,
             test_collection.mint.pubkey()
         );
-        assert_eq!(metadata.collection.unwrap().verified, false);
+        assert!(!metadata.collection.unwrap().verified);
         let (record, _) = find_collection_authority_account(
             &test_collection.mint.pubkey(),
             &new_collection_authority.pubkey(),
@@ -992,7 +992,7 @@ mod verify_collection {
             .await
             .unwrap()
             .is_none();
-        assert_eq!(account_after_none, true);
+        assert!(account_after_none);
 
         let err = test_metadata
             .verify_collection(
@@ -1007,6 +1007,6 @@ mod verify_collection {
             .unwrap_err();
         assert_custom_error!(err, MetadataError::InvalidCollectionUpdateAuthority);
         let metadata_after = test_metadata.get_data(&mut context).await;
-        assert_eq!(metadata_after.collection.unwrap().verified, false);
+        assert!(!metadata_after.collection.unwrap().verified);
     }
 }


### PR DESCRIPTION
This is the start of enforcing proper formatting for all our contracts. We're going to start with `token-metadata` and migrate all the programs one by one. After everything is migrated, the `verify-rust` action will be removed and the logic will be "potentially" moved to the `install-rust` action, this end state is still TBD.