### PR TITLE
Add versioning and build actions to workflows

### DIFF
--- a/.github/actions/get-pr-for-commit/action.yaml
+++ b/.github/actions/get-pr-for-commit/action.yaml
@@ -1,0 +1,38 @@
+name: 'Get pull_request number for commit, if any'
+description: 'Returns pull_request number or -1 if no pull_request associated with commit'
+inputs:
+  commit-sha:
+    description: 'Commit SHA'
+    required: true
+
+outputs:
+  pull-number:
+    description: Pull request number
+    value: ${{ steps.set-output.outputs.pull-number }}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+
+    - name: Fetch pull_request data associated with commit SHA
+      uses: actions/github-script@v4
+      id: fetch-pull-number-for-commit
+      # assummption: we only care about the latest PR associated with the commit?
+      with:
+        script: |
+          const { data } = await github.request(
+            "GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls",
+            {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: '${{ inputs.commit-sha }}'
+            })
+          return data.length === 0 ? -1 : data[data.length-1].number
+
+    - name: Set output
+      id: set-output
+      run: echo "::set-output name=pull-number::$PR_NUMBER"
+      shell: bash
+      env:
+        PR_NUMBER: ${{ steps.fetch-pull-number-for-commit.outputs.result }}

--- a/.github/actions/publish-to-crates/action.yaml
+++ b/.github/actions/publish-to-crates/action.yaml
@@ -5,11 +5,10 @@
 name: 'Publish to updated package artifacts'
 description: 'Publish to Crates registry and push updates to Github'
 inputs:
-  # cannot load token directly in action, so we need to pass it in
+  # cannot load tokens directly in action, so we need to pass it in
   cargo-token:
     description: 'Cargo token for authenticated requests'
     required: true
-  # cannot load token directly in action, so we need to pass it in
   github-token:
     description: 'Github token for authenticated requests'
     required: true
@@ -20,8 +19,11 @@ inputs:
     description: "Path to the package to update's Cargo.toml"
     required: true
   pull-number:
-    description: 'Pull request numeric ID'
-    required: true
+    description: 'Pull request numeric ID. If this is empty, expect a commit-sha with an associated PR.'
+    required: false
+  commit-sha:
+    description: 'Commit SHA of code to publish'
+    required: false
   branch:
     description: 'Branch to update'
     required: true
@@ -33,11 +35,30 @@ runs:
       with:
         node-version: ${{ env.NODE_VERSION }}
 
+    - name: Get PR for push event HEAD commit
+      if: ${{ inputs.pull-number == '' }}
+      uses: ./.github/actions/get-pr-for-commit
+      id: get-pr-for-commit
+      with:
+        commit-sha: ${{ inputs.commit-sha }}
+
+    - name: Decide the value of pull-number
+      id: set-pull-number
+      shell: bash
+      run: |
+        if [[ '${{ inputs.pull-number }}' != '' ]]
+        then
+            echo "::set-output name=pull-number::${{ inputs.pull-number }}"
+        else
+            echo "::set-output name=pull-number::${{ steps.get-pr-for-commit.outputs.pull-number }}"
+        fi
+
     - name: Map PR review to version update
+      if: steps.set-pull-number.outputs.pull-number > 0
       uses: ./.github/actions/map-pr-review-to-version
       id: map-pr-review-to-version
       with:
-        pull-number: ${{ inputs.pull-number }}
+        pull-number: ${{ steps.set-pull-number.outputs.pull-number }}
 
     - name: Update version in Cargo.toml
       if: steps.map-pr-review-to-version.outputs.version != 'none'
@@ -55,8 +76,7 @@ runs:
 
     - name: Commit and tag version changes
       if:
-        steps.map-pr-review-to-version.outputs.version != 'none' &&
-        steps.update-cargo-version.outputs.update-ok == 'true'
+        steps.map-pr-review-to-version.outputs.version != 'none' && steps.update-cargo-version.outputs.update-ok == 'true'
       id: upgrade-program-version
       shell: bash
       run: |
@@ -70,8 +90,7 @@ runs:
 
     - name: Cargo login
       if:
-        steps.map-pr-review-to-version.outputs.version != 'none' &&
-        steps.update-cargo-version.outputs.update-ok == 'true'
+        steps.map-pr-review-to-version.outputs.version != 'none' && steps.update-cargo-version.outputs.update-ok == 'true'
       run: cargo login $CARGO_TOKEN
       shell: bash
       env:
@@ -79,8 +98,7 @@ runs:
 
     - name: Publish to crates registry
       if:
-        steps.map-pr-review-to-version.outputs.version != 'none' &&
-        steps.update-cargo-version.outputs.update-ok == 'true'
+        steps.map-pr-review-to-version.outputs.version != 'none' && steps.update-cargo-version.outputs.update-ok == 'true'
       run: cargo publish --token $CARGO_TOKEN -p $PACKAGE_NAME
       shell: bash
       env:
@@ -89,8 +107,7 @@ runs:
 
     - name: Push changes to Github
       if:
-        steps.map-pr-review-to-version.outputs.version != 'none' &&
-        steps.update-cargo-version.outputs.update-ok == 'true'
+        steps.map-pr-review-to-version.outputs.version != 'none' && steps.update-cargo-version.outputs.update-ok == 'true'
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ inputs.github-token }}

--- a/.github/actions/publish-to-npm/action.yaml
+++ b/.github/actions/publish-to-npm/action.yaml
@@ -2,49 +2,65 @@
 #   id-token: write for writing to github
 #   contents: write for updating package contents
 
-name: 'Publish to updated package artifacts'
-description: 'Publish to NPM registry and push updates to Github'
+name: "Publish to updated package artifacts"
+description: "Publish to NPM registry and push updates to Github"
 inputs:
   # cannot load token directly in action, so we need to pass it in
   npm-token:
-    description: 'NPM token for authenticated requests'
+    description: "NPM token for authenticated requests"
     required: true
   github-token:
-    description: 'Github token for authenticated requests'
-    required: true
-  package-name:
-    description: 'Package name to update'
+    description: "Github token for authenticated requests"
     required: true
   path-to-package-dir:
     description: "Path to the package to update's directory"
     required: true
   pull-number:
-    description: 'Pull request numeric ID'
-    required: true
+    description: "Pull request numeric ID. If this is empty, expect a commit-sha with an associated PR."
+    required: false
+  commit-sha:
+    description: "Commit SHA of code to publish"
+    required: false
   branch:
-    description: 'Branch to update'
+    description: "Branch to update"
     required: true
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/checkout@v3
       with:
         node-version: ${{ env.NODE_VERSION }}
 
+    - name: Get PR for push event HEAD commit
+      # only fetch PR for commit if pull-number is not specified
+      if: ${{ inputs.pull-number == '' }}
+      uses: ./.github/actions/get-pr-for-commit
+      id: get-pr-for-commit
+      with:
+        commit-sha: ${{ inputs.commit-sha }}
+
+    - name: Decide the value of pull-number
+      id: set-pull-number
+      shell: bash
+      run: |
+        if [[ '${{ inputs.pull-number }}' != '' ]]
+        then
+            echo "::set-output name=pull-number::${{ inputs.pull-number }}"
+        else
+            echo "::set-output name=pull-number::${{ steps.get-pr-for-commit.outputs.pull-number }}"
+        fi
+
     - name: Map PR review to version update
+      if: steps.set-pull-number.outputs.pull-number > 0
       uses: ./.github/actions/map-pr-review-to-version
       id: map-pr-review-to-version
       with:
-        pull-number: ${{ inputs.pull-number }}
-
-    - name: Print updated package version
-      shell: bash
-      run: |
-        echo "Updated version: ${{ steps.map-pr-review-to-version.outputs.version }}"
+        pull-number: ${{ steps.set-pull-number.outputs.pull-number }}
 
     - name: Install dependencies && upgrade package version
-      if: steps.map-pr-review-to-version.outputs.version != 'none'
+      # this prevents any subsequent steps from running in the event there is (1) no version update or (2) no PR associated with the commit
+      if: contains(fromJson('["", "none"]'), steps.map-pr-review-to-version.outputs.version) == false
       id: update-package-version
       shell: bash
       run: |
@@ -60,7 +76,7 @@ runs:
         PATH_TO_PACKAGE_DIR: ${{ inputs.path-to-package-dir }}
 
     - name: NPM login
-      if: steps.map-pr-review-to-version.outputs.version != 'none'
+      if: contains(fromJson('["", "none"]'), steps.map-pr-review-to-version.outputs.version) == false
       shell: bash
       run: |
         echo "//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}" > ~/.npmrc
@@ -68,7 +84,7 @@ runs:
         NPM_PUBLISH_TOKEN: ${{ inputs.npm-token }}
 
     - name: Publish artifacts to NPM
-      if: steps.map-pr-review-to-version.outputs.version != 'none'
+      if: contains(fromJson('["", "none"]'), steps.map-pr-review-to-version.outputs.version) == false
       run: npm publish $PATH_TO_PACKAGE_DIR
       shell: bash
       env:
@@ -76,7 +92,7 @@ runs:
         PATH_TO_PACKAGE_DIR: ${{ inputs.path-to-package-dir }}
 
     - name: Push changes to Github
-      if: steps.map-pr-review-to-version.outputs.version != 'none'
+      if: contains(fromJson('["", "none"]'), steps.map-pr-review-to-version.outputs.version) == false
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ inputs.github-token }}

--- a/.github/actions/publish-to-npm/action.yaml
+++ b/.github/actions/publish-to-npm/action.yaml
@@ -88,7 +88,6 @@ runs:
       run: npm publish $PATH_TO_PACKAGE_DIR
       shell: bash
       env:
-        NPM_PUBLISH_TOKEN: ${{ inputs.npm-token }}
         PATH_TO_PACKAGE_DIR: ${{ inputs.path-to-package-dir }}
 
     - name: Push changes to Github

--- a/.github/actions/setup-aws-env/action.yaml
+++ b/.github/actions/setup-aws-env/action.yaml
@@ -3,7 +3,6 @@ description: "Export AWS environment variables to GH context"
 runs:
   using: "composite"
   steps:
-    # move to a secret?
     - run: echo "BINARY_STORAGE_ACCOUNT_ID=813125037859" >> $GITHUB_ENV
       shell: bash
     - run: echo "BINARY_STORAGE_REGION=us-east-1" >> $GITHUB_ENV

--- a/.github/actions/setup-aws-env/action.yaml
+++ b/.github/actions/setup-aws-env/action.yaml
@@ -1,0 +1,14 @@
+name: "Setup AWS environment variables"
+description: "Export AWS environment variables to GH context"
+runs:
+  using: "composite"
+  steps:
+    # move to a secret?
+    - run: echo "BINARY_STORAGE_ACCOUNT_ID=813125037859" >> $GITHUB_ENV
+      shell: bash
+    - run: echo "BINARY_STORAGE_REGION=us-east-1" >> $GITHUB_ENV
+      shell: bash
+    - run: echo "BINARY_STORAGE_ROLE=uploadToS3Role" >> $GITHUB_ENV
+      shell: bash
+    - run: echo "BINARY_STORAGE_BUCKET=programbinarystorage-programbinaries5c3d16e8-kzk7oebhpkxe" >> $GITHUB_ENV
+      shell: bash

--- a/.github/workflows/program-auction-house.yml
+++ b/.github/workflows/program-auction-house.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION_STABLE: 1.9.22
@@ -30,6 +34,7 @@ jobs:
               - 'core/**'
             package:
               - 'auction-house/**'
+
   build-and-test-auction-house-stable:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -125,3 +130,36 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-auction-house
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to Crates and Github
+        uses: ./.github/actions/publish-to-crates
+        id: publish-to-crates
+        with:
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: auction-house
+          path-to-cargo: ./auction-house/program/Cargo.toml
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}
+
+      - uses: ./.github/actions/setup-aws-env/
+      - name: Build and upload
+        uses: ./.github/actions/build-and-upload/
+        id: upload-binary-metadata
+        with:
+          # based on Cargo.toml package name
+          program-binary: mpl_auction_house.so
+          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
+          region: ${{ env.BINARY_STORAGE_REGION }}
+          role: ${{ env.BINARY_STORAGE_ROLE }}
+          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
+          prefix: auction-house

--- a/.github/workflows/program-auction.yml
+++ b/.github/workflows/program-auction.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.15
@@ -68,3 +72,36 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-auction
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to Crates and Github
+        uses: ./.github/actions/publish-to-crates
+        id: publish-to-crates
+        with:
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: auction
+          path-to-cargo: ./auction/program/Cargo.toml
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}
+
+      - uses: ./.github/actions/setup-aws-env/
+      - name: Build and upload
+        uses: ./.github/actions/build-and-upload/
+        id: upload-binary-metadata
+        with:
+          # based on Cargo.toml package name
+          program-binary: mpl_auction.so
+          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
+          region: ${{ env.BINARY_STORAGE_REGION }}
+          role: ${{ env.BINARY_STORAGE_ROLE }}
+          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
+          prefix: auction

--- a/.github/workflows/program-candy-machine.yml
+++ b/.github/workflows/program-candy-machine.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.18
@@ -74,3 +78,36 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-candy-machine
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to Crates and Github
+        uses: ./.github/actions/publish-to-crates
+        id: publish-to-crates
+        with:
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: candy-machine
+          path-to-cargo: ./candy-machine/program/Cargo.toml
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}
+
+      - uses: ./.github/actions/setup-aws-env/
+      - name: Build and upload
+        uses: ./.github/actions/build-and-upload/
+        id: upload-binary-metadata
+        with:
+          # based on Cargo.toml package name
+          program-binary: mpl_candy_machine.so
+          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
+          region: ${{ env.BINARY_STORAGE_REGION }}
+          role: ${{ env.BINARY_STORAGE_ROLE }}
+          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
+          prefix: candy-machine

--- a/.github/workflows/program-fixed-price-sale.yml
+++ b/.github/workflows/program-fixed-price-sale.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.22
@@ -68,3 +72,35 @@ jobs:
         working-directory: ./fixed-price-sale/program
         run: |
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --test-threads 1
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-fixed-price-sale
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to Crates and Github
+        uses: ./.github/actions/publish-to-crates
+        id: publish-to-crates
+        with:
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: fixed-price-sale
+          path-to-cargo: ./fixed-price-sale/program/Cargo.toml
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}
+
+      - uses: ./.github/actions/setup-aws-env/
+      - name: Build and upload
+        uses: ./.github/actions/build-and-upload/
+        id: upload-binary-metadata
+        with:
+          program-binary: mpl_fixed_price_sale.so
+          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
+          region: ${{ env.BINARY_STORAGE_REGION }}
+          role: ${{ env.BINARY_STORAGE_ROLE }}
+          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
+          prefix: fixed-price-sale

--- a/.github/workflows/program-gumdrop.yml
+++ b/.github/workflows/program-gumdrop.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.14
@@ -69,3 +73,36 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-gumdrop
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to Crates and Github
+        uses: ./.github/actions/publish-to-crates
+        id: publish-to-crates
+        with:
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: gumdrop
+          path-to-cargo: ./gumdrop/program/Cargo.toml
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}
+
+      - uses: ./.github/actions/setup-aws-env/
+      - name: Build and upload
+        uses: ./.github/actions/build-and-upload/
+        id: upload-binary-metadata
+        with:
+          # based on Cargo.toml package name
+          program-binary: mpl_gumdrop.so
+          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
+          region: ${{ env.BINARY_STORAGE_REGION }}
+          role: ${{ env.BINARY_STORAGE_ROLE }}
+          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
+          prefix: gumdrop

--- a/.github/workflows/program-metaplex.yml
+++ b/.github/workflows/program-metaplex.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.14
@@ -30,6 +34,7 @@ jobs:
             - 'core/**'
           package:
             - 'metaplex/**'
+
   build-and-test-metaplex:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -67,3 +72,36 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-metaplex
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to Crates and Github
+        uses: ./.github/actions/publish-to-crates
+        id: publish-to-crates
+        with:
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: metaplex
+          path-to-cargo: ./metaplex/program/Cargo.toml
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}
+
+      - uses: ./.github/actions/setup-aws-env/
+      - name: Build and upload
+        uses: ./.github/actions/build-and-upload/
+        id: upload-binary-metadata
+        with:
+          # based on Cargo.toml package name
+          program-binary: mpl_metaplex.so
+          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
+          region: ${{ env.BINARY_STORAGE_REGION }}
+          role: ${{ env.BINARY_STORAGE_ROLE }}
+          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
+          prefix: metaplex

--- a/.github/workflows/program-nft-packs.yml
+++ b/.github/workflows/program-nft-packs.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+permissions:
+  id-token: write
+  contents: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -29,6 +32,7 @@ jobs:
             - 'core/**'
           package:
             - 'nft-packs/**'
+
   build-and-test-nft-packs:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -68,3 +72,36 @@ jobs:
         run: |
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-nft-packs
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to Crates and Github
+        uses: ./.github/actions/publish-to-crates
+        id: publish-to-crates
+        with:
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: nft-packs
+          path-to-cargo: ./nft-packs/program/Cargo.toml
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}
+
+      - uses: ./.github/actions/setup-aws-env/
+      - name: Build and upload
+        uses: ./.github/actions/build-and-upload/
+        id: upload-binary-metadata
+        with:
+          # based on Cargo.toml package name
+          program-binary: mpl_nft_packs.so
+          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
+          region: ${{ env.BINARY_STORAGE_REGION }}
+          role: ${{ env.BINARY_STORAGE_ROLE }}
+          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
+          prefix: nft-packs

--- a/.github/workflows/program-token-entangler.yml
+++ b/.github/workflows/program-token-entangler.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.15
@@ -29,6 +33,7 @@ jobs:
               - 'core/**'
             package:
               - 'token-entangler/**'
+
   build-and-test-token-entangler:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -72,3 +77,36 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-token-entangler
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to Crates and Github
+        uses: ./.github/actions/publish-to-crates
+        id: publish-to-crates
+        with:
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: token-entangler
+          path-to-cargo: ./token-entangler/program/Cargo.toml
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}
+
+      - uses: ./.github/actions/setup-aws-env/
+      - name: Build and upload
+        uses: ./.github/actions/build-and-upload/
+        id: upload-binary-metadata
+        with:
+          # based on Cargo.toml package name
+          program-binary: mpl_token_entangler.so
+          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
+          region: ${{ env.BINARY_STORAGE_REGION }}
+          role: ${{ env.BINARY_STORAGE_ROLE }}
+          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
+          prefix: token-entangler

--- a/.github/workflows/program-token-metadata.yml
+++ b/.github/workflows/program-token-metadata.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.22
@@ -29,6 +33,7 @@ jobs:
               - 'core/**'
             package:
               - 'token-metadata/**'
+
   build-and-test-token-metadata:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -76,3 +81,36 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-token-metadata
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to Crates and Github
+        uses: ./.github/actions/publish-to-crates
+        id: publish-to-crates
+        with:
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: token-metadata
+          path-to-cargo: ./token-metadata/program/Cargo.toml
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}
+
+      - uses: ./.github/actions/setup-aws-env/
+      - name: Build and upload
+        uses: ./.github/actions/build-and-upload/
+        id: upload-binary-metadata
+        with:
+          # based on Cargo.toml package name
+          program-binary: mpl_token_metadata.so
+          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
+          region: ${{ env.BINARY_STORAGE_REGION }}
+          role: ${{ env.BINARY_STORAGE_ROLE }}
+          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
+          prefix: token-metadata

--- a/.github/workflows/program-token-vault.yml
+++ b/.github/workflows/program-token-vault.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.14
@@ -66,3 +70,36 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-token-vault
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to Crates and Github
+        uses: ./.github/actions/publish-to-crates
+        id: publish-to-crates
+        with:
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: token-vault
+          path-to-cargo: ./token-vault/program/Cargo.toml
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}
+
+      - uses: ./.github/actions/setup-aws-env/
+      - name: Build and upload
+        uses: ./.github/actions/build-and-upload/
+        id: upload-binary-metadata
+        with:
+          # based on Cargo.toml package name
+          program-binary: mpl_token_vault.so
+          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
+          region: ${{ env.BINARY_STORAGE_REGION }}
+          role: ${{ env.BINARY_STORAGE_ROLE }}
+          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
+          prefix: token-vault

--- a/.github/workflows/sdk-auction-house.yml
+++ b/.github/workflows/sdk-auction-house.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -24,6 +28,7 @@ jobs:
             - 'core/**'
           package:
             - 'auction-house/**'
+
   build-lint-and-test-auction-house:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -33,6 +38,26 @@ jobs:
       - uses: actions/checkout@v1
       - uses: ./.github/actions/yarn-install-and-verify
         with: 
-          cache_id: sdk-auction  
-          working_dir: ./auction/js
+          cache_id: sdk-auction-house
+          working_dir: ./auction-house/js
           skip_test: true
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if:
+      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-auction-house
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to NPM and Github
+        uses: ./.github/actions/publish-to-npm
+        id: publish-to-npm
+        with:
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-package-dir: ./auction-house/js
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-auction-house.yml
+++ b/.github/workflows/sdk-auction-house.yml
@@ -56,7 +56,7 @@ jobs:
         uses: ./.github/actions/publish-to-npm
         id: publish-to-npm
         with:
-          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-package-dir: ./auction-house/js
           commit-sha: ${{ github.sha }}

--- a/.github/workflows/sdk-auction.yml
+++ b/.github/workflows/sdk-auction.yml
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/actions/publish-to-npm
         id: publish-to-npm
         with:
-          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-package-dir: ./auction/js
           commit-sha: ${{ github.sha }}

--- a/.github/workflows/sdk-auction.yml
+++ b/.github/workflows/sdk-auction.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -24,6 +28,7 @@ jobs:
             - 'core/**'
           package:
             - 'auction/**'
+
   build-lint-and-test-auction:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -35,3 +40,23 @@ jobs:
         with: 
           cache_id: sdk-auction  
           working_dir: ./auction/js
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if:
+      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-auction
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to NPM and Github
+        uses: ./.github/actions/publish-to-npm
+        id: publish-to-npm
+        with:
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-package-dir: ./auction/js
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-candy-machine.yml
+++ b/.github/workflows/sdk-candy-machine.yml
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/actions/publish-to-npm
         id: publish-to-npm
         with:
-          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-package-dir: ./candy-machine/js
           commit-sha: ${{ github.sha }}

--- a/.github/workflows/sdk-candy-machine.yml
+++ b/.github/workflows/sdk-candy-machine.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -24,6 +28,7 @@ jobs:
             - 'core/**'
           package:
             - 'candy-machine/**'
+
   build-lint-and-test-candy-machine:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -35,3 +40,23 @@ jobs:
         with: 
           cache_id: sdk-candy-machine
           working_dir: ./candy-machine/js
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if:
+      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-candy-machine
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to NPM and Github
+        uses: ./.github/actions/publish-to-npm
+        id: publish-to-npm
+        with:
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-package-dir: ./candy-machine/js
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-core.yml
+++ b/.github/workflows/sdk-core.yml
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/publish-to-npm
         id: publish-to-npm
         with:
-          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-package-dir: ./core/js
           commit-sha: ${{ github.sha }}

--- a/.github/workflows/sdk-core.yml
+++ b/.github/workflows/sdk-core.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -21,6 +25,7 @@ jobs:
         filters: |
           core:
             - 'core/**'
+
   build-lint-and-test-core:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' }}
@@ -33,3 +38,23 @@ jobs:
           cache_id: sdk-core  
           working_dir: ./core/js
           build_core: false
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if:
+      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-core
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to NPM and Github
+        uses: ./.github/actions/publish-to-npm
+        id: publish-to-npm
+        with:
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-package-dir: ./core/js
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-fixed-price-sale.yml
+++ b/.github/workflows/sdk-fixed-price-sale.yml
@@ -57,7 +57,7 @@ jobs:
         uses: ./.github/actions/publish-to-npm
         id: publish-to-npm
         with:
-          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-package-dir: ./fixed-price-sale/js
           commit-sha: ${{ github.sha }}

--- a/.github/workflows/sdk-fixed-price-sale.yml
+++ b/.github/workflows/sdk-fixed-price-sale.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -24,6 +28,7 @@ jobs:
               - 'core/**'
             package:
               - 'fixed-price-sale/**'
+
   build-lint-and-test-fixed-price-sale:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -37,3 +42,23 @@ jobs:
           working_dir: ./fixed-price-sale/js
           build_token_metadata: true
           skip_test: true
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if:
+      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-fixed-price-sale
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to NPM and Github
+        uses: ./.github/actions/publish-to-npm
+        id: publish-to-npm
+        with:
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-package-dir: ./fixed-price-sale/js
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-gumdrop.yml
+++ b/.github/workflows/sdk-gumdrop.yml
@@ -56,7 +56,7 @@ jobs:
         uses: ./.github/actions/publish-to-npm
         id: publish-to-npm
         with:
-          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-package-dir: ./gumdrop/js
           commit-sha: ${{ github.sha }}

--- a/.github/workflows/sdk-gumdrop.yml
+++ b/.github/workflows/sdk-gumdrop.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -24,6 +28,7 @@ jobs:
             - 'core/**'
           package:
             - 'gumdrop/**'
+
   build-lint-and-test-gumdrop:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -36,3 +41,23 @@ jobs:
           cache_id: sdk-gumdrop
           working_dir: ./gumdrop/js
           build_token_metadata: true
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if:
+      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-gumdrop
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to NPM and Github
+        uses: ./.github/actions/publish-to-npm
+        id: publish-to-npm
+        with:
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-package-dir: ./gumdrop/js
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-metaplex.yml
+++ b/.github/workflows/sdk-metaplex.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -39,3 +43,23 @@ jobs:
           build_token_vault: true
           build_token_metadata: true
           skip_test: true
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if:
+      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-metaplex
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to NPM and Github
+        uses: ./.github/actions/publish-to-npm
+        id: publish-to-npm
+        with:
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-package-dir: ./metaplex/js
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-metaplex.yml
+++ b/.github/workflows/sdk-metaplex.yml
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/publish-to-npm
         id: publish-to-npm
         with:
-          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-package-dir: ./metaplex/js
           commit-sha: ${{ github.sha }}

--- a/.github/workflows/sdk-token-entangler.yml
+++ b/.github/workflows/sdk-token-entangler.yml
@@ -56,7 +56,7 @@ jobs:
         uses: ./.github/actions/publish-to-npm
         id: publish-to-npm
         with:
-          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-package-dir: ./token-entangler/js
           commit-sha: ${{ github.sha }}

--- a/.github/workflows/sdk-token-entangler.yml
+++ b/.github/workflows/sdk-token-entangler.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -24,6 +28,7 @@ jobs:
             - 'core/**'
           package:
             - 'token-entangler/**'
+
   build-lint-and-test-token-entangler:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -36,3 +41,23 @@ jobs:
           cache_id: sdk-token-entangler
           working_dir: ./token-entangler/js
           build_token_metadata: true
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if:
+      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-token-entangler
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to NPM and Github
+        uses: ./.github/actions/publish-to-npm
+        id: publish-to-npm
+        with:
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-package-dir: ./token-entangler/js
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-token-metadata.yml
+++ b/.github/workflows/sdk-token-metadata.yml
@@ -56,7 +56,7 @@ jobs:
         uses: ./.github/actions/publish-to-npm
         id: publish-to-npm
         with:
-          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-package-dir: ./token-metadata/js
           commit-sha: ${{ github.sha }}

--- a/.github/workflows/sdk-token-metadata.yml
+++ b/.github/workflows/sdk-token-metadata.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -24,6 +28,7 @@ jobs:
             - 'core/**'
           package:
             - 'token-metadata/**'
+
   build-lint-and-test-token-metadata:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
@@ -36,3 +41,23 @@ jobs:
           cache_id: sdk-token-metadata
           working_dir: ./token-metadata/js
           skip_test: false
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if:
+      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-token-metadata
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to NPM and Github
+        uses: ./.github/actions/publish-to-npm
+        id: publish-to-npm
+        with:
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-package-dir: ./token-metadata/js
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-token-vault.yml
+++ b/.github/workflows/sdk-token-vault.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -39,3 +43,24 @@ jobs:
           cache_id: sdk-token-vault
           working_dir: ./token-vault/js
           skip_test: true
+
+
+  upgrade-version-and-publish-binary:
+    needs: changes
+    if:
+      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      cache_id: program-token-vault
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish updated artifacts to NPM and Github
+        uses: ./.github/actions/publish-to-npm
+        id: publish-to-npm
+        with:
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-package-dir: ./token-vault/js
+          commit-sha: ${{ github.sha }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-token-vault.yml
+++ b/.github/workflows/sdk-token-vault.yml
@@ -59,7 +59,7 @@ jobs:
         uses: ./.github/actions/publish-to-npm
         id: publish-to-npm
         with:
-          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-package-dir: ./token-vault/js
           commit-sha: ${{ github.sha }}


### PR DESCRIPTION
## Context
* This change wires up the actions I previously added for verifiable builds and NPM & Crates versioning
  * https://github.com/metaplex-foundation/metaplex-program-library/pull/488
  * https://github.com/metaplex-foundation/metaplex-program-library/pull/515
* When a PR is merged, it triggers a `push` event to master. In this case, the workflow checks for (1) changes in the package and (2) a `push` event before trying to publish a new version and build, in the case of Rust

## Changes
* Most changes are adding the top-level actions for publishing version updates for JS (`publish-to-npm`) & Rust (`publish-to-cratess`) and publishing builds for Rust (`build-and-publish`)
* During a push event, we don't have access to the associated PR number. So, I added a custom `get-pr-for-commit` action that takes the event's commit SHA and relates it to a PR, if it exists.
* I also created an action called `setup-aws-env` that sets up common AWS env vars so that I didn't have to copy pasta in every single workflow

## Future
* After getting a feel for the comment-to-version packages these workflows enable, we can add more granular comment parsing like `patch:js` or `patch:rust:auction-house` 
* Maybe add the link to a build artifact on the original PR
* Do we need extra work/infra to sync deployed binary and the compatible IDL? 