### PR TITLE
Add auto-publishing to NPM and crate registry based on PR comment

### DIFF
--- a/.github/actions/fetch-pr-labels/action.yaml
+++ b/.github/actions/fetch-pr-labels/action.yaml
@@ -1,0 +1,43 @@
+name: 'Fetch PR labels'
+description: 'Fetch all label names assigned to a PR'
+inputs:
+  pull-number:
+    description: 'Pull request number'
+    required: true
+
+outputs:
+  labels:
+    description: Label names
+    value: ${{ steps.set-output.outputs.labels }}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+    - name: Parse PR data for label names
+      uses: actions/github-script@v4
+      id: fetch-labels
+      with:
+        script: |
+          const request = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: ${{ inputs.pull-number }}
+          }
+          core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+          try {
+            const { data } = await github.pulls.get(request)
+            core.info(`Got PR data: ${JSON.stringify(data)}`)
+            const labels = data.labels.length > 0 ? data.labels.map((label) => label.name) : []
+            core.info(`Found ${labels.length} labels: ${labels}`)
+            return labels
+          } catch (err) {
+            core.setFailed(`Request failed with error ${err}`)
+          }
+
+    - name: Set labels as output
+      id: set-output
+      run: echo "::set-output name=labels::$LABELS"
+      shell: bash
+      env:
+        LABELS: ${{steps.fetch-labels.outputs.result}}

