### PR TITLE
bump spl-token version

### DIFF
--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -19,7 +19,7 @@ arrayref = "~0.3.6"
 num-traits = "~0.2"
 solana-program = "~1.9.15"
 mpl-token-vault = { version = "~0.1.0", features = [ "no-entrypoint" ] }
-spl-token = { version="~3.2.0", features = [ "no-entrypoint" ] }
+spl-token = { version="~3.3.0", features = [ "no-entrypoint" ] }
 spl-associated-token-account = { version = "~1.0.3", features = ["no-entrypoint"] }
 thiserror = "~1.0"
 borsh = "~0.9.2"


### PR DESCRIPTION
Was getting problems with conflicting versions in another package, so bumped this.