### PR TITLE
fix: don't rely on explicit export of TransactionCtorFields type

### DIFF
--- a/auction/js/src/transactions/CancelBid.ts
+++ b/auction/js/src/transactions/CancelBid.ts
@@ -12,7 +12,6 @@ import {
   SystemProgram,
   SYSVAR_CLOCK_PUBKEY,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import { AuctionProgram } from '../AuctionProgram';
@@ -41,7 +40,7 @@ type CancelBidParams = {
 };
 
 export class CancelBid extends Transaction {
-  constructor(options: TransactionCtorFields, params: CancelBidParams) {
+  constructor(options: ConstructorParameters<typeof Transaction>[0], params: CancelBidParams) {
     super(options);
     const {
       auction,

--- a/auction/js/src/transactions/CreateAuction.ts
+++ b/auction/js/src/transactions/CreateAuction.ts
@@ -10,7 +10,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import BN from 'bn.js';
@@ -98,7 +97,7 @@ type CreateAuctionParams = {
 };
 
 export class CreateAuction extends Transaction {
-  constructor(options: TransactionCtorFields, params: CreateAuctionParams) {
+  constructor(options: ConstructorParameters<typeof Transaction>[0], params: CreateAuctionParams) {
     super(options);
     const { args, auction, auctionExtended, creator } = params;
 

--- a/auction/js/src/transactions/CreateAuctionV2.ts
+++ b/auction/js/src/transactions/CreateAuctionV2.ts
@@ -10,7 +10,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import BN from 'bn.js';
@@ -77,7 +76,10 @@ type CreateAuctionV2Params = {
 };
 
 export class CreateAuctionV2 extends Transaction {
-  constructor(options: TransactionCtorFields, params: CreateAuctionV2Params) {
+  constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: CreateAuctionV2Params,
+  ) {
     super(options);
     const { args, auction, auctionExtended, creator } = params;
 

--- a/auction/js/src/transactions/PlaceBid.ts
+++ b/auction/js/src/transactions/PlaceBid.ts
@@ -12,7 +12,6 @@ import {
   SystemProgram,
   SYSVAR_CLOCK_PUBKEY,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import { AuctionProgram } from '../AuctionProgram';
@@ -47,7 +46,7 @@ type PlaceBidParams = {
 };
 
 export class PlaceBid extends Transaction {
-  constructor(options: TransactionCtorFields, params: PlaceBidParams) {
+  constructor(options: ConstructorParameters<typeof Transaction>[0], params: PlaceBidParams) {
     super(options);
     const { feePayer } = options;
     assert(feePayer != null, 'feePayer expected');

--- a/auction/js/src/transactions/SetAuctionAuthority.ts
+++ b/auction/js/src/transactions/SetAuctionAuthority.ts
@@ -6,7 +6,7 @@
  * that would be a wasted effort and therefore we make an EXCEPTION here.
  */
 import { Borsh, Transaction } from '@metaplex-foundation/mpl-core';
-import { PublicKey, TransactionCtorFields, TransactionInstruction } from '@solana/web3.js';
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { AuctionProgram } from '../AuctionProgram';
 
 export class SetAuctionAuthorityArgs extends Borsh.Data {
@@ -23,7 +23,7 @@ type SetAuctionAuthorityParams = {
 };
 
 export class SetAuctionAuthority extends Transaction {
-  constructor(options: TransactionCtorFields, params: SetAuctionAuthorityParams) {
+  constructor(options: ConstructorParameters<typeof Transaction>[0], params: SetAuctionAuthorityParams) {
     super(options);
     const { auction, currentAuthority, newAuthority } = params;
 

--- a/core/js/src/Transaction.ts
+++ b/core/js/src/Transaction.ts
@@ -1,11 +1,11 @@
-import { Transaction as SolanaTransaction, TransactionCtorFields } from '@solana/web3.js';
+import { Transaction as SolanaTransaction } from '@solana/web3.js';
 
 export class Transaction extends SolanaTransaction {
-  constructor(options?: TransactionCtorFields) {
+  constructor(options?: ConstructorParameters<typeof Transaction>[0]) {
     super(options);
   }
 
-  static fromCombined(transactions: Transaction[], options: TransactionCtorFields = {}) {
+  static fromCombined(transactions: Transaction[], options: ConstructorParameters<typeof Transaction>[0] = {}) {
     const combinedTransaction = new Transaction(options);
     transactions.forEach((transaction) =>
       transaction.instructions.forEach((instruction) => {

--- a/fixed-price-sale/js/test/actions/createMintAccount.ts
+++ b/fixed-price-sale/js/test/actions/createMintAccount.ts
@@ -2,14 +2,7 @@ import { strict as assert } from 'assert';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore createInitializeMintInstruction export actually exist but isn't setup correctly
 import { createInitializeMintInstruction, MintLayout, TOKEN_PROGRAM_ID } from '@solana/spl-token';
-import {
-  Connection,
-  Keypair,
-  PublicKey,
-  SystemProgram,
-  Transaction,
-  TransactionCtorFields,
-} from '@solana/web3.js';
+import { Connection, Keypair, PublicKey, SystemProgram, Transaction } from '@solana/web3.js';
 
 type CreateMintParams = {
   newAccountPubkey: PublicKey;
@@ -23,7 +16,10 @@ type CreateMintParams = {
  * Transaction that is used to create a mint.
  */
 export class CreateMint extends Transaction {
-  private constructor(options: TransactionCtorFields, params: CreateMintParams) {
+  private constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: CreateMintParams,
+  ) {
     const { feePayer } = options;
     assert(feePayer != null, 'need to provide non-null feePayer');
 

--- a/metaplex/js/src/transactions/ClaimBid.ts
+++ b/metaplex/js/src/transactions/ClaimBid.ts
@@ -9,12 +9,7 @@ import { Borsh, Transaction } from '@metaplex-foundation/mpl-core';
 import { ParamsWithStore } from './vault';
 import { AuctionProgram } from '@metaplex-foundation/mpl-auction';
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
-import {
-  PublicKey,
-  SYSVAR_CLOCK_PUBKEY,
-  TransactionCtorFields,
-  TransactionInstruction,
-} from '@solana/web3.js';
+import { PublicKey, SYSVAR_CLOCK_PUBKEY, TransactionInstruction } from '@solana/web3.js';
 import { MetaplexProgram } from '../MetaplexProgram';
 
 export class ClaimBidArgs extends Borsh.Data {
@@ -37,7 +32,10 @@ type ClaimBidParams = {
 };
 
 export class ClaimBid extends Transaction {
-  constructor(options: TransactionCtorFields, params: ParamsWithStore<ClaimBidParams>) {
+  constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: ParamsWithStore<ClaimBidParams>,
+  ) {
     super(options);
     const {
       store,

--- a/metaplex/js/src/transactions/EndAuction.ts
+++ b/metaplex/js/src/transactions/EndAuction.ts
@@ -7,12 +7,7 @@
  */
 import BN from 'bn.js';
 import { Borsh, Transaction } from '@metaplex-foundation/mpl-core';
-import {
-  PublicKey,
-  SYSVAR_CLOCK_PUBKEY,
-  TransactionCtorFields,
-  TransactionInstruction,
-} from '@solana/web3.js';
+import { PublicKey, SYSVAR_CLOCK_PUBKEY, TransactionInstruction } from '@solana/web3.js';
 import { ParamsWithStore } from './vault';
 import { AuctionProgram } from '@metaplex-foundation/mpl-auction';
 import { MetaplexProgram } from '../MetaplexProgram';
@@ -37,7 +32,10 @@ type EndAuctionParams = {
 };
 
 export class EndAuction extends Transaction {
-  constructor(options: TransactionCtorFields, params: ParamsWithStore<EndAuctionParams>) {
+  constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: ParamsWithStore<EndAuctionParams>,
+  ) {
     super(options);
     const {
       store,

--- a/metaplex/js/src/transactions/InitAuctionManagerV2.ts
+++ b/metaplex/js/src/transactions/InitAuctionManagerV2.ts
@@ -11,7 +11,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import BN from 'bn.js';
@@ -50,7 +49,10 @@ type InitAuctionManagerV2Params = {
 };
 
 export class InitAuctionManagerV2 extends Transaction {
-  constructor(options: TransactionCtorFields, params: ParamsWithStore<InitAuctionManagerV2Params>) {
+  constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: ParamsWithStore<InitAuctionManagerV2Params>,
+  ) {
     super(options);
     const { feePayer } = options;
     assert(feePayer != null, 'need to provide feePayer account');

--- a/metaplex/js/src/transactions/RedeemBid.ts
+++ b/metaplex/js/src/transactions/RedeemBid.ts
@@ -11,7 +11,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import { MetadataProgram } from '@metaplex-foundation/mpl-token-metadata';
@@ -71,7 +70,10 @@ type RedeemBidParams = {
 };
 
 export class RedeemBid extends Transaction {
-  constructor(options: TransactionCtorFields, params: ParamsWithStore<RedeemBidParams>) {
+  constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: ParamsWithStore<RedeemBidParams>,
+  ) {
     super(options);
     const { feePayer } = options;
     assert(feePayer != null, 'need to provide feePayer account');

--- a/metaplex/js/src/transactions/RedeemFullRightsTransferBid.ts
+++ b/metaplex/js/src/transactions/RedeemFullRightsTransferBid.ts
@@ -12,7 +12,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import { MetadataProgram } from '@metaplex-foundation/mpl-token-metadata';
@@ -50,7 +49,7 @@ type RedeemFullRightsTransferBidParams = {
 
 export class RedeemFullRightsTransferBid extends Transaction {
   constructor(
-    options: TransactionCtorFields,
+    options: ConstructorParameters<typeof Transaction>[0],
     params: ParamsWithStore<RedeemFullRightsTransferBidParams>,
   ) {
     super(options);

--- a/metaplex/js/src/transactions/RedeemParticipationBidV3.ts
+++ b/metaplex/js/src/transactions/RedeemParticipationBidV3.ts
@@ -14,7 +14,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import BN from 'bn.js';
@@ -58,7 +57,7 @@ type RedeemParticipationBidV3Params = {
 
 export class RedeemParticipationBidV3 extends Transaction {
   constructor(
-    options: TransactionCtorFields,
+    options: ConstructorParameters<typeof Transaction>[0],
     params: ParamsWithStore<RedeemParticipationBidV3Params>,
   ) {
     super(options);

--- a/metaplex/js/src/transactions/RedeemPrintingV2Bid.ts
+++ b/metaplex/js/src/transactions/RedeemPrintingV2Bid.ts
@@ -14,7 +14,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import BN from 'bn.js';
@@ -57,7 +56,10 @@ type RedeemPrintingV2BidParams = {
 };
 
 export class RedeemPrintingV2Bid extends Transaction {
-  constructor(options: TransactionCtorFields, params: ParamsWithStore<RedeemPrintingV2BidParams>) {
+  constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: ParamsWithStore<RedeemPrintingV2BidParams>,
+  ) {
     super(options);
     const { feePayer } = options;
     assert(feePayer != null, 'need to provide feePayer');

--- a/metaplex/js/src/transactions/SetStore.ts
+++ b/metaplex/js/src/transactions/SetStore.ts
@@ -12,7 +12,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 
@@ -38,7 +37,10 @@ type SetStoreParams = {
 };
 
 export class SetStore extends Transaction {
-  constructor(options: TransactionCtorFields, params: ParamsWithStore<SetStoreParams>) {
+  constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: ParamsWithStore<SetStoreParams>,
+  ) {
     super(options);
     const { feePayer } = options;
     assert(feePayer != null, 'need to provide feePayer');

--- a/metaplex/js/src/transactions/SetStoreV2.ts
+++ b/metaplex/js/src/transactions/SetStoreV2.ts
@@ -11,7 +11,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import { Borsh, Transaction } from '@metaplex-foundation/mpl-core';
@@ -41,7 +40,10 @@ type SetStoreV2Params = {
 };
 
 export class SetStoreV2 extends Transaction {
-  constructor(options: TransactionCtorFields, params: ParamsWithStore<SetStoreV2Params>) {
+  constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: ParamsWithStore<SetStoreV2Params>,
+  ) {
     super(options);
     const { feePayer } = options;
     assert(feePayer != null, 'need to provide feePayer');

--- a/metaplex/js/src/transactions/SetWhitelistedCreator.ts
+++ b/metaplex/js/src/transactions/SetWhitelistedCreator.ts
@@ -12,7 +12,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import { MetaplexProgram } from '../MetaplexProgram';
@@ -37,7 +36,7 @@ type SetWhitelistedCreatorParams = {
 
 export class SetWhitelistedCreator extends Transaction {
   constructor(
-    options: TransactionCtorFields,
+    options: ConstructorParameters<typeof Transaction>[0],
     params: ParamsWithStore<SetWhitelistedCreatorParams>,
   ) {
     super(options);

--- a/metaplex/js/src/transactions/StartAuction.ts
+++ b/metaplex/js/src/transactions/StartAuction.ts
@@ -6,12 +6,7 @@
  * that would be a wasted effort and therefore we make an EXCEPTION here.
  */
 import { Borsh, Transaction } from '@metaplex-foundation/mpl-core';
-import {
-  PublicKey,
-  SYSVAR_CLOCK_PUBKEY,
-  TransactionCtorFields,
-  TransactionInstruction,
-} from '@solana/web3.js';
+import { PublicKey, SYSVAR_CLOCK_PUBKEY, TransactionInstruction } from '@solana/web3.js';
 import { AuctionProgram } from '@metaplex-foundation/mpl-auction';
 import { MetaplexProgram } from '../MetaplexProgram';
 import { ParamsWithStore } from './vault';
@@ -30,7 +25,10 @@ type StartAuctionParams = {
 };
 
 export class StartAuction extends Transaction {
-  constructor(options: TransactionCtorFields, params: ParamsWithStore<StartAuctionParams>) {
+  constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: ParamsWithStore<StartAuctionParams>,
+  ) {
     super(options);
     const { store, auction, auctionManager, auctionManagerAuthority } = params;
 

--- a/metaplex/js/src/transactions/ValidateSafetyDepositBoxV2.ts
+++ b/metaplex/js/src/transactions/ValidateSafetyDepositBoxV2.ts
@@ -13,7 +13,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import { MetaplexProgram } from '../MetaplexProgram';
@@ -54,7 +53,7 @@ type ValidateSafetyDepositBoxV2Params = {
 
 export class ValidateSafetyDepositBoxV2 extends Transaction {
   constructor(
-    options: TransactionCtorFields,
+    options: ConstructorParameters<typeof Transaction>[0],
     params: ParamsWithStore<ValidateSafetyDepositBoxV2Params>,
   ) {
     super(options);

--- a/metaplex/js/test/utils.ts
+++ b/metaplex/js/test/utils.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Keypair, PublicKey, TransactionCtorFields } from '@solana/web3.js';
+import { Keypair, PublicKey } from '@solana/web3.js';
 import { tmpdir } from 'os';
 import { readFileSync } from 'fs';
 import { LOCALHOST } from '@metaplex-foundation/amman';
@@ -89,7 +89,7 @@ export const VAULT_EXTENRNAL_PRICE_ACCOUNT = new PublicKey(
   '58S2MNcuS79ncBc5xi1T8jdS98jcXJbXqM5UvGvgmwcr',
 );
 
-export const mockTransaction: TransactionCtorFields = {
+export const mockTransaction: ConstructorParameters<typeof Transaction>[0] = {
   feePayer: new PublicKey('7J6QvJGCB22vDvYB33ikrWCXRBRsFY74ntAArSK4KJUn'),
   recentBlockhash: RECENT_ISH_BLOCKHASH,
 };


### PR DESCRIPTION
This is our bad. We:

1. Over-export fundamentally private types from @solana/web3.js _just_ so that TypeDoc can generate documentation for them. This has to stop.
2. Didn't stop to think that someone might have imported those types for use.

In this PR I replace the recently-renamed `TransactionCtorFields` type with a type that _derives_ it, for all current and future versions of web3.js. This will not break again, no matter how many times the parameter gets renamed.

Fixes: https://github.com/metaplex-foundation/js/issues/202