--- a/.github/actions/map-labels-to-version/action.yaml
+++ b/.github/actions/map-labels-to-version/action.yaml
@@ -1,0 +1,43 @@
+name: 'Map labels to version'
+description: 'Map labels assigned to a PR to a specific semvar version for package updates'
+inputs:
+  pull-number:
+    description: 'Pull request number'
+    required: true
+
+outputs:
+  version:
+    description: Semvar version
+    value: ${{ steps.set-version-output.outputs.version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+
+    - name: Fetch PR labels
+      uses: ./.github/actions/fetch-pr-labels
+      id: fetch-pr-labels
+      with:
+        pull-number: ${{ inputs.pull-number }}
+
+    - name: Map labels to version
+      uses: actions/github-script@v4
+      id: parse-labels-for-version
+      with:
+        script: |
+          const isOfType = (lbls, v) => lbls.filter(l => l.toLowerCase() === v).length > 0
+          const labels = ${{ steps.fetch-pr-labels.outputs.labels }}
+          if (labels.length > 0) {
+            if (isOfType(labels, "version:major")) return 'major'
+            if (isOfType(labels, "version:minor")) return 'minor'
+            if (isOfType(labels, "version:patch")) return 'patch'
+          }
+          return 'none'
+
+    - name: Set output path to uploaded file
+      id: set-version-output
+      run: echo "::set-output name=version::$VERSION"
+      shell: bash
+      env:
+        VERSION: ${{ steps.parse-labels-for-version.outputs.result }}

--- a/.github/actions/map-pr-review-to-version/action.yaml
+++ b/.github/actions/map-pr-review-to-version/action.yaml
@@ -1,0 +1,30 @@
+name: 'Map PR review comments to version'
+description:
+  'Map the last comment associated with a package upgrade to the specific semvar version update -
+  patch, minor, or major'
+inputs:
+  pull-number:
+    description: 'Pull request number'
+    required: true
+
+outputs:
+  version:
+    description: Version
+    value: ${{ steps.set-version.outputs.version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+    - name: Map review comments to version
+      uses: actions/github-script@v4
+      with:
+        script: |
+          const script = require('.github/actions/map-pr-review-to-version/script.js')
+          await script({github, context, core}, ${{ inputs.pull-number }})
+
+    - name: Set version
+      id: set-version
+      # env.REVIEW_VERSION exported from script.js
+      run: echo "::set-output name=version::'${{ env.REVIEW_VERSION }}'"
+      shell: bash

--- a/.github/actions/map-pr-review-to-version/script.js
+++ b/.github/actions/map-pr-review-to-version/script.js
@@ -1,0 +1,129 @@
+// https://github.com/octokit/octokit.graphql.net/blob/master/Octokit.GraphQL/Model/CommentAuthorAssociation.cs
+const VALID_AUTHOR_ASSOCIATIONS = ['owner', 'member', 'contributor'];
+const VALID_REVIEW_STATES = ['approved', 'commented'];
+const VERSIONING_REGEX = /^(patch|minor|major)$/g;
+
+/**
+ * Search reviews for first instance with a semvar version command.
+ * Reviews are expected to be in reverse chronological order.
+ *
+ * @param {reviews} list A list of review objects returned from the `listReviews` API
+ * @return {string} The semvar version for the review
+ */
+const findFirstReviewWithVersion = (reviews) => {
+  let version = 'none';
+  for (const review of reviews) {
+    if (!isValidReview(review)) continue;
+    const reviewVersion = getVersionFromReview(review);
+    if (reviewVersion) {
+      // update version and break, we found the most recent version comment
+      version = reviewVersion;
+      break;
+    }
+  }
+
+  return version;
+};
+
+/**
+ * Filters the review body for version update based on `VERSIONING_REGEX`. Returns the last found instance,
+ * otherwise null.
+ *
+ * @param {review} obj A review obj returned from the `listReviews` API
+ * @return {string} The semvar version for the review
+ */
+const getVersionFromReview = (review) => {
+  const body = review.body
+    .toLowerCase()
+    .split('\n')
+    .filter((t) => t.length > 0);
+
+  const versionCommentsInBody = body.filter((c) => VERSIONING_REGEX.test(c.trim()));
+
+  // return empty list or last matching version comment
+  return versionCommentsInBody.length === 0
+    ? null
+    : versionCommentsInBody[versionCommentsInBody.length - 1];
+};
+
+/**
+ * Returns true if a review matches heuristics for a valid review. Otherwise, false.
+ *
+ * @param {review} obj A review obj returned from the `listReviews` API
+ * @return {boolean} Indication of whether or not this review is valid
+ */
+const isValidReview = (review) => {
+  const author_association = review.author_association.toLowerCase();
+  const state = review.state.toLowerCase();
+
+  if (!VALID_AUTHOR_ASSOCIATIONS.includes(author_association)) return false;
+  if (!VALID_REVIEW_STATES.includes(state)) return false;
+  return true;
+};
+
+/**
+ * Returns all reviews for a given PR in reverse chronological order.
+ * The function will iterate through pages to fetch all reviews,
+ * with a default of 100 reviews per page.
+ *
+ * @param {github} obj An @actions/github object
+ * @param {owner} string The owners of the repository
+ * @param {repo} string The name of the repository
+ * @param {pull_number} n The numeric pull requests ID.
+ * @param {per_page} n The page size for a given GET request.
+ * @return {reviews} The list of reviews associated with this PR
+ */
+fetchPullRequestReviewsDesc = async (github, owner, repo, pull_number, per_page = 100) => {
+  console.log(`Getting PR #${pull_number} from ${owner}/${repo}`);
+  let page = 0;
+  let reviews = []; // string[]
+
+  while (true) {
+    const { data } = await github.pulls.listReviews({
+      owner,
+      repo,
+      pull_number,
+      direction: 'asc',
+      per_page,
+      page,
+    });
+
+    if (data.length === 0) break;
+    reviews = [
+      ...reviews,
+      ...data.map((r) => {
+        return {
+          author_association: r.author_association,
+          state: r.state,
+          body: r.body,
+        };
+      }),
+    ];
+
+    console.log(`Fetched reviews page: ${page}`);
+    page += 1;
+  }
+
+  console.log(`Fetched ${reviews.length} reviews for PR ${pull_number}`);
+  return reviews.length === 0 ? [] : reviews.reverse();
+};
+
+/**
+ * Returns all reviews for a given PR. The function will iterate through pages to fetch all reviews, with a default of 100 reviews per page.
+ *
+ * @param {github} obj An @actions/github object
+ * @param {core} obj An @actions/core object
+ * @param {pull_number} n The numeric pull request ID
+ * @return void
+ */
+module.exports = async ({ github, context, core }, pull_number) => {
+  const reviews = await fetchPullRequestReviewsDesc(
+    github,
+    context.repo.owner,
+    context.repo.repo,
+    pull_number,
+  );
+  const version = findFirstReviewWithVersion(reviews);
+  // force js to recognize this as a quoted string for subsequent consumers
+  core.exportVariable('REVIEW_VERSION', version);
+};

--- a/.github/actions/publish-to-crates/action.yaml
+++ b/.github/actions/publish-to-crates/action.yaml
@@ -1,0 +1,97 @@
+# required permissions:
+#   id-token: write for writing to github
+#   contents: write for updating package contents
+
+name: 'Publish to updated package artifacts'
+description: 'Publish to Crates registry and push updates to Github'
+inputs:
+  # cannot load token directly in action, so we need to pass it in
+  cargo-token:
+    description: 'Cargo token for authenticated requests'
+    required: true
+  # cannot load token directly in action, so we need to pass it in
+  github-token:
+    description: 'Github token for authenticated requests'
+    required: true
+  package-name:
+    description: 'Package name to update'
+    required: true
+  path-to-cargo:
+    description: "Path to the package to update's Cargo.toml"
+    required: true
+  pull-number:
+    description: 'Pull request numeric ID'
+    required: true
+  branch:
+    description: 'Branch to update'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    - name: Map PR review to version update
+      uses: ./.github/actions/map-pr-review-to-version
+      id: map-pr-review-to-version
+      with:
+        pull-number: ${{ inputs.pull-number }}
+
+    - name: Update version in Cargo.toml
+      if: steps.map-pr-review-to-version.outputs.version != 'none'
+      uses: ./.github/actions/update-cargo-version
+      id: update-cargo-version
+      with:
+        semvar: ${{ steps.map-pr-review-to-version.outputs.version }}
+        cargo-path: ${{ inputs.path-to-cargo }}
+
+    - name: Print updated package version
+      shell: bash
+      run: |
+        echo "Updated version: ${{ steps.update-cargo-version.outputs.version }}"
+        echo "Updated OK: ${{ steps.update-cargo-version.outputs.update-ok }}"
+
+    - name: Commit and tag version changes
+      if:
+        steps.map-pr-review-to-version.outputs.version != 'none' &&
+        steps.update-cargo-version.outputs.update-ok == 'true'
+      id: upgrade-program-version
+      shell: bash
+      run: |
+        git config user.name github-actions[bot]
+        git config user.email github-actions[bot]@users.noreply.github.com
+        git add $PATH_TO_CARGO && git commit -m "chore: update ${PACKAGE_NAME} crate to v${UPDATED_VERSION}" && git tag $PACKAGE_NAME@$UPDATED_VERSION
+      env:
+        PACKAGE_NAME: ${{ inputs.package-name }}
+        UPDATED_VERSION: ${{ steps.update-cargo-version.outputs.version }}
+        PATH_TO_CARGO: ${{ inputs.path-to-cargo }}
+
+    - name: Cargo login
+      if:
+        steps.map-pr-review-to-version.outputs.version != 'none' &&
+        steps.update-cargo-version.outputs.update-ok == 'true'
+      run: cargo login $CARGO_TOKEN
+      shell: bash
+      env:
+        CARGO_TOKEN: ${{ inputs.cargo-token }}
+
+    - name: Publish to crates registry
+      if:
+        steps.map-pr-review-to-version.outputs.version != 'none' &&
+        steps.update-cargo-version.outputs.update-ok == 'true'
+      run: cargo publish --token $CARGO_TOKEN -p $PACKAGE_NAME
+      shell: bash
+      env:
+        CARGO_TOKEN: ${{ inputs.cargo-token }}
+        PACKAGE_NAME: ${{ inputs.package-name }}
+
+    - name: Push changes to Github
+      if:
+        steps.map-pr-review-to-version.outputs.version != 'none' &&
+        steps.update-cargo-version.outputs.update-ok == 'true'
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ inputs.github-token }}
+        branch: ${{ inputs.branch }}

--- a/.github/actions/publish-to-npm/action.yaml
+++ b/.github/actions/publish-to-npm/action.yaml
@@ -1,0 +1,83 @@
+# required permissions:
+#   id-token: write for writing to github
+#   contents: write for updating package contents
+
+name: 'Publish to updated package artifacts'
+description: 'Publish to NPM registry and push updates to Github'
+inputs:
+  # cannot load token directly in action, so we need to pass it in
+  npm-token:
+    description: 'NPM token for authenticated requests'
+    required: true
+  github-token:
+    description: 'Github token for authenticated requests'
+    required: true
+  package-name:
+    description: 'Package name to update'
+    required: true
+  path-to-package-dir:
+    description: "Path to the package to update's directory"
+    required: true
+  pull-number:
+    description: 'Pull request numeric ID'
+    required: true
+  branch:
+    description: 'Branch to update'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    - name: Map PR review to version update
+      uses: ./.github/actions/map-pr-review-to-version
+      id: map-pr-review-to-version
+      with:
+        pull-number: ${{ inputs.pull-number }}
+
+    - name: Print updated package version
+      shell: bash
+      run: |
+        echo "Updated version: ${{ steps.map-pr-review-to-version.outputs.version }}"
+
+    - name: Install dependencies && upgrade package version
+      if: steps.map-pr-review-to-version.outputs.version != 'none'
+      id: update-package-version
+      shell: bash
+      run: |
+        cd $PATH_TO_PACKAGE_DIR
+        yarn install
+        git config user.name github-actions[bot]
+        git config user.email github-actions[bot]@users.noreply.github.com
+        npm version ${{ steps.map-pr-review-to-version.outputs.version }}
+        echo "\n\nLog after update"
+        git log
+        echo "\n\n"
+      env:
+        PATH_TO_PACKAGE_DIR: ${{ inputs.path-to-package-dir }}
+
+    - name: NPM login
+      if: steps.map-pr-review-to-version.outputs.version != 'none'
+      shell: bash
+      run: |
+        echo "//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}" > ~/.npmrc
+      env:
+        NPM_PUBLISH_TOKEN: ${{ inputs.npm-token }}
+
+    - name: Publish artifacts to NPM
+      if: steps.map-pr-review-to-version.outputs.version != 'none'
+      run: npm publish $PATH_TO_PACKAGE_DIR
+      shell: bash
+      env:
+        NPM_PUBLISH_TOKEN: ${{ inputs.npm-token }}
+        PATH_TO_PACKAGE_DIR: ${{ inputs.path-to-package-dir }}
+
+    - name: Push changes to Github
+      if: steps.map-pr-review-to-version.outputs.version != 'none'
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ inputs.github-token }}
+        branch: ${{ inputs.branch }}

