### PR TITLE
bugfix: AuctioneerReclaimIndex could be 0 but data is required

### DIFF
--- a/metaplex/js/src/transactions/RedeemBid.ts
+++ b/metaplex/js/src/transactions/RedeemBid.ts
@@ -97,7 +97,7 @@ export class RedeemBid extends Transaction {
       auctioneerReclaimIndex,
     } = params;
 
-    const data = auctioneerReclaimIndex
+    const data = auctioneerReclaimIndex !== undefined
       ? RedeemUnusedWinningConfigItemsAsAuctioneerArgs.serialize({
           winningConfigItemIndex: auctioneerReclaimIndex,
           proxyCall: ProxyCallAddress.RedeemBid,


### PR DESCRIPTION
If an auctioneer trying to reclaim a specific winning index, the index could be 0