### PR TITLE
[CM] [Specs] Assert Minter is the Owner of the NFT 

### DIFF
--- a/candy-machine/program/tests/core/helpers.rs
+++ b/candy-machine/program/tests/core/helpers.rs
@@ -305,7 +305,7 @@ pub async fn prepare_nft(context: &mut ProgramTestContext, minter: &Keypair) -> 
         context,
         &nft_info.mint.pubkey(),
         minter,
-        vec![(nft_info.token, 1)],
+        vec![(minter.pubkey(), 1)],
     )
     .await
     .unwrap();


### PR DESCRIPTION
### Issue
The spec for mint NFT success of CM was assigning ownership of the NFT to the nft_info.token instead of the payer for the mint.

### Changes
- Add assertion to mint_nft test for the owner of the NFT being the payer.
- Fix prepare_nft helper method to assign ownership to the minter.

### Before Change

```
[2022-05-31T16:21:31.605867000Z DEBUG solana_rbpf::vm] BPF instructions executed (interp): 22881
[2022-05-31T16:21:31.605876000Z DEBUG solana_rbpf::vm] Max frame depth reached: 13
[2022-05-31T16:21:31.605883000Z DEBUG solana_runtime::message_processor::stable_log] Program cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ consumed 51385 of 1231572 compute units
[2022-05-31T16:21:31.605937000Z DEBUG solana_runtime::message_processor::stable_log] Program cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ success
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', tests/core/helpers.rs:42:51
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
FAILED

failures:

failures:
    init_default_success

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.75s

error: test failed, to rerun pass '--test initialize'
```