--- a/.github/actions/update-cargo-version/action.yaml
+++ b/.github/actions/update-cargo-version/action.yaml
@@ -1,0 +1,45 @@
+name: 'Update crate version'
+description: 'Update crate version based on semvar version bump'
+inputs:
+  semvar:
+    description: 'Semvar version update to make'
+    required: true
+  cargo-path:
+    description: 'Path to Cargo.toml'
+    required: true
+
+outputs:
+  version:
+    description: Updated version based on semvar convention
+    value: ${{ steps.set-output.outputs.version }}
+  update-ok:
+    description: Updated status indicating whether update was successful or not
+    value: ${{ steps.set-output.outputs.update_ok }}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependency packages for script
+      run: |
+        yarn init --yes
+        yarn add @iarna/toml
+      shell: bash
+
+    - name: Update cargo version
+      uses: actions/github-script@v4
+      id: update-cargo-version
+      with:
+        script: |
+          const toml = require('@iarna/toml')
+          const script = require('.github/actions/update-cargo-version/script.js')
+          script({core, toml}, '${{ inputs.cargo-path }}', ${{ inputs.semvar }})
+
+    - name: Set outputs
+      id: set-output
+      # env.UPDATED_VERSION and env.UPDATE_OK exported from script.js
+      run: |
+        echo "::set-output name=version::${{ env.UPDATED_VERSION }}"
+        echo "::set-output name=update_ok::${{ env.UPDATE_OK }}"
+      shell: bash

--- a/.github/actions/update-cargo-version/script.js
+++ b/.github/actions/update-cargo-version/script.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+
+const MAJOR = 'major';
+const MINOR = 'minor';
+const PATCH = 'patch';
+
+/**
+ * Compute the updated version based on the semvar value
+ *
+ * @param {semvar} string The string representation of the version update to make
+ * @param {version} string The current semantic version
+ * @return {string} The updated version
+ */
+const getUpdatedVersion = (semvar, version) => {
+  let [major, minor, patch] = version.split('.').map((v) => +v);
+
+  if (semvar === MAJOR) {
+    major += 1;
+  } else if (semvar === MINOR) {
+    minor += 1;
+  } else if (semvar === PATCH) {
+    patch += 1;
+  }
+
+  return `${major}.${minor}.${patch}`;
+};
+
+/**
+ * Parse the Cargo.toml for the current version, and bump the version based on the semvar update value.
+ *
+ * @param {github} obj An @actions/github object
+ * @param {toml} obj A @iarna/toml object
+ * @param {cargo_path} string The path to the Cargo.toml to update
+ * @param {semvar} string The semvar udpate value
+ * @return void
+ */
+module.exports = ({ core, toml }, cargo_path, semvar) => {
+  if ([MAJOR, MINOR, PATCH].includes(semvar)) {
+    // Verify read and write permissions
+    fs.access(cargo_path, fs.constants.R_OK | fs.constants.W_OK, (err) => {
+      console.log('\n> Checking Permission for reading and writing to file');
+      if (err) {
+        throw new Error('No read and write access');
+      }
+
+      let tomlObj = toml.parse(fs.readFileSync(cargo_path, 'utf-8'));
+      if (!tomlObj.package) throw new Error('No package tag defined in Cargo.toml');
+
+      tomlObj.package.version = getUpdatedVersion(semvar, tomlObj.package.version);
+
+      fs.writeFileSync(cargo_path, toml.stringify(tomlObj));
+      // set output var to read in subsequent steps
+      core.exportVariable('UPDATED_VERSION', tomlObj.package.version);
+      core.exportVariable('UPDATE_OK', true);
+    });
+  }
+
+  // set default output vars
+  core.exportVariable('UPDATED_VERSION', '0.0.0');
+  core.exportVariable('UPDATE_OK', false);
+};


### PR DESCRIPTION
## Context

These are additional Github actions to assist on the quest for auto-publishing. These are likely not the final end-state but rather something to get us started and get a better feel for the workflow they enable.

On PR merge, these actions can be triggered to do the following:

1. Fetch expected semvar version from PR. There are two possibilities here:
   - grab a PR's reviews from PR in reverse chronological order and look for a matching `patch|minor|major` comment.
   - grab a PR's labels and search for a specific label indicating a version bump
2. Modify package version based on the output from step 1. If no command was found, exit job. 
3. Commit and tag changes via git
4. Publish to respective registry — NPM for JS, Crates for Rust.
3. Push changes to Github

### Label actions
* These actions unused right now. Defaulting to the review comments for version bumps. 

### Comment actions
* There are multiple types of comments on a PR. The only 'comments' we parse are the `body` attributes of reviews. A review can be added by explicitly hitting the `review changes` button.
   * Plain comments on a PR will be ignored in this implementation
* The actions will parse reviews in reverse chronological order, taking the first that matches the `patch|minor|major` format.

### Misc
* End to end workflows were tested in a separate repository with dummy js and rust packages

## How to integrate publish into workflows

### Pre-reqs
* Add `CARGO_TOKEN` secret(s) per package
* Add `NPM_PUBLISH_TOKEN` secret(s) per package
* Update workflow permissions

### Crates action
```yaml
permissions:
  id-token: write
  contents: write

...

- name: Publish updated artifacts to Crates and Github
  uses: ./.github/actions/publish-to-crates
  id: publish-to-crates
  with:
    cargo-token: ${{ secrets.CARGO_TOKEN }}
    github-token: ${{ secrets.GITHUB_TOKEN }}
    package-name: <package-name> # e.g. auction-house
    path-to-cargo: <path> # path to package's Cargo.toml
    pull-number: ${{ github.event.number }}
    branch: ${{ github.ref }}
```

### NPM action
```yaml
permissions:
  id-token: write
  contents: write

...

- name: Publish updated artifacts to NPM and Github
  uses: ./.github/actions/publish-to-npm
  id: publish-to-npm
  with:
    npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
    github-token: ${{ secrets.GITHUB_TOKEN }}
    package-name: <package-name> # e.g. auction-house
    path-to-package-dir: <path> # parent dir of package's package.json
    pull-number: ${{ github.event.number }}
    branch: ${{ github.ref }}
```
