### PR TITLE
refactor(token-metadata): set-collection-size

### DIFF
--- a/token-metadata/Cargo.toml
+++ b/token-metadata/Cargo.toml
@@ -3,3 +3,6 @@ members=[
   "program",
   "cli"
 ]
+
+[profile.release]
+overflow-checks = true

--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -1940,6 +1940,13 @@
           "isMut": false,
           "isSigner": false,
           "desc": "Mint of the Collection"
+        },
+        {
+          "name": "collectionAuthorityRecord",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Collection Authority Record PDA",
+          "optional": true
         }
       ],
       "args": [

--- a/token-metadata/js/src/generated/instructions/SetCollectionSize.ts
+++ b/token-metadata/js/src/generated/instructions/SetCollectionSize.ts
@@ -39,6 +39,7 @@ export const SetCollectionSizeStruct = new beet.BeetArgsStruct<
  * @property [_writable_] collectionMetadata Collection Metadata account
  * @property [_writable_, **signer**] collectionAuthority Collection Update authority
  * @property [] collectionMint Mint of the Collection
+ * @property [] collectionAuthorityRecord (optional) Collection Authority Record PDA
  * @category Instructions
  * @category SetCollectionSize
  * @category generated
@@ -47,6 +48,7 @@ export type SetCollectionSizeInstructionAccounts = {
   collectionMetadata: web3.PublicKey;
   collectionAuthority: web3.PublicKey;
   collectionMint: web3.PublicKey;
+  collectionAuthorityRecord?: web3.PublicKey;
 };
 
 export const setCollectionSizeInstructionDiscriminator = 34;
@@ -65,7 +67,8 @@ export function createSetCollectionSizeInstruction(
   accounts: SetCollectionSizeInstructionAccounts,
   args: SetCollectionSizeInstructionArgs,
 ) {
-  const { collectionMetadata, collectionAuthority, collectionMint } = accounts;
+  const { collectionMetadata, collectionAuthority, collectionMint, collectionAuthorityRecord } =
+    accounts;
 
   const [data] = SetCollectionSizeStruct.serialize({
     instructionDiscriminator: setCollectionSizeInstructionDiscriminator,
@@ -88,6 +91,14 @@ export function createSetCollectionSizeInstruction(
       isSigner: false,
     },
   ];
+
+  if (collectionAuthorityRecord != null) {
+    keys.push({
+      pubkey: collectionAuthorityRecord,
+      isWritable: false,
+      isSigner: false,
+    });
+  }
 
   const ix = new web3.TransactionInstruction({
     programId: new web3.PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -8,6 +8,8 @@ license = "AGPL-3.0"
 edition = "2021"
 readme = "README.md"
 
+[profile.release]
+overflow-checks = true
 
 [features]
 no-entrypoint = []

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -8,9 +8,6 @@ license = "AGPL-3.0"
 edition = "2021"
 readme = "README.md"
 
-[profile.release]
-overflow-checks = true
-
 [features]
 no-entrypoint = []
 test-bpf = []

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -494,7 +494,7 @@ pub enum MetadataInstruction {
 }
 
 /// Creates an CreateMetadataAccounts instruction
-/// #[deprecated(since="1.1.0", note="please use `create_metadata_accounts_v2` instead")]
+/// #[deprecated(since="1.1.0", note="please use `create_metadata_accounts_v3` instead")]
 #[allow(clippy::too_many_arguments)]
 pub fn create_metadata_accounts(
     program_id: Pubkey,
@@ -539,6 +539,7 @@ pub fn create_metadata_accounts(
 
 /// Creates an CreateMetadataAccounts instruction
 #[allow(clippy::too_many_arguments)]
+/// #[deprecated(since="1.3.0", note="please use `create_metadata_accounts_v3` instead")]
 pub fn create_metadata_accounts_v2(
     program_id: Pubkey,
     metadata_account: Pubkey,

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -482,6 +482,7 @@ pub enum MetadataInstruction {
     #[account(0, writable, name="collection_metadata", desc="Collection Metadata account")]
     #[account(1, signer, writable, name="collection_authority", desc="Collection Update authority")]
     #[account(2, name="collection_mint", desc="Mint of the Collection")]
+    #[account(3, optional, name="collection_authority_record", desc="Collection Authority Record PDA")]
     SetCollectionSize(SetCollectionSizeArgs),
 
     /// Set the token standard of the asset.

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -1809,8 +1809,11 @@ pub fn process_burn_nft(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
         if let Some(ref details) = collection_metadata.collection_details {
             match details {
                 CollectionDetails::V1 { size } => {
-                    collection_metadata.collection_details =
-                        Some(CollectionDetails::V1 { size: size - 1 });
+                    collection_metadata.collection_details = Some(CollectionDetails::V1 {
+                        size: size
+                            .checked_sub(1)
+                            .ok_or(MetadataError::NumericalOverflowError)?,
+                    });
                     clean_write_metadata(&mut collection_metadata, collection_metadata_info)?;
                 }
             }
@@ -1869,7 +1872,7 @@ pub fn set_collection_size(
             }
         }
     } else {
-        return Err(MetadataError::NotACollectionParent.into());
+        metadata.collection_details = Some(CollectionDetails::V1 { size });
     }
 
     clean_write_metadata(&mut metadata, parent_nft_metadata_account_info)?;

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -1863,14 +1863,9 @@ pub fn set_collection_size(
         }
     }
 
-    if let Some(details) = metadata.collection_details {
-        match details {
-            CollectionDetails::V1 {
-                size: _current_size,
-            } => {
-                metadata.collection_details = Some(CollectionDetails::V1 { size });
-            }
-        }
+    // Only unsized collections can have the size set, and only once.
+    if metadata.collection_details.is_some() {
+        return Err(MetadataError::SizedCollection.into());
     } else {
         metadata.collection_details = Some(CollectionDetails::V1 { size });
     }

--- a/token-metadata/program/src/utils.rs
+++ b/token-metadata/program/src/utils.rs
@@ -1252,7 +1252,11 @@ pub fn increment_collection_size(
     if let Some(ref details) = metadata.collection_details {
         match details {
             CollectionDetails::V1 { size } => {
-                metadata.collection_details = Some(CollectionDetails::V1 { size: size + 1 });
+                metadata.collection_details = Some(CollectionDetails::V1 {
+                    size: size
+                        .checked_add(1)
+                        .ok_or(MetadataError::NumericalOverflowError)?,
+                });
                 msg!("Clean writing collection parent metadata");
                 clean_write_metadata(metadata, metadata_info)?;
                 Ok(())
@@ -1271,7 +1275,11 @@ pub fn decrement_collection_size(
     if let Some(ref details) = metadata.collection_details {
         match details {
             CollectionDetails::V1 { size } => {
-                metadata.collection_details = Some(CollectionDetails::V1 { size: size - 1 });
+                metadata.collection_details = Some(CollectionDetails::V1 {
+                    size: size
+                        .checked_sub(1)
+                        .ok_or(MetadataError::NumericalOverflowError)?,
+                });
                 clean_write_metadata(metadata, metadata_info)?;
                 Ok(())
             }


### PR DESCRIPTION
A few more changes to be included in v1.3.1:

* ~~Set Collection Size allows setting size for both Some and None variants of the collection_details field~~.
* Add overflow checks to release profile in Cargo.toml
* Add optional account to Shank annotations for Set Collection SIze
* Perform checked addition and subtraction for collection size math
* Regenerate the JS SDK

Pivot:

There are attacks possible with allowing `set-collection-size` to always update the size. Instead, it's going to only allow unsized collection Parents to be set (If the collection details is not populated or set to `None`).  This means a collection size can only be set once, after that a new collection has to be created and the items migrated over. This is annoying for users who mess up but makes it so the on-chain size can actually be trusted once it's set correctly.