### PR TITLE
switches types so idel gen happens with no issue

### DIFF
--- a/.github/workflows/program-fixed-price-sale.yml
+++ b/.github/workflows/program-fixed-price-sale.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.14
+  SOLANA_VERSION: 1.9.22
   RUST_TOOLCHAIN: stable
 
 jobs:

--- a/.github/workflows/program-fixed-price-sale.yml
+++ b/.github/workflows/program-fixed-price-sale.yml
@@ -10,7 +10,6 @@ env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.22
   RUST_TOOLCHAIN: stable
-
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3064,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994e8a8e9aed70ebbce13783ee0b4645dd3d47fe9cd308fd31e528fe595d08b3"
+checksum = "9a7760e28434b32eeaabd2fb57688d2a6d7bd58de2bde82607f57162ecbbb1c7"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -3087,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861c1d66c733e1def5abca45808413a46202000bd10f3c9c5338ee565fdd5d75"
+checksum = "9508c839fd7cce94b21678ad28a6529cec2ea08acaa3514554ad99b564eed2f9"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3107,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a627212fee048b6b85a893501a520246dea31f214f88721d356994162d7142b"
+checksum = "b02cda34ec70e84a9cf6636d8a2529531fb8cca75d31e6ebf0947662f7ee9b12"
 dependencies = [
  "borsh 0.9.3",
  "futures",
@@ -3124,9 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa72b2a1b8ab9967de005beb43cdf4ba73838be249c2a92c3dedcef6ffa101e2"
+checksum = "a2fac396ff86d7c8b5a3d086c4884c9b365440857933f6557114cc5d640eb4f9"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -3135,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d83ef0c37f6a836368bacb9d29ed952aae1d2c129af737b2b3ab6bec11746e9"
+checksum = "9c9fc996ae6c27db5af34b8144102ea2e6efbdd973c201fc08a917550ef74e50"
 dependencies = [
  "bincode",
  "futures",
@@ -3153,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e41b4f3c405805f247cb497960e49eee78796b1e0afc3a769c33813e37076f6d"
+checksum = "3d16ac280328dabe13f77fc15be1e8e3c719a01ae90309e9f31df6dc24011af2"
 dependencies = [
  "bv",
  "fnv",
@@ -3172,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e61d54414024e3f372b0f7b003e29f33a4a5f8949a35d081b23567db3fa813"
+checksum = "2fb1e3df53df7bacecd261c0cdf0b1c6f4a84a724a1312d216ca3ee796c119b8"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3190,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881def5f751dc2d3949a6953bbcd749a031f1161f2c73b93320800b755492f13"
+checksum = "6a97c11377eb1059d3fdddd02ad0fe0c480434f1df812f6b5d16ae7087af44a0"
 dependencies = [
  "fs_extra",
  "log",
@@ -3207,9 +3207,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90307da8720cda2547c170ff0e56b2e4e3d9cc6309b81e2267219ad3091f652a"
+checksum = "0ec52a2bede69e10bb0583a55cce3945ab39c76415cc673069cbb2d2a60ee0ba"
 dependencies = [
  "chrono",
  "clap",
@@ -3225,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab00fb123209bf9139bd18cd73ae3d1437b07c6183b67d087b2a80f8e10c8a8"
+checksum = "76c1cdf42c00a375d8353ce013bc96697f45a2cee0c5473aec0c7ce5ff38478e"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -3239,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afba0a31bd0e10cc61a410267b7884338b14559b04afd855081484f74c4c6f"
+checksum = "ba6d0e50ba77919abd70de4bc935749a5d6dea4490e212f5f5959d827fc2d43e"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -3273,9 +3273,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f52cfd9f51573d9e974a2f6f91418cc745ec6d43a90d90b2fd095f66578888a"
+checksum = "fe51d03e2899e00b8c32c6bd9930fc105be88b04243aa2d398b9825c9b09f34b"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -3283,9 +3283,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137c7c8c532b94ac8ee8643d3369e47ad26a4823c96ecce7a76dc85cb4006331"
+checksum = "416632936e7ac85e3a24925299e8c8ebc89ed190e090348e99a7158fb84551ff"
 dependencies = [
  "bincode",
  "chrono",
@@ -3297,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0aecd46d09d30e7e6b2cc430d613981da4805547d925db94536e553d763cdf3"
+checksum = "2ec717a20cd39a67b7e5ad2990be23c28eb08cb1dd40ee1591538420171d353e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3320,9 +3320,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a9783aac947e789852cbd6f4650521f8f6f744cba5fc0524a8bc104fa11e01"
+checksum = "e30fc7f860ff75b2916735189534c5353db8d84953af7842f8dd9a6982dbcaaf"
 dependencies = [
  "bs58 0.4.0",
  "bv",
@@ -3340,9 +3340,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32ebf882f69105e64e283966d9ce0dd22696aec8b8de9bb6b61ea26c7fc896a"
+checksum = "a5e0c0121908ff5df45308b11eef48f696876064884d6aa12b70424dae7459d6"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -3352,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8b0587f360598ef3a9444e05dce63e701a5c008c54101f54707b5f5852ec09"
+checksum = "bbd76a790f207ea9b523fb051c9d446e424e2e0b9fd539bb76c3ea797abf8ea5"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -3363,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9dac70ec308d0ad9d83750efbb5802b11e65e6de1def5b3b76095648926fdd9"
+checksum = "405913a0367af42c58b34266d04cd8d3653f07e7ad95015e598aebdd84066169"
 dependencies = [
  "log",
  "solana-sdk",
@@ -3373,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7689beb2716b7f97fb4b4fc0a25b379e838bf62dd8cb19df89e5249d961b3c"
+checksum = "2c4fd520d3360d0e8c90930da09512c5e896754c66faa05763b0ca516bf6a28c"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -3387,9 +3387,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b07c8b932aa1ad1d20a1848e25851d9539123a58466af20ea9c93de6ace8f06"
+checksum = "ca9ca350c274800cef7043bca93134c85dd615d7be4aebd5fab6ec9475ddfbe1"
 dependencies = [
  "bincode",
  "clap",
@@ -3408,9 +3408,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b003f4a58c425723db0c6d6feed1390b7a47680b942a3816a3986bc11c3cbac1"
+checksum = "6b922eca19a4d76a7181b1c72da6ea96a8bf0e4b36476155aa6cb826db0b8280"
 dependencies = [
  "ahash",
  "bincode",
@@ -3437,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252118d7b708b0bec7e1ec5aeb3397843c8d9dbe8946f04fcebed06c5d3a32c7"
+checksum = "64c86be9edb9a0cb3fc44f776c6bef21d19bc5f69b0f83b3999d0d9d103e1c61"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -3480,9 +3480,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ba8080c1313b7d25c0b2299ce2f7b72acc5fecd54140bb5bac9238774ce338"
+checksum = "63b54e692cc189e105f30875b2ac4279da1ffccef8fb138e55e7339a94c1e9e5"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -3504,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d6ed01012cad0e5ce26a9d5ebd40fc6380704fade5c28974cca4171526e78f"
+checksum = "e4342cdd61b179a74df61f9055b4e870959966a2207f50e9584d60f9c43b74a4"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3528,9 +3528,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ed16e34600bd6a5e62587fb83d4bfb6a555315b031d699bc7ddbc36cc4ebc0"
+checksum = "c481ccd3319d37ebe6ba72c8b097247c8387912f8615702daf58919c0f86a2f9"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -3538,9 +3538,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca9d86e5f80874fc445fcc33c62d7a3cbf39eff34cc736c2b0875cce0e50c2"
+checksum = "26069e2c4c679817db11a1598f9bc400c273632f9e353449ee02bba125d6a3b7"
 dependencies = [
  "base32",
  "console",
@@ -3559,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf609aa4bc1486e7e9b1a83991df204f2977504da8651d9a2ee22ed1ce4969c"
+checksum = "18bbc5aee342aeb48d03600b07b7908090376a8a66ecd6d0d2195818273cb088"
 dependencies = [
  "arrayref",
  "bincode",
@@ -3614,9 +3614,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4232f83293b76b7eddf1e7886a6a645177a1d1cf72ccd1f4d3b7f4f3d683119d"
+checksum = "d1dc0a8e4f1dede7f0f91879a67459723e30c39018c34a1fdc30da2c4cd292fa"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -3665,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6340ca326c8a919575e594a3ca71a380c233ae2615f62acd15c7af4f2aafb21d"
+checksum = "17d66726cf3324c91601f047d34b7f9d9bf26982775f0f673655bb55df00ec87"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2 1.0.36",
@@ -3678,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383387972d3310039c27235fb276164ff9e59ffc040dcd2459bec38261f64f91"
+checksum = "bdee500d68920df86128854a52816afd59d137ed5d4c59979d6fa6b36ef670dd"
 dependencies = [
  "log",
  "solana-logger",
@@ -3691,9 +3691,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aee1faad18563bc529e83e0c0391082d2c6f342aecff402a0a56e5ee5f1c158"
+checksum = "af6311ce5695dbc1a6cdcbffb13f1f3a0b2ccfd08442352cb487d7bf52c99b17"
 dependencies = [
  "bincode",
  "log",
@@ -3714,9 +3714,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26a8016fae6036700dc71ab4abc7934b20958b404be3f47bd97e3dc33cd74ca"
+checksum = "2b284ee14652a807ca6e4546257688bad2e771ea0f81ce31bc9e4d3757513ea6"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -3741,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2c8b104f3acf8fd646e8a788cfcca9190a7de59c3b94c580a137acf4c849d"
+checksum = "5126f48ec74bef527b640b17843e35d7fbe89de9592d4b1afda94b08ae18540a"
 dependencies = [
  "log",
  "rustc_version",
@@ -3756,9 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.9.15"
+version = "1.9.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9075f07f9c381bb91f5f3e0d48355e51a672e1b00685031ce394de87c14df37"
+checksum = "554d67ee6ef9b559fe14d339baec35cf465ecc0f47bbd2622a03a0169c00b0eb"
 dependencies = [
  "bincode",
  "log",
@@ -4076,10 +4076,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "b9d0183f6f6001549ab68f8c7585093bb732beefbcf6d23a10b9b95c73a1dd49"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-fixed-price-sale"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anchor-client 0.22.1",
  "anchor-lang 0.22.1",

--- a/fixed-price-sale/js/package.json
+++ b/fixed-price-sale/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaplex-foundation/mpl-fixed-price-sale",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "MPL Fixed Price Sale JavaScript API.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/fixed-price-sale/js/test/transactions/buy.ts
+++ b/fixed-price-sale/js/test/transactions/buy.ts
@@ -93,7 +93,7 @@ export const createBuyTransaction = async ({
 
   const tx = new Transaction();
   tx.add(instruction);
-  tx.recentBlockhash = (await connection.getRecentBlockhash()).blockhash;
+  tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
   tx.feePayer = buyer;
 
   return { tx };

--- a/fixed-price-sale/program/Cargo.toml
+++ b/fixed-price-sale/program/Cargo.toml
@@ -24,7 +24,7 @@ mpl-token-metadata = { features = [ "no-entrypoint" ], version="~1.1.0" }
 
 [dev-dependencies]
 anchor-client = "~0.22"
-solana-program-test = "~1.9.5"
-solana-program = "~1.9.5"
-solana-sdk = "~1.9.5"
+solana-program-test = "~1.9.28"
+solana-program = "~1.9.28"
+solana-sdk = "~1.9.28"
 spl-associated-token-account = "~1.0.3"

--- a/fixed-price-sale/program/Cargo.toml
+++ b/fixed-price-sale/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpl-fixed-price-sale"
-version = "0.2.0"
+version = "0.2.1"
 description = "Created with Anchor"
 edition = "2018"
 license = "AGPL-3.0"

--- a/fixed-price-sale/program/src/processor/save_primary_metadata_creators.rs
+++ b/fixed-price-sale/program/src/processor/save_primary_metadata_creators.rs
@@ -1,5 +1,6 @@
 use crate::{error::ErrorCode, utils::*, SavePrimaryMetadataCreators};
 use anchor_lang::prelude::*;
+use crate::state::{Creator, from_mpl_creators};
 
 impl<'info> SavePrimaryMetadataCreators<'info> {
     pub fn process(
@@ -30,7 +31,7 @@ impl<'info> SavePrimaryMetadataCreators<'info> {
 
         assert_keys_equal(metadata_state.update_authority, *admin.key)?;
 
-        secondary_metadata_creators.creators = creators;
+        secondary_metadata_creators.creators = from_mpl_creators(creators);
 
         Ok(())
     }

--- a/fixed-price-sale/program/src/processor/withdraw.rs
+++ b/fixed-price-sale/program/src/processor/withdraw.rs
@@ -9,6 +9,7 @@ use anchor_spl::{
     associated_token::{self, get_associated_token_address},
     token,
 };
+use crate::state::from_mpl_creators;
 
 impl<'info> Withdraw<'info> {
     pub fn process(
@@ -72,7 +73,7 @@ impl<'info> Withdraw<'info> {
             )?;
             Box::new(Some(primary_metadata_creators.creators))
         } else {
-            Box::new(metadata.data.creators)
+            Box::new(metadata.data.creators.map(from_mpl_creators))
         };
 
         // Check, that funder is `Creator` or `Market` owner

--- a/fixed-price-sale/program/src/state.rs
+++ b/fixed-price-sale/program/src/state.rs
@@ -2,6 +2,7 @@
 
 use crate::utils::{DESCRIPTION_DEFAULT_SIZE, MAX_PRIMARY_CREATORS_LEN, NAME_DEFAULT_SIZE};
 use anchor_lang::prelude::*;
+use borsh::{BorshDeserialize, BorshSerialize};
 
 // by system acc I mean account to hold only native SOL
 pub const MINIMUM_BALANCE_FOR_SYSTEM_ACCS: u64 = 890880;
@@ -115,10 +116,30 @@ impl TradeHistory {
     pub const LEN: usize = 8 + 32 + 32 + 8;
 }
 
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone)]
+pub struct Creator {
+    pub address: Pubkey,
+    pub verified: bool,
+    // In percentages, NOT basis points ;) Watch out!
+    pub share: u8,
+}
+
 #[account]
 pub struct PrimaryMetadataCreators {
-    pub creators: Vec<mpl_token_metadata::state::Creator>,
+    pub creators: Vec<Creator>,
 }
+
+pub fn from_mpl_creators(creators: Vec<mpl_token_metadata::state::Creator>) -> Vec<Creator> {
+    creators.iter().map(|e| {
+        Creator {
+            address: e.address,
+            share: e.share,
+            verified: e.verified,
+        }
+    })
+        .collect()
+}
+
 
 impl PrimaryMetadataCreators {
     pub const LEN: usize = 8 + ((32 + 1 + 1) * MAX_PRIMARY_CREATORS_LEN + 1);


### PR DESCRIPTION
# Problem
The imported creators type from token metadata has no anchor serialize, or account trait impl and this stops it from getting proper treatment from the idl generator.

# Solution
create a new type that gets saved in the runtime that can be properly idl'ed