### PR TITLE
build: add verfiable builds via anchor and uploads to S3

### DIFF
--- a/.github/actions/anchor-build/action.yaml
+++ b/.github/actions/anchor-build/action.yaml
@@ -1,0 +1,12 @@
+name: 'Anchor Publish'
+description: 'Perform a verifiable build for a Solana program in a given directory'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/install-anchor/
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+    - run: ~/.cargo/bin/anchor build --verifiable
+      shell: bash

--- a/.github/actions/build-and-publish/action.yaml
+++ b/.github/actions/build-and-publish/action.yaml
@@ -1,0 +1,84 @@
+name: 'Build program and upload output to S3'
+description: 'Uploads verifiable build output and metadata to S3'
+inputs:
+  program-binary:
+    description: 'Program binary to upload'
+    required: true
+  name:
+    description: 'The file name that will be exist in S3'
+    required: true
+  account-id:
+    description: 'AWS account ID'
+    required: true
+  region:
+    description: 'AWS region'
+    required: true
+  role:
+    description: 'AWS role with permissions to perform desired action'
+    required: true
+  bucket:
+    description: 'S3 bucket to which file will upload'
+    required: true
+  prefix:
+    description: 'Prefix in the bucket to which the file will upload'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+    - uses: ./.github/actions/anchor-build/
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ inputs.program-binary }}
+        # this is referencing the workspace since upload-artifact does not respect relative the working-directory
+        path: target/verifiable/${{ inputs.program-binary }}
+        if-no-files-found: error
+
+    # todo: parse toml for version and use that in S3 prefix
+    - name: Upload binary to S3
+      uses: ./.github/actions/upload-to-s3/
+      id: upload-binary
+      with:
+        # should be at root of workspace, which is where target/ dir is
+        path-to-file: ${{ inputs.program-binary }}
+        name: ${{ inputs.program-binary }}
+        account-id: ${{ inputs.account-id }}
+        region: ${{ inputs.region }}
+        role: ${{ inputs.role }}
+        bucket: ${{ inputs.bucket }}
+        prefix: ${{ inputs.prefix }}/${{ github.event.head_commit.id }}
+
+    # dump commit context to index.json & upload that
+    - name: Dump context to metadata
+      run: |
+        echo "$(cat <<-END
+            {
+                "binary_path": "${{ steps.upload-binary.outputs.uploaded-file-path }}",
+                "id": "${{ github.event.head_commit.id }}",
+                "url": "${{ github.event.head_commit.url }}",
+                "timestamp": "${{ github.event.head_commit.timestamp }}"
+            }
+        END
+        )" > ~/program-binary-context.json
+      shell: bash
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: program-binary-context.json
+        path: ~/program-binary-context.json
+        if-no-files-found: error
+
+    - name: Upload binary metadata to S3
+      uses: ./.github/actions/upload-to-s3/
+      id: upload-binary-metadata
+      with:
+        path-to-file: program-binary-context.json
+        name: index.json
+        account-id: ${{ inputs.account-id }}
+        region: ${{ inputs.region }}
+        role: ${{ inputs.role }}
+        bucket: ${{ inputs.bucket }}
+        prefix: ${{ inputs.prefix }}

--- a/.github/actions/install-anchor/action.yml
+++ b/.github/actions/install-anchor/action.yml
@@ -1,15 +1,11 @@
-name: Setup Anchor cli
+name: Setup Anchor CLI
+description: 'Setup Anchor VLI'
 
-inputs:
-  anchor_git:
-    description: Link to Anchor cli GH repository
-    required: true
-  
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - uses: actions/cache@v2
-      name: Cache Cargo registry + index
+      name: Cache Anchor CLI
       id: cache-anchor
       with:
         path: |
@@ -18,10 +14,9 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           ./target/
-        key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
-    - run: cargo install --git ${{inputs.anchor_git}} anchor-cli --locked --force
+        key: anchor-cli-${{ runner.os }}-v0000-${{ env.ANCHOR_VERSION }}
+    - run:
+        cargo install --git https://github.com/project-serum/anchor --tag "v$ANCHOR_VERSION"
+        anchor-cli --locked
       shell: bash
-    - uses: actions/upload-artifact@v2
-      with:
-        name: anchor-binary
-        path: ~/.cargo/bin/anchor
+      if: steps.cache-anchor-cli.outputs.cache-hit != 'true'

--- a/.github/actions/upload-to-s3/action.yaml
+++ b/.github/actions/upload-to-s3/action.yaml
@@ -1,0 +1,72 @@
+name: 'Upload File to S3'
+description: 'Uploads a file to S3 bucket with a specific prefix'
+inputs:
+  path-to-file:
+    description: 'Path to the file to upload'
+    required: true
+  name:
+    description: 'The file name that will be exist in S3'
+    required: true
+  account-id:
+    description: 'AWS account ID'
+    required: true
+  region:
+    description: 'AWS region'
+    required: true
+  role:
+    description: 'AWS role with permissions to perform desired action'
+    required: true
+  bucket:
+    description: 'S3 bucket to which file will upload'
+    required: true
+  prefix:
+    description: 'Prefix in the bucket to which the file will upload'
+    required: true
+
+outputs:
+  uploaded-file-path:
+    description: Path of the uploaded file
+    value: ${{ steps.set-output-for-uploaded-file.outputs.uploaded-file-path }}
+
+permissions:
+  id-token: write
+  contents: read
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: arn:aws:iam::${{ inputs.account-id }}:role/${{ inputs.role }}
+        # not strictly required since s3 buckets are global, but this is the pattern I noticed other places
+        aws-region: ${{ inputs.region }}
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: ${{ inputs.path-to-file }}
+        path: .
+
+    - name: Upload file to S3
+      run: aws s3 cp $FILE_PATH s3://$BUCKET/$PREFIX/$NAME
+      shell: bash
+      env:
+        BUCKET: ${{ inputs.bucket }}
+        PREFIX: ${{ inputs.prefix }}
+        NAME: ${{ inputs.name }}
+        FILE_PATH: ${{ inputs.path-to-file }}
+
+    - name: Set output path to uploaded file
+      id: set-output-for-uploaded-file
+      run:
+        echo "::set-output name=uploaded-file-path::https://$BUCKET.s3.amazonaws.com/$PREFIX/$NAME"
+      shell: bash
+      env:
+        BUCKET: ${{ inputs.bucket }}
+        PREFIX: ${{ inputs.prefix }}
+        NAME: ${{ inputs.name }}
+        FILE_PATH: ${{ inputs.path-to-file }}


### PR DESCRIPTION
### Context
* We want to store binaries related for programs at specific points in time. These changes will allow us to add workflows that build a program via anchor and upload that output + metadata to AWS S3.
* When including the `build-and-upload` action, 
  * we will save the output of `anchor build --verifiable` to bucket at `<bucket-name>/program-name/commit-sha/program-name.so`.
  * we will save a file called `index.json` with some basic metadata at `<bucket-name>/program-name/index.json`. Right now, this will contain the commit URL, ID, timestamp, and a URL to the most recent binary uploaded to the bucket for that program.
* These changes use the [OpenID Connect model](https://github.blog/changelog/2021-10-27-github-actions-secure-cloud-deployments-with-openid-connect) to connect GH with AWS, as opposed to the normal access + secret keys model. The infra changes to enable this are in a separate PR.

### What is added here
* Separate ctions to build a program via `anchor build --verifiable`, upload any file to S3, and a higher level action to combine those 2 things
* Updated the install Anchor CLI action

### How do we use this?
In any workflow, we simply have to add these few lines:

```
- name: Build and upload
  uses: ./.github/actions/build-and-upload/
  id: upload-binary-metadata
  with:
    program-binary: <PROGRAM_BINARY_NAME>
    account-id: <ACCOUNT_ID>
    region: <REGION>
    role: <ROLE>
    bucket: <BUCKET>
    prefix: <BUCKET_PREFIX>
```