### PR TITLE
Minimize forward bias in `get_config_line`.

### DIFF
--- a/candy-machine/program/src/lib.rs
+++ b/candy-machine/program/src/lib.rs
@@ -1418,10 +1418,10 @@ pub fn get_config_line<'info>(
     let mut arr = a_info.data.borrow_mut();
 
     let (mut index_to_use, good) =
-        get_good_index(&mut arr, a.data.items_available as usize, index, true)?;
+        get_good_index(&mut arr, a.data.items_available as usize, index, index % 2 == 0)?;
     if !good {
         let (index_to_use_new, good_new) =
-            get_good_index(&mut arr, a.data.items_available as usize, index, false)?;
+            get_good_index(&mut arr, a.data.items_available as usize, index, index % 2 != 0)?;
         index_to_use = index_to_use_new;
         if !good_new {
             return Err(ErrorCode::CannotFindUsableConfigLine.into());


### PR DESCRIPTION
`get_config_line` calls `get_good_index` to find a free mint index.

Because of the way it handles wrap around (by failing a forward search, then doing a backward search), it biases the distribution of the mint towards latter config lines.

This leads to a situation where the earlier config lines aren't used until the mint gets close to exhausting the supply.

An example of this phenomenon can be seen in the Reptilian Renegades mint:

https://moonrank.app/collection/reptilian_renegades

When sorted by latest to earliest mint time.

The problem is especially pronounced in this mint as all the rare pieces were loaded at early indexes.

This change attempts to minimize the forward bias by alternating forward/backward searches.