### PR TITLE
token-vault: Remove tilde in dependencies to fix future package resolving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,7 +2091,7 @@ version = "1.2.10"
 dependencies = [
  "arrayref",
  "borsh 0.9.3",
- "mpl-token-vault 0.1.0",
+ "mpl-token-vault 0.1.1",
  "num-derive",
  "num-traits",
  "shank",

--- a/token-metadata/Cargo.lock
+++ b/token-metadata/Cargo.lock
@@ -1508,13 +1508,12 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-vault"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ade4ef15bc06a6033076c4ff28cba9b42521df5ec61211d6f419415ace2746a"
+version = "0.1.1"
 dependencies = [
  "borsh",
  "num-derive",
  "num-traits",
+ "shank",
  "solana-program",
  "spl-token",
  "thiserror",

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -18,7 +18,7 @@ num-derive = "~0.3"
 arrayref = "~0.3.6"
 num-traits = "~0.2"
 solana-program = "~1.9.15"
-mpl-token-vault = { version = "~0.1.0", features = [ "no-entrypoint" ] }
+mpl-token-vault = { version = "0.1.0", path = "../../token-vault/program", features = [ "no-entrypoint" ] }
 spl-token = { version="~3.2.0", features = [ "no-entrypoint" ] }
 spl-associated-token-account = { version = "~1.0.3", features = ["no-entrypoint"] }
 thiserror = "~1.0"

--- a/token-vault/program/Cargo.toml
+++ b/token-vault/program/Cargo.toml
@@ -12,13 +12,13 @@ no-entrypoint = []
 test-bpf = []
 
 [dependencies]
-num-derive = "~0.3"
-num-traits = "~0.2"
-solana-program = "~1.9.15"
-spl-token = { version="~3.2.0", features = [ "no-entrypoint" ] }
-shank="~0.0.2"
-thiserror = "~1.0"
-borsh = "~0.9.1"
+num-derive = "0.3"
+num-traits = "0.2"
+solana-program = "1.9.15"
+spl-token = { version="3.2.0", features = [ "no-entrypoint" ] }
+shank="0.0.2"
+thiserror = "1.0"
+borsh = "0.9.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
#### Problem

This is a continuation of #481 to allow for easier updates for downstream dependencies, specifically for token-vault, which is a dependency of token-metadata.

It's impossible to update spl-token in downstream crates because of the tilde dependency resolution here.

#### Solution

Get rid of the tilde when specifying version numbers, and have `token-metadata` use the local `token-vault` for builds.  There's more info about why this is useful in #481 .  Feel free to ask any questions!