### PR TITLE
[Bug] Users Unable to Cancel Offer Because Trade State Derivation

### DIFF
--- a/auction-house/program/src/pda.rs
+++ b/auction-house/program/src/pda.rs
@@ -160,3 +160,29 @@ pub fn find_auctioneer_trade_state_address(
         &id(),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::find_public_bid_trade_state_address;
+    use solana_program::pubkey::{Pubkey, ParsePubkeyError};
+    use std::str::FromStr;
+
+    #[test]
+    fn test_assert_find_public_trade_state() -> Result<(), ParsePubkeyError>{
+        let auction_house = Pubkey::from_str("BeAgRZwvRrDnfsEtAdFd9BkpgNGhP5ERg56DGym9KfJL")?;
+        let wallet = Pubkey::from_str("JDKex5xSPp7skRdTVJbahDhQBhMLjoCYg6R2a9exs1ob")?;
+        let trade_state = Pubkey::from_str("AtWnhkgLb8CYmAeAwzdFWfDaiypPpz32xeFGLwkNMPLf")?;
+        let price = 1800000000;
+        let token_size = 1;
+        let treasury_mint = spl_token::native_mint::id();
+        let token_mint = spl_token::native_mint::id();
+        let ts_bump = 255;
+
+        let (address, bump) = find_public_bid_trade_state_address(&wallet, &auction_house, &treasury_mint, &token_mint, price, token_size);
+
+        assert_eq!(ts_bump, bump);
+        assert_eq!(trade_state, address);
+
+        Ok(())
+    }
+}

--- a/auction-house/program/src/pda.rs
+++ b/auction-house/program/src/pda.rs
@@ -164,25 +164,23 @@ pub fn find_auctioneer_trade_state_address(
 #[cfg(test)]
 mod tests {
     use super::find_public_bid_trade_state_address;
-    use solana_program::pubkey::{Pubkey, ParsePubkeyError};
+    use solana_program::pubkey::Pubkey;
     use std::str::FromStr;
 
     #[test]
-    fn test_assert_find_public_trade_state() -> Result<(), ParsePubkeyError>{
-        let auction_house = Pubkey::from_str("BeAgRZwvRrDnfsEtAdFd9BkpgNGhP5ERg56DGym9KfJL")?;
-        let wallet = Pubkey::from_str("JDKex5xSPp7skRdTVJbahDhQBhMLjoCYg6R2a9exs1ob")?;
-        let trade_state = Pubkey::from_str("AtWnhkgLb8CYmAeAwzdFWfDaiypPpz32xeFGLwkNMPLf")?;
-        let price = 1800000000;
+    fn test_assert_find_public_trade_state() {
+        let auction_house = Pubkey::from_str("BeAgRZwvRrDnfsEtAdFd9BkpgNGhP5ERg56DGym9KfJL").unwrap();
+        let wallet = Pubkey::from_str("JDKex5xSPp7skRdTVJbahDhQBhMLjoCYg6R2a9exs1ob").unwrap();
+        let trade_state = Pubkey::from_str("AtWnhkgLb8CYmAeAwzdFWfDaiypPpz32xeFGLwkNMPLf").unwrap();
+        let price = 1_800_000_000;
         let token_size = 1;
         let treasury_mint = spl_token::native_mint::id();
-        let token_mint = spl_token::native_mint::id();
+        let token_mint = Pubkey::from_str("ApxbCyUaj1wTHnK4Umq7xxYeHkFE1XA67RfDi6aiym9w").unwrap();
         let ts_bump = 255;
 
         let (address, bump) = find_public_bid_trade_state_address(&wallet, &auction_house, &treasury_mint, &token_mint, price, token_size);
 
-        assert_eq!(ts_bump, bump);
         assert_eq!(trade_state, address);
-
-        Ok(())
+        assert_eq!(ts_bump, bump);
     }
 }

--- a/auction-house/program/src/utils.rs
+++ b/auction-house/program/src/utils.rs
@@ -583,7 +583,7 @@ pub fn assert_valid_trade_state(
             treasury_mint_bytes,
             mint_bytes,
             &buyer_price_bytes,
-            &token_size_bytes,
+            &token_size_bytes
         ],
     );
     let canonical_public_bump = assert_derivation(
@@ -596,7 +596,7 @@ pub fn assert_valid_trade_state(
             treasury_mint_bytes,
             mint_bytes,
             &buyer_price_bytes,
-            &token_size_bytes,
+            &token_size_bytes
         ],
     );
 


### PR DESCRIPTION
## Issue

An offer was made on an NFT using public bid but now the user is unable to cancel the offer. Its fails to pass transaction simulation with error 0x177d (aka 6013) (aka DerivedKeyInvalid). This error is thrown from [`assert_deriviation`](https://github.com/metaplex-foundation/metaplex-program-library/blob/master/auction-house/program/src/utils.rs#L548) which is only called from [`assert_valid_trade_state`](https://github.com/metaplex-foundation/metaplex-program-library/blob/master/auction-house/program/src/utils.rs#L556)

https://explorer.solana.com/tx/656XjsyTmLr1iQ6CAuyFVCvw8j259M6VTyDMiDV44GCzSzJ54bHkE1q9DoTCET2zNnrggGt9BdMngvZycEqeafeL

This is the bid receipt we have indexed and reference when putting together the instruction.
```json
{
"address": "56nsPGPv3LajcZ8ufv64VCWEoTSTWfjWzoHczQo55YCU",
"auctionHouse": "BeAgRZwvRrDnfsEtAdFd9BkpgNGhP5ERg56DGym9KfJL",
"buyer": "JDKex5xSPp7skRdTVJbahDhQBhMLjoCYg6R2a9exs1ob",
"canceledAt": null,
"createdAt": "2022-05-27T23:57:17+00:00",
"metadata": "6hKqXWUbq8oqGUnGt7jjV7zDe5Ckye6QGdnHdjgFowp7",
"price": "1800000000",  // this is converted to number with bn.js before submitting the instruction
"tokenAccount": null,
"tradeState": "AtWnhkgLb8CYmAeAwzdFWfDaiypPpz32xeFGLwkNMPLf",
"tradeStateBump": 255
}
```

The offer that can't be canceled is for wallet `JDKex5xSPp7skRdTVJbahDhQBhMLjoCYg6R2a9exs1ob`
https://www.holaplex.com/nfts/6hKqXWUbq8oqGUnGt7jjV7zDe5Ckye6QGdnHdjgFowp7