### PR TITLE
Fix burning editions

### DIFF
--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -1671,10 +1671,10 @@
           "desc": "Token account to close"
         },
         {
-          "name": "editionAccount",
+          "name": "masterEditionAccount",
           "isMut": true,
           "isSigner": false,
-          "desc": "MasterEdition2 or Edition Account of the NFT"
+          "desc": "MasterEdition2 of the NFT"
         },
         {
           "name": "splTokenProgram",
@@ -3326,6 +3326,16 @@
       "code": 108,
       "name": "MissingEditionAccount",
       "msg": "This mint account has an edition but none was provided."
+    },
+    {
+      "code": 109,
+      "name": "NotAMasterEdition",
+      "msg": "This edition is not a Master Edition"
+    },
+    {
+      "code": 110,
+      "name": "MasterEditionHasPrints",
+      "msg": "This Master Edition has existing prints"
     }
   ],
   "metadata": {

--- a/token-metadata/js/src/generated/errors/index.ts
+++ b/token-metadata/js/src/generated/errors/index.ts
@@ -2354,6 +2354,46 @@ createErrorFromCodeLookup.set(0x6c, () => new MissingEditionAccountError());
 createErrorFromNameLookup.set('MissingEditionAccount', () => new MissingEditionAccountError());
 
 /**
+ * NotAMasterEdition: 'This edition is not a Master Edition'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class NotAMasterEditionError extends Error {
+  readonly code: number = 0x6d;
+  readonly name: string = 'NotAMasterEdition';
+  constructor() {
+    super('This edition is not a Master Edition');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, NotAMasterEditionError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x6d, () => new NotAMasterEditionError());
+createErrorFromNameLookup.set('NotAMasterEdition', () => new NotAMasterEditionError());
+
+/**
+ * MasterEditionHasPrints: 'This Master Edition has existing prints'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class MasterEditionHasPrintsError extends Error {
+  readonly code: number = 0x6e;
+  readonly name: string = 'MasterEditionHasPrints';
+  constructor() {
+    super('This Master Edition has existing prints');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, MasterEditionHasPrintsError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x6e, () => new MasterEditionHasPrintsError());
+createErrorFromNameLookup.set('MasterEditionHasPrints', () => new MasterEditionHasPrintsError());
+
+/**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors
  * @category generated

--- a/token-metadata/js/src/generated/instructions/BurnNft.ts
+++ b/token-metadata/js/src/generated/instructions/BurnNft.ts
@@ -24,7 +24,7 @@ export const BurnNftStruct = new beet.BeetArgsStruct<{ instructionDiscriminator:
  * @property [_writable_, **signer**] owner NFT owner
  * @property [_writable_] mint Mint of the NFT
  * @property [_writable_] tokenAccount Token account to close
- * @property [_writable_] editionAccount MasterEdition2 or Edition Account of the NFT
+ * @property [_writable_] masterEditionAccount MasterEdition2 of the NFT
  * @property [] splTokenProgram SPL Token Program
  * @property [_writable_] collectionMetadata (optional) Metadata of the Collection
  * @category Instructions
@@ -36,7 +36,7 @@ export type BurnNftInstructionAccounts = {
   owner: web3.PublicKey;
   mint: web3.PublicKey;
   tokenAccount: web3.PublicKey;
-  editionAccount: web3.PublicKey;
+  masterEditionAccount: web3.PublicKey;
   splTokenProgram: web3.PublicKey;
   collectionMetadata?: web3.PublicKey;
 };
@@ -57,7 +57,7 @@ export function createBurnNftInstruction(accounts: BurnNftInstructionAccounts) {
     owner,
     mint,
     tokenAccount,
-    editionAccount,
+    masterEditionAccount,
     splTokenProgram,
     collectionMetadata,
   } = accounts;
@@ -87,7 +87,7 @@ export function createBurnNftInstruction(accounts: BurnNftInstructionAccounts) {
       isSigner: false,
     },
     {
-      pubkey: editionAccount,
+      pubkey: masterEditionAccount,
       isWritable: true,
       isSigner: false,
     },

--- a/token-metadata/program/src/error.rs
+++ b/token-metadata/program/src/error.rs
@@ -428,6 +428,10 @@ pub enum MetadataError {
     /// 108 - Missing edition account for a non-fungible token type.
     #[error("This mint account has an edition but none was provided.")]
     MissingEditionAccount,
+
+    /// 109 - Not a Master Edition
+    #[error("This edition is not a Master Edition")]
+    NotAMasterEdition,
 }
 
 impl PrintProgramError for MetadataError {

--- a/token-metadata/program/src/error.rs
+++ b/token-metadata/program/src/error.rs
@@ -432,6 +432,10 @@ pub enum MetadataError {
     /// 109 - Not a Master Edition
     #[error("This edition is not a Master Edition")]
     NotAMasterEdition,
+
+    /// 110 - Master Edition has prints.
+    #[error("This Master Edition has existing prints")]
+    MasterEditionHasPrints,
 }
 
 impl PrintProgramError for MetadataError {

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -428,7 +428,7 @@ pub enum MetadataInstruction {
     #[account(1, signer, writable, name="owner", desc="NFT owner")]
     #[account(2, writable, name="mint", desc="Mint of the NFT")]
     #[account(3, writable, name="token_account", desc="Token account to close")]
-    #[account(4, writable, name="edition_account", desc="MasterEdition2 of the NFT")]
+    #[account(4, writable, name="master_edition_account", desc="MasterEdition2 of the NFT")]
     #[account(5, name="spl token program", desc="SPL Token Program")]
     #[account(6, optional, writable, name="collection_metadata", desc="Metadata of the Collection")]
     BurnNft,

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -428,7 +428,7 @@ pub enum MetadataInstruction {
     #[account(1, signer, writable, name="owner", desc="NFT owner")]
     #[account(2, writable, name="mint", desc="Mint of the NFT")]
     #[account(3, writable, name="token_account", desc="Token account to close")]
-    #[account(4, writable, name="edition_account", desc="MasterEdition2 or Edition Account of the NFT")]
+    #[account(4, writable, name="edition_account", desc="MasterEdition2 of the NFT")]
     #[account(5, name="spl token program", desc="SPL Token Program")]
     #[account(6, optional, writable, name="collection_metadata", desc="Metadata of the Collection")]
     BurnNft,

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -1693,8 +1693,13 @@ pub fn process_burn_nft(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     }
 
     // Ensure this is a Master Edition and not a Print.
-    let _master_edition = MasterEditionV2::from_account_info(edition_info)
+    let master_edition = MasterEditionV2::from_account_info(edition_info)
         .map_err(|_err: ProgramError| MetadataError::NotAMasterEdition)?;
+
+    // Cannot burn Master Editions with existing prints, for now.
+    if master_edition.supply > 0 {
+        return Err(MetadataError::MasterEditionHasPrints.into());
+    }
 
     // Checks:
     // * Metadata is owned by the token-metadata program

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -1692,6 +1692,10 @@ pub fn process_burn_nft(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
         return Err(MetadataError::MissingCollectionMetadata.into());
     }
 
+    // Ensure this is a Master Edition and not a Print.
+    let _master_edition = MasterEditionV2::from_account_info(edition_info)
+        .map_err(|_err: ProgramError| MetadataError::NotAMasterEdition)?;
+
     // Checks:
     // * Metadata is owned by the token-metadata program
     // * Mint is owned by the spl-token program

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -1684,7 +1684,7 @@ pub fn process_burn_nft(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     let metadata = Metadata::from_account_info(metadata_info)?;
 
     // If the NFT is a verified part of a collection but the user has not provided the collection
-    // metadata account, we cannot burn it because we need to decrement the collection size.
+    // metadata account, we cannot burn it because we need to check if we need to decrement the collection size.
     if !collection_nft_provided
         && metadata.collection.is_some()
         && metadata.collection.as_ref().unwrap().verified
@@ -1693,12 +1693,26 @@ pub fn process_burn_nft(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     }
 
     // Ensure this is a Master Edition and not a Print.
-    let master_edition = MasterEditionV2::from_account_info(edition_info)
-        .map_err(|_err: ProgramError| MetadataError::NotAMasterEdition)?;
 
-    // Cannot burn Master Editions with existing prints, for now.
-    if master_edition.supply > 0 {
-        return Err(MetadataError::MasterEditionHasPrints.into());
+    // Scope this so the borrow gets dropped and doesn't conflict with the mut borrow
+    // later in the handler when overwriting data.
+    {
+        let edition_account_data = edition_info.try_borrow_data()?;
+
+        // First byte is the object key.
+        let key = edition_account_data[0];
+        if key != Key::MasterEditionV1 as u8 && key != Key::MasterEditionV2 as u8 {
+            return Err(MetadataError::NotAMasterEdition.into());
+        }
+
+        // Next eight bytes are the supply, which must be converted to a u64.
+        let supply_bytes = array_ref![edition_account_data, 1, 8];
+        let supply = u64::from_le_bytes(*supply_bytes);
+
+        // Cannot burn Master Editions with existing prints in this handler.
+        if supply > 0 {
+            return Err(MetadataError::MasterEditionHasPrints.into());
+        }
     }
 
     // Checks:
@@ -1791,8 +1805,16 @@ pub fn process_burn_nft(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
         // NFT is actually a verified member of the specified collection.
         assert_verified_member_of_collection(&metadata, &collection_metadata)?;
 
-        // Update collection size.
-        decrement_collection_size(&mut collection_metadata, collection_metadata_info)?;
+        // Update collection size if it's sized.
+        if let Some(ref details) = collection_metadata.collection_details {
+            match details {
+                CollectionDetails::V1 { size } => {
+                    collection_metadata.collection_details =
+                        Some(CollectionDetails::V1 { size: size - 1 });
+                    clean_write_metadata(&mut collection_metadata, collection_metadata_info)?;
+                }
+            }
+        }
     }
 
     Ok(())

--- a/token-metadata/program/tests/burn_nft.rs
+++ b/token-metadata/program/tests/burn_nft.rs
@@ -1,13 +1,10 @@
 #![cfg(feature = "test-bpf")]
 pub mod utils;
 
-use mpl_token_metadata::{error::MetadataError, state::Metadata as ProgramMetadata};
+use mpl_token_metadata::state::Metadata as ProgramMetadata;
 use num_traits::FromPrimitive;
 use solana_program_test::*;
-use solana_sdk::{
-    instruction::InstructionError, signature::Keypair, signer::Signer,
-    transaction::TransactionError,
-};
+use solana_sdk::{instruction::InstructionError, signer::Signer, transaction::TransactionError};
 use utils::*;
 mod burn_nft {
 
@@ -488,153 +485,239 @@ mod burn_nft {
             panic!("CollectionDetails is not set!");
         }
     }
-}
 
-#[tokio::test]
-async fn only_owner_can_burn() {
-    let mut context = program_test().start_with_context().await;
+    #[tokio::test]
+    async fn burn_unsized_collection_item() {
+        let mut context = program_test().start_with_context().await;
 
-    let test_metadata = Metadata::new();
-    test_metadata
-        .create_v2(
+        // Create a Collection Parent NFT without the CollectionDetails struct
+        let collection_parent_nft = Metadata::new();
+        collection_parent_nft
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let parent_master_edition_account = MasterEditionV2::new(&collection_parent_nft);
+        parent_master_edition_account
+            .create_v3(&mut context, Some(0))
+            .await
+            .unwrap();
+
+        let collection = Collection {
+            key: collection_parent_nft.mint.pubkey(),
+            verified: false,
+        };
+
+        let collection_item_nft = Metadata::new();
+        collection_item_nft
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                Some(collection),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let kpbytes = &context.payer;
+        let payer = Keypair::from_bytes(&kpbytes.to_bytes()).unwrap();
+
+        // Verifying collection
+        collection_item_nft
+            .verify_collection(
+                &mut context,
+                collection_parent_nft.pubkey,
+                &payer,
+                collection_parent_nft.mint.pubkey(),
+                parent_master_edition_account.pubkey,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let item_master_edition_account = MasterEditionV2::new(&collection_item_nft);
+        item_master_edition_account
+            .create_v3(&mut context, Some(0))
+            .await
+            .unwrap();
+
+        // Burn the NFT
+        burn(
             &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
-            None,
-            None,
-            None,
+            collection_item_nft.pubkey,
+            &payer,
+            collection_item_nft.mint.pubkey(),
+            collection_item_nft.token.pubkey(),
+            item_master_edition_account.pubkey,
+            Some(collection_parent_nft.pubkey),
         )
         .await
         .unwrap();
+    }
 
-    let master_edition = MasterEditionV2::new(&test_metadata);
-    master_edition
-        .create_v3(&mut context, Some(0))
-        .await
-        .unwrap();
+    #[tokio::test]
+    async fn only_owner_can_burn() {
+        let mut context = program_test().start_with_context().await;
 
-    // Metadata, Master Edition and token account exist.
-    let md_account = context
-        .banks_client
-        .get_account(test_metadata.pubkey)
-        .await
-        .unwrap();
-    let token_account = context
-        .banks_client
-        .get_account(test_metadata.token.pubkey())
-        .await
-        .unwrap();
-    let master_edition_account = context
-        .banks_client
-        .get_account(master_edition.pubkey)
-        .await
-        .unwrap();
+        let test_metadata = Metadata::new();
+        test_metadata
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
 
-    assert!(md_account.is_some());
-    assert!(token_account.is_some());
-    assert!(master_edition_account.is_some());
+        let master_edition = MasterEditionV2::new(&test_metadata);
+        master_edition
+            .create_v3(&mut context, Some(0))
+            .await
+            .unwrap();
 
-    let not_owner = Keypair::new();
-    airdrop(&mut context, &not_owner.pubkey(), 1_000_000_000)
-        .await
-        .unwrap();
+        // Metadata, Master Edition and token account exist.
+        let md_account = context
+            .banks_client
+            .get_account(test_metadata.pubkey)
+            .await
+            .unwrap();
+        let token_account = context
+            .banks_client
+            .get_account(test_metadata.token.pubkey())
+            .await
+            .unwrap();
+        let master_edition_account = context
+            .banks_client
+            .get_account(master_edition.pubkey)
+            .await
+            .unwrap();
 
-    let err = burn(
-        &mut context,
-        test_metadata.pubkey,
-        &not_owner,
-        test_metadata.mint.pubkey(),
-        test_metadata.token.pubkey(),
-        master_edition.pubkey,
-        None,
-    )
-    .await
-    .unwrap_err();
+        assert!(md_account.is_some());
+        assert!(token_account.is_some());
+        assert!(master_edition_account.is_some());
 
-    assert_custom_error!(err, MetadataError::InvalidOwner);
-}
+        let not_owner = Keypair::new();
+        airdrop(&mut context, &not_owner.pubkey(), 1_000_000_000)
+            .await
+            .unwrap();
 
-#[tokio::test]
-async fn update_authority_cannot_burn() {
-    let mut context = program_test().start_with_context().await;
-
-    let name = "Test".to_string();
-    let symbol = "TST".to_string();
-    let uri = "uri".to_string();
-    let creators = None;
-    let seller_fee_basis_points = 10;
-    let is_mutable = true;
-    let freeze_authority = None;
-    let collection = None;
-    let uses = None;
-
-    let test_metadata = Metadata::new();
-    test_metadata
-        .create_v2(
+        let err = burn(
             &mut context,
-            name.clone(),
-            symbol.clone(),
-            uri.clone(),
-            creators.clone(),
-            seller_fee_basis_points,
-            is_mutable,
-            freeze_authority,
-            collection.clone(),
-            uses.clone(),
+            test_metadata.pubkey,
+            &not_owner,
+            test_metadata.mint.pubkey(),
+            test_metadata.token.pubkey(),
+            master_edition.pubkey,
+            None,
         )
         .await
-        .unwrap();
+        .unwrap_err();
 
-    let master_edition = MasterEditionV2::new(&test_metadata);
-    master_edition
-        .create_v3(&mut context, Some(0))
+        assert_custom_error!(err, MetadataError::InvalidOwner);
+    }
+
+    #[tokio::test]
+    async fn update_authority_cannot_burn() {
+        let mut context = program_test().start_with_context().await;
+
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+        let creators = None;
+        let seller_fee_basis_points = 10;
+        let is_mutable = true;
+        let freeze_authority = None;
+        let collection = None;
+        let uses = None;
+
+        let test_metadata = Metadata::new();
+        test_metadata
+            .create_v2(
+                &mut context,
+                name.clone(),
+                symbol.clone(),
+                uri.clone(),
+                creators.clone(),
+                seller_fee_basis_points,
+                is_mutable,
+                freeze_authority,
+                collection.clone(),
+                uses.clone(),
+            )
+            .await
+            .unwrap();
+
+        let master_edition = MasterEditionV2::new(&test_metadata);
+        master_edition
+            .create_v3(&mut context, Some(0))
+            .await
+            .unwrap();
+
+        // Metadata, Master Edition and token account exist.
+        let md_account = context
+            .banks_client
+            .get_account(test_metadata.pubkey)
+            .await
+            .unwrap();
+        let token_account = context
+            .banks_client
+            .get_account(test_metadata.token.pubkey())
+            .await
+            .unwrap();
+        let master_edition_account = context
+            .banks_client
+            .get_account(master_edition.pubkey)
+            .await
+            .unwrap();
+
+        assert!(md_account.is_some());
+        assert!(token_account.is_some());
+        assert!(master_edition_account.is_some());
+
+        // NFT is created with context payer as the update authority so we need to update this first.
+        let new_update_authority = Keypair::new();
+
+        test_metadata
+            .change_update_authority(&mut context, new_update_authority.pubkey())
+            .await
+            .unwrap();
+
+        let err = burn(
+            &mut context,
+            test_metadata.pubkey,
+            &new_update_authority,
+            test_metadata.mint.pubkey(),
+            test_metadata.token.pubkey(),
+            master_edition.pubkey,
+            None,
+        )
         .await
-        .unwrap();
+        .unwrap_err();
 
-    // Metadata, Master Edition and token account exist.
-    let md_account = context
-        .banks_client
-        .get_account(test_metadata.pubkey)
-        .await
-        .unwrap();
-    let token_account = context
-        .banks_client
-        .get_account(test_metadata.token.pubkey())
-        .await
-        .unwrap();
-    let master_edition_account = context
-        .banks_client
-        .get_account(master_edition.pubkey)
-        .await
-        .unwrap();
-
-    assert!(md_account.is_some());
-    assert!(token_account.is_some());
-    assert!(master_edition_account.is_some());
-
-    // NFT is created with context payer as the update authority so we need to update this first.
-    let new_update_authority = Keypair::new();
-
-    test_metadata
-        .change_update_authority(&mut context, new_update_authority.pubkey())
-        .await
-        .unwrap();
-
-    let err = burn(
-        &mut context,
-        test_metadata.pubkey,
-        &new_update_authority,
-        test_metadata.mint.pubkey(),
-        test_metadata.token.pubkey(),
-        master_edition.pubkey,
-        None,
-    )
-    .await
-    .unwrap_err();
-
-    assert_custom_error!(err, MetadataError::InvalidOwner);
+        assert_custom_error!(err, MetadataError::InvalidOwner);
+    }
 }

--- a/token-metadata/program/tests/burn_nft.rs
+++ b/token-metadata/program/tests/burn_nft.rs
@@ -174,7 +174,7 @@ mod burn_nft {
     }
 
     #[tokio::test]
-    async fn successfully_burn_master_edition_with_existing_prints() {
+    async fn fail_to_burn_master_edition_with_existing_prints() {
         let mut context = program_test().start_with_context().await;
 
         let original_nft = Metadata::new();


### PR DESCRIPTION
v1.3.1

Prevents print editions and master editions with a supply > 0 from being burned in `burn_nft` until we decide how to handle burning print editions. (If it's decided to do this it should be in a new handler e.g. `burn_print_nft`). 

Adds two new errors.

Fixes a bug where collection items belonging to unsized collections couldn't be burned.

This changes the TypeScript package slightly by adding two new errors to the IDL and changing some account names and descriptions. 

Some comments and explanations on the changes:

This verbosity 

```rust
    // Ensure this is a Master Edition and not a Print.

    // Scope this so the borrow gets dropped and doesn't conflict with the mut borrow
    // later in the handler when overwriting data.
    {
        let edition_account_data = edition_info.try_borrow_data()?;

        // First byte is the object key.
        let key = edition_account_data[0];
        if key != Key::MasterEditionV1 as u8 && key != Key::MasterEditionV2 as u8 {
            return Err(MetadataError::NotAMasterEdition.into());
        }

        // Next eight bytes are the supply, which must be converted to a u64.
        let supply_bytes = array_ref![edition_account_data, 1, 8];
        let supply = u64::from_le_bytes(*supply_bytes);

        // Cannot burn Master Editions with existing prints in this handler.
        if supply > 0 {
            return Err(MetadataError::MasterEditionHasPrints.into());
        }
    }
```

is to save compute while checking for both versions of `MasterEdition`. If we only have to worry about MasterEditionV2 this can be replaced with:

```rust
let master_edition = MasterEditionV2::from_account_info(edition_info).map_err(|| MetadataError::NotAMasterEdition)?;

if master_edition.supply > 0 {
            return Err(MetadataError::MasterEditionHasPrints.into());
}
```

This function fails if the collection parent is unsized (doesn't have CollectionDetails populated).

```rust
decrement_collection_size(&mut collection_metadata, collection_metadata_info)?;
```

So I pulled the logic out from it to allow decrementing the size but allowing burning anyway if it's unsized. 

I'm not sure how good my error handling is (paging @thlorenz) but I have eight tests for this handler now. Let me know if there's some edge case I'm missing and I can write more tests.