### PR TITLE
Add escrow account per buy offer functionality

### DIFF
--- a/auction-house/program/src/constants.rs
+++ b/auction-house/program/src/constants.rs
@@ -5,3 +5,4 @@ pub const SIGNER: &str = "signer";
 pub const PURCHASE_RECEIPT_PREFIX: &str = "purchase_receipt";
 pub const BID_RECEIPT_PREFIX: &str = "bid_receipt";
 pub const LISTING_RECEIPT_PREFIX: &str = "listing_receipt";
+pub const ESCROW_PREFIX: &str = "escrow";

--- a/auction-house/program/src/pda.rs
+++ b/auction-house/program/src/pda.rs
@@ -37,6 +37,19 @@ pub fn find_auction_house_buyer_escrow_account_address(
     Pubkey::find_program_address(auction_house_buyer_escrow_seeds, &id())
 }
 
+pub fn find_auction_house_buyer_escrow_account_address_dedicated(
+    trade_state_address: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[
+            PREFIX.as_bytes(),
+            ESCROW_PREFIX.as_bytes(),
+            trade_state_address.as_ref(),
+        ],
+        &id(),
+    )
+}
+
 pub fn find_program_as_signer_address() -> (Pubkey, u8) {
     Pubkey::find_program_address(&[PREFIX.as_bytes(), SIGNER.as_bytes()], &id())
 }

--- a/auction-house/program/src/utils.rs
+++ b/auction-house/program/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::{AuctionHouse, ErrorCode, PREFIX};
+use crate::{pda::*, AuctionHouse, ErrorCode, ESCROW_PREFIX, PREFIX};
 use anchor_lang::{
     prelude::*,
     solana_program::{
@@ -583,5 +583,42 @@ pub fn rent_checked_add(escrow_account: AccountInfo, diff: u64) -> Result<u64> {
         Ok(rent_minimum - account_lamports)
     } else {
         Ok(diff)
+    }
+}
+
+pub fn get_escrow_seeds<'a>(
+    escrow_payment_account: &'a Pubkey,
+    escrow_payment_bump_seed: &'a [u8],
+    auction_house: &'a Pubkey,
+    wallet: &'a Pubkey,
+    buyer_trade_state: &'a Pubkey,
+    dedicated_escrow: bool,
+) -> Result<[&'a [u8]; 4]> {
+    if dedicated_escrow {
+        let (expected_escrow_payment_account, _) =
+            find_auction_house_buyer_escrow_account_address_dedicated(&buyer_trade_state);
+        if escrow_payment_account != &expected_escrow_payment_account {
+            Err(ErrorCode::EscrowAccountInvalid.into())
+        } else {
+            Ok([
+                PREFIX.as_bytes(),
+                ESCROW_PREFIX.as_bytes(),
+                buyer_trade_state.as_ref(),
+                escrow_payment_bump_seed,
+            ])
+        }
+    } else {
+        let (expected_escrow_payment_account, _) =
+            find_auction_house_buyer_escrow_account_address(auction_house, wallet);
+        if escrow_payment_account.key() != expected_escrow_payment_account {
+            Err(ErrorCode::EscrowAccountInvalid.into())
+        } else {
+            Ok([
+                PREFIX.as_bytes(),
+                auction_house.as_ref(),
+                wallet.as_ref(),
+                escrow_payment_bump_seed,
+            ])
+        }
     }
 }

--- a/auction-house/program/tests/buy.rs
+++ b/auction-house/program/tests/buy.rs
@@ -2,10 +2,11 @@
 pub mod utils;
 
 use anchor_lang::AccountDeserialize;
-use mpl_auction_house::receipt::BidReceipt;
+use mpl_auction_house::{pda::find_trade_state_address, receipt::BidReceipt};
 use mpl_testing_utils::{solana::airdrop, utils::Metadata};
 use solana_program_test::*;
 use solana_sdk::{signature::Keypair, signer::Signer};
+use spl_associated_token_account::get_associated_token_address;
 use std::assert_eq;
 use utils::setup_functions::*;
 
@@ -18,7 +19,7 @@ async fn buy_success() {
         .unwrap();
     let test_metadata = Metadata::new();
 
-    airdrop(&mut context, &test_metadata.token.pubkey(), 1000000000)
+    airdrop(&mut context, &test_metadata.token.pubkey(), 1_000_000_000)
         .await
         .unwrap();
     test_metadata
@@ -34,60 +35,92 @@ async fn buy_success() {
         .await
         .unwrap();
     let buyer = Keypair::new();
-    airdrop(&mut context, &buyer.pubkey(), 10000000000)
+    airdrop(&mut context, &buyer.pubkey(), 10_000_000_000)
         .await
         .unwrap();
-    let (_, deposit_tx) = deposit(
-        &mut context,
-        &ahkey,
-        &ah,
-        &test_metadata,
-        &buyer,
-        1000000000,
-    );
-    context
-        .banks_client
-        .process_transaction(deposit_tx)
-        .await
-        .unwrap();
-    let ((acc, print_bid_acc), buy_tx) = buy(
-        &mut context,
-        &ahkey,
-        &ah,
-        &test_metadata,
-        &test_metadata.token.pubkey(),
-        &buyer,
-        1000000000,
-    );
-    context
-        .banks_client
-        .process_transaction(buy_tx)
-        .await
-        .unwrap();
-    let bts = context
-        .banks_client
-        .get_account(acc.buyer_trade_state)
-        .await
-        .expect("Error Getting Trade State")
-        .expect("Trade State Empty");
-    assert_eq!(bts.data.len(), 1);
 
-    let bid_receipt_account = context
-        .banks_client
-        .get_account(print_bid_acc.receipt)
-        .await
-        .expect("Error Getting Public Bid Receipt")
-        .expect("Public Bid Empty");
+    for dedicated_escrow in [false, true] {
+        let sale_price = if dedicated_escrow {
+            2_000_000_000
+        } else {
+            1_000_000_000
+        };
 
-    let bid_receipt = BidReceipt::try_deserialize(&mut bid_receipt_account.data.as_ref()).unwrap();
+        let seller_token_account = get_associated_token_address(
+            &test_metadata.token.pubkey(),
+            &test_metadata.mint.pubkey(),
+        );
+        let (trade_state, _) = find_trade_state_address(
+            &buyer.pubkey(),
+            &ahkey,
+            &seller_token_account,
+            &ah.treasury_mint,
+            &test_metadata.mint.pubkey(),
+            sale_price,
+            1,
+        );
 
-    assert_eq!(bid_receipt.price, 1000000000);
-    assert_eq!(bid_receipt.auction_house, acc.auction_house);
-    assert_eq!(bid_receipt.metadata, acc.metadata);
-    assert_eq!(bid_receipt.token_account, Some(acc.token_account));
-    assert_eq!(bid_receipt.buyer, acc.wallet);
-    assert_eq!(bid_receipt.trade_state, acc.buyer_trade_state);
-    assert_eq!(bid_receipt.token_size, 1);
-    assert_eq!(bid_receipt.purchase_receipt, None);
-    assert_eq!(bid_receipt.bookkeeper, buyer.pubkey());
+        let buyer_trade_state = if dedicated_escrow {
+            Some(trade_state)
+        } else {
+            None
+        };
+
+        let (_, deposit_tx) = deposit(
+            &mut context,
+            &ahkey,
+            &ah,
+            &test_metadata,
+            &buyer,
+            sale_price,
+            buyer_trade_state,
+        );
+        context
+            .banks_client
+            .process_transaction(deposit_tx)
+            .await
+            .unwrap();
+        let ((acc, print_bid_acc), buy_tx) = buy(
+            &mut context,
+            &ahkey,
+            &ah,
+            &test_metadata,
+            &test_metadata.token.pubkey(),
+            &buyer,
+            sale_price,
+            dedicated_escrow,
+        );
+        context
+            .banks_client
+            .process_transaction(buy_tx)
+            .await
+            .unwrap();
+        let bts = context
+            .banks_client
+            .get_account(acc.buyer_trade_state)
+            .await
+            .expect("Error Getting Trade State")
+            .expect("Trade State Empty");
+        assert_eq!(bts.data.len(), 1);
+
+        let bid_receipt_account = context
+            .banks_client
+            .get_account(print_bid_acc.receipt)
+            .await
+            .expect("Error Getting Public Bid Receipt")
+            .expect("Public Bid Empty");
+
+        let bid_receipt =
+            BidReceipt::try_deserialize(&mut bid_receipt_account.data.as_ref()).unwrap();
+
+        assert_eq!(bid_receipt.price, sale_price);
+        assert_eq!(bid_receipt.auction_house, acc.auction_house);
+        assert_eq!(bid_receipt.metadata, acc.metadata);
+        assert_eq!(bid_receipt.token_account, Some(acc.token_account));
+        assert_eq!(bid_receipt.buyer, acc.wallet);
+        assert_eq!(bid_receipt.trade_state, acc.buyer_trade_state);
+        assert_eq!(bid_receipt.token_size, 1);
+        assert_eq!(bid_receipt.purchase_receipt, None);
+        assert_eq!(bid_receipt.bookkeeper, buyer.pubkey());
+    }
 }

--- a/auction-house/program/tests/cancel.rs
+++ b/auction-house/program/tests/cancel.rs
@@ -163,6 +163,7 @@ async fn cancel_bid() {
         &test_metadata.token.pubkey(),
         &buyer,
         price,
+        false,
     );
 
     context

--- a/auction-house/program/tests/deposit.rs
+++ b/auction-house/program/tests/deposit.rs
@@ -1,8 +1,10 @@
 #![cfg(feature = "test-bpf")]
 pub mod utils;
+use mpl_auction_house::pda::find_trade_state_address;
 use mpl_testing_utils::{solana::airdrop, utils::Metadata};
 use solana_program_test::*;
 use solana_sdk::{signature::Keypair, signer::Signer};
+use spl_associated_token_account::get_associated_token_address;
 use std::assert_eq;
 use utils::setup_functions::*;
 
@@ -30,28 +32,52 @@ async fn deposit_success() {
         .await
         .unwrap();
     let buyer = Keypair::new();
-    airdrop(&mut context, &buyer.pubkey(), 2000000000)
+    airdrop(&mut context, &buyer.pubkey(), 3_000_000_000)
         .await
         .unwrap();
-    let (acc, deposit_tx) = deposit(
-        &mut context,
-        &ahkey,
-        &ah,
-        &test_metadata,
-        &buyer,
-        1000000000,
-        None,
-    );
-    context
-        .banks_client
-        .process_transaction(deposit_tx)
-        .await
-        .unwrap();
-    let escrow = context
-        .banks_client
-        .get_account(acc.escrow_payment_account)
-        .await
-        .expect("Error Getting Escrow")
-        .expect("Trade State Escrow");
-    assert_eq!(escrow.lamports, 1000890880);
+    for dedicated_escrow in [false, true] {
+        let sale_price = 1_000_000_000;
+        let seller_token_account = get_associated_token_address(
+            &test_metadata.token.pubkey(),
+            &test_metadata.mint.pubkey(),
+        );
+        let (trade_state, _) = find_trade_state_address(
+            &buyer.pubkey(),
+            &ahkey,
+            &seller_token_account,
+            &ah.treasury_mint,
+            &test_metadata.mint.pubkey(),
+            sale_price,
+            1,
+        );
+
+        let buyer_trade_state = if dedicated_escrow {
+            Some(trade_state)
+        } else {
+            None
+        };
+
+        let (acc, deposit_tx) = deposit(
+            &mut context,
+            &ahkey,
+            &ah,
+            &test_metadata,
+            &buyer,
+            sale_price,
+            buyer_trade_state,
+        );
+
+        context
+            .banks_client
+            .process_transaction(deposit_tx)
+            .await
+            .unwrap();
+        let escrow = context
+            .banks_client
+            .get_account(acc.escrow_payment_account)
+            .await
+            .expect("Error Getting Escrow")
+            .expect("Trade State Escrow");
+        assert_eq!(escrow.lamports, sale_price + 890880);
+    }
 }

--- a/auction-house/program/tests/deposit.rs
+++ b/auction-house/program/tests/deposit.rs
@@ -40,6 +40,7 @@ async fn deposit_success() {
         &test_metadata,
         &buyer,
         1000000000,
+        None,
     );
     context
         .banks_client

--- a/auction-house/program/tests/execute_sell.rs
+++ b/auction-house/program/tests/execute_sell.rs
@@ -160,7 +160,7 @@ async fn execute_sale_success() {
             .get_account(buyer_token_account)
             .await
             .unwrap();
-        assert_eq!(buyer_token_before.is_none(), true);
+        assert_eq!(buyer_token_before.is_none(), !dedicated_escrow);
         context.banks_client.process_transaction(tx).await.unwrap();
 
         let seller_after = context
@@ -184,7 +184,7 @@ async fn execute_sale_success() {
             sale_price - ((ah.seller_fee_basis_points as u64 * sale_price) / 10000);
         assert_eq!(seller_before.lamports + fee_minus, seller_after.lamports);
         assert_eq!(seller_before.lamports < seller_after.lamports, true);
-        assert_eq!(buyer_token_after.amount, 1);
+        assert_eq!(buyer_token_after.amount, 1 + dedicated_escrow as u64);
     }
 }
 #[tokio::test]
@@ -456,17 +456,7 @@ async fn execute_sale_wrong_token_account_owner_success() {
         &[&authority],
         context.last_blockhash,
     );
-    let seller_before = context
-        .banks_client
-        .get_account(test_metadata.token.pubkey())
-        .await
-        .unwrap()
-        .unwrap();
-    let buyer_token_before = &context
-        .banks_client
-        .get_account(malicious_buyer_token_account)
-        .await
-        .unwrap();
+
     let err = context
         .banks_client
         .process_transaction(tx)

--- a/token-metadata/program/src/utils.rs
+++ b/token-metadata/program/src/utils.rs
@@ -692,17 +692,17 @@ pub fn spl_token_burn(params: TokenBurnParams<'_, '_>) -> ProgramResult {
 
 /// TokenBurnParams
 pub struct TokenBurnParams<'a: 'b, 'b> {
-    /// mint
+    /// CHECK: mint
     pub mint: AccountInfo<'a>,
-    /// source
+    /// CHECK: source
     pub source: AccountInfo<'a>,
     /// amount
     pub amount: u64,
-    /// authority
+    /// CHECK: authority
     pub authority: AccountInfo<'a>,
     /// authority_signer_seeds
     pub authority_signer_seeds: Option<&'b [&'b [u8]]>,
-    /// token_program
+    /// CHECK: token_program
     pub token_program: AccountInfo<'a>,
 }
 
@@ -736,17 +736,17 @@ pub fn spl_token_mint_to(params: TokenMintToParams<'_, '_>) -> ProgramResult {
 
 /// TokenMintToParams
 pub struct TokenMintToParams<'a: 'b, 'b> {
-    /// mint
+    /// CHECK: mint
     pub mint: AccountInfo<'a>,
-    /// destination
+    /// CHECK: destination
     pub destination: AccountInfo<'a>,
     /// amount
     pub amount: u64,
-    /// authority
+    /// CHECK: authority
     pub authority: AccountInfo<'a>,
     /// authority_signer_seeds
     pub authority_signer_seeds: Option<&'b [&'b [u8]]>,
-    /// token_program
+    /// CHECK: token_program
     pub token_program: AccountInfo<'a>,
 }
 


### PR DESCRIPTION
Adds functionality to support dedicated escrow account for each buy offer:

* Adds [pda::find_auction_house_buyer_escrow_account_address_dedicated](https://github.com/CalebEverett/metaplex-program-library/blob/4c4fddab0e9d6f3604bf6dc98d4696af85b7821c/auction-house/program/src/pda.rs#L40) that uses trade state address in the seeds
* Moves validation of escrow account address and seeds off of the `Accounts` structs to [utils::get_escrow_seeds](https://github.com/CalebEverett/metaplex-program-library/blob/4c4fddab0e9d6f3604bf6dc98d4696af85b7821c/auction-house/program/src/utils.rs#L589) to be able to use the same `Accounts` struct for the original escrow account and the dedicated one
* Adds `dedicated_escrow: bool` argument to [public_bid](https://github.com/CalebEverett/metaplex-program-library/blob/4c4fddab0e9d6f3604bf6dc98d4696af85b7821c/auction-house/program/src/bid/mod.rs#L48), [private_bid](https://github.com/CalebEverett/metaplex-program-library/blob/4c4fddab0e9d6f3604bf6dc98d4696af85b7821c/auction-house/program/src/bid/mod.rs#L113) and [bid_logic](https://github.com/CalebEverett/metaplex-program-library/blob/4c4fddab0e9d6f3604bf6dc98d4696af85b7821c/auction-house/program/src/bid/mod.rs#L146)

* Adds `buyer_trade_state: Option<Pubkey>` to [deposit](https://github.com/CalebEverett/metaplex-program-library/blob/4c4fddab0e9d6f3604bf6dc98d4696af85b7821c/auction-house/program/src/lib.rs#L433) and [withdrawal](https://github.com/CalebEverett/metaplex-program-library/blob/4c4fddab0e9d6f3604bf6dc98d4696af85b7821c/auction-house/program/src/lib.rs#L297)

* Updates [buy](https://github.com/CalebEverett/metaplex-program-library/blob/4c4fddab0e9d6f3604bf6dc98d4696af85b7821c/auction-house/program/tests/buy.rs#L42), [deposit](https://github.com/CalebEverett/metaplex-program-library/blob/4c4fddab0e9d6f3604bf6dc98d4696af85b7821c/auction-house/program/tests/deposit.rs#L38) and [execute_sell](https://github.com/CalebEverett/metaplex-program-library/blob/4c4fddab0e9d6f3604bf6dc98d4696af85b7821c/auction-house/program/tests/execute_sell.rs#L52) tests to include both the original and dedicated escrow accounts


