### PR TITLE
refactor(auction-house): remove mpl-testing-utils crate dep

### DIFF
--- a/auction-house/program/Cargo.toml
+++ b/auction-house/program/Cargo.toml
@@ -36,7 +36,7 @@ anchor-client = "~0.24.1"
 shellexpand = "~2.1.0"
 serde_json = "~1.0"
 solana-program = "~1.9.15"
-mpl-testing-utils= {path="../../core/rust/testing-utils", version="0.0.2"}
+mpl-testing-utils= {path="../../core/rust/testing-utils" }
 solana-program-test = "~1.9.15"
 solana-sdk = "~1.9.15"
 env_logger="~0.9.0"


### PR DESCRIPTION
`mpl-testing-utils` v0.0.2 relies on an older version of `token-metadata` so blocks us from publish auction house as a crate. However, it's a dev dependency so isn't actually required for the functional crate stuff. Removing the crate dependency and leaving it as a path means it gets ignored by Cargo when it's published. 