### PR TITLE
token-metadata: Remove tilde in dependencies to fix future package resolving

### DIFF
--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -14,22 +14,22 @@ test-bpf = []
 serde-feature = ["serde", "serde_with"]
 
 [dependencies]
-num-derive = "~0.3"
-arrayref = "~0.3.6"
-num-traits = "~0.2"
-solana-program = "~1.10.19"
-mpl-token-vault = { version = "~0.1.0", features = [ "no-entrypoint" ] }
-spl-token = { version="~3.3.0", features = [ "no-entrypoint" ] }
-spl-associated-token-account = { version = "~1.0.5", features = ["no-entrypoint"] }
-thiserror = "~1.0"
-borsh = "~0.9.2"
-shank = { version = "~0.0.2" }
-serde = { version = "~1.0.136", optional = true }
-serde_with = { version = "~1.12.0", optional = true }
+num-derive = "0.3"
+arrayref = "0.3.6"
+num-traits = "0.2"
+solana-program = "1.9.13"
+mpl-token-vault = { version = "0.1.0", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.3.0", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "1.0.5", features = ["no-entrypoint"] }
+thiserror = "1.0"
+borsh = "0.9.2"
+shank = { version = "0.0.2" }
+serde = { version = "1.0.136", optional = true }
+serde_with = { version = "1.12.0", optional = true }
 
 [dev-dependencies]
-solana-sdk = "~1.10.19"
-solana-program-test = "~1.10.19"
+solana-sdk = "1.9.13"
+solana-program-test = "1.9.13"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-vault/program/Cargo.toml
+++ b/token-vault/program/Cargo.toml
@@ -12,13 +12,13 @@ no-entrypoint = []
 test-bpf = []
 
 [dependencies]
-num-derive = "~0.3"
-num-traits = "~0.2"
-solana-program = "~1.9.15"
-spl-token = { version="~3.2.0", features = [ "no-entrypoint" ] }
-shank="~0.0.2"
-thiserror = "~1.0"
-borsh = "~0.9.1"
+num-derive = "0.3"
+num-traits = "0.2"
+solana-program = "1.9.13"
+spl-token = { version = "3.2.0", features = [ "no-entrypoint" ] }
+shank = "0.0.2"
+thiserror = "1.0"
+borsh = "0.9.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
#### Problem

`anchor-spl` depends on both `metaplex-token-metadata` and `spl-token`, and `metaplex-token-metadata` depends on `spl-token`, but both have specified dependencies with a `~`, meaning that only patch version bumps are allowed by the Cargo resolver, and not minor version bumps.

The Solana CI used to build Anchor and Metaplex to check for downstream breakage, but because of Anchor's metaplex dependency, it's impossible to select a viable package of `spl-token` when building Anchor, since the Solana crates use version `3.3`, but metaplex-token-metadata only allows `3.2`.

Currently, Anchor can't upgrade because of its dependency on token-metadata.

#### Solution

Since `metaplex-token-metadata` is used by many other programs, it will be much more usable to relax the version requirements to the default on the Cargo resolver, which allows minor version bumps, except for 0.* packages, where it only allows patch version bumps.  The SPL programs all use this mode for their dependencies. 

Let me know if you have any questions!