### PR TITLE
Make changes label more specific to each package workflow

### DIFF
--- a/.github/workflows/integration-fixed-price-sale.yml
+++ b/.github/workflows/integration-fixed-price-sale.yml
@@ -12,7 +12,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  fixed-price-sale-integration-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       cache_id: program-fixed-price-sale
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
+    needs: fixed-price-sale-integration-changes
+    if: ${{ needs.fixed-price-sale-integration-changes.outputs.core == 'true' || needs.fixed-price-sale-integration-changes.outputs.package == 'true' || needs.fixed-price-sale-integration-changes.outputs.workflow == 'true' }}
     steps:
       # Setup Deps
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-metaplex.yml
+++ b/.github/workflows/integration-metaplex.yml
@@ -12,7 +12,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  metaplex-integration-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       cache_id: program-metaplex 
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: metaplex-integration-changes
+    if: ${{ needs.metaplex-integration-changes.outputs.core == 'true' || needs.metaplex-integration-changes.outputs.package == 'true' }}
     steps:
       # Setup Deps
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-token-vault.yml
+++ b/.github/workflows/integration-token-vault.yml
@@ -12,7 +12,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  token-vault-integration-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       cache_id: program-token-vault 
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
+    needs: token-vault-integration-changes
+    if: ${{ needs.token-vault-integration-changes.outputs.core == 'true' || needs.token-vault-integration-changes.outputs.package == 'true' || needs.token-vault-integration-changes.outputs.workflow == 'true' }}
     steps:
       # Setup Deps
       - uses: actions/checkout@v2

--- a/.github/workflows/program-auction-house.yml
+++ b/.github/workflows/program-auction-house.yml
@@ -17,7 +17,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  auction-house-program-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -36,8 +36,8 @@ jobs:
               - 'auction-house/**'
 
   build-and-test-auction-house-stable:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: auction-house-program-changes
+    if: ${{ needs.auction-house-program-changes.outputs.core == 'true' || needs.auction-house-program-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-auction-house
@@ -84,8 +84,8 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
 
   build-and-test-auction-house-unstable:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: auction-house-program-changes
+    if: ${{ needs.auction-house-program-changes.outputs.core == 'true' || needs.auction-house-program-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-auction-house
@@ -132,8 +132,8 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
 
   upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    needs: auction-house-program-changes
+    if: ${{ (needs.auction-house-program-changes.outputs.core == 'true' || needs.auction-house-program-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-auction-house

--- a/.github/workflows/program-auction.yml
+++ b/.github/workflows/program-auction.yml
@@ -16,7 +16,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  auction-program-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -34,8 +34,8 @@ jobs:
             package:
               - 'auction/**'
   build-and-test-auction:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: auction-program-changes
+    if: ${{ needs.auction-program-changes.outputs.core == 'true' || needs.auction-program-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-auction
@@ -74,8 +74,8 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
 
   upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    needs: auction-program-changes
+    if: ${{ (needs.auction-program-changes.outputs.core == 'true' || needs.auction-program-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-auction

--- a/.github/workflows/program-candy-machine.yml
+++ b/.github/workflows/program-candy-machine.yml
@@ -16,7 +16,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  candy-machine-program-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -34,8 +34,8 @@ jobs:
           package:
             - 'candy-machine/**'
   build-and-test-candy-machine:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: candy-machine-program-changes
+    if: ${{ needs.candy-machine-program-changes.outputs.core == 'true' || needs.candy-machine-program-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-candy-machine
@@ -80,8 +80,8 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
 
   upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    needs: candy-machine-program-changes
+    if: ${{ (needs.candy-machine-program-changes.outputs.core == 'true' || needs.candy-machine-program-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-candy-machine

--- a/.github/workflows/program-fixed-price-sale.yml
+++ b/.github/workflows/program-fixed-price-sale.yml
@@ -15,7 +15,7 @@ env:
   SOLANA_VERSION: 1.9.22
   RUST_TOOLCHAIN: stable
 jobs:
-  changes:
+  fixed-price-sale-program-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -36,8 +36,8 @@ jobs:
             workflow:
               - '.github/workflows/program-fixed-price-sale.yml'
   build-and-test-fixed-price-sale:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
+    needs: fixed-price-sale-program-changes
+    if: ${{ needs.fixed-price-sale-program-changes.outputs.core == 'true' || needs.fixed-price-sale-program-changes.outputs.package == 'true' || needs.fixed-price-sale-program-changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-fixed-price-sale
@@ -74,8 +74,8 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --test-threads 1
 
   upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    needs: fixed-price-sale-program-changes
+    if: ${{ (needs.fixed-price-sale-program-changes.outputs.core == 'true' || needs.fixed-price-sale-program-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-fixed-price-sale

--- a/.github/workflows/program-gumdrop.yml
+++ b/.github/workflows/program-gumdrop.yml
@@ -16,7 +16,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  gumdrop-program-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -34,8 +34,8 @@ jobs:
           package:
             - 'gumdrop/**'
   build-and-test-gumdrop:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: gumdrop-program-changes
+    if: ${{ needs.gumdrop-program-changes.outputs.core == 'true' || needs.gumdrop-program-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-gumdrop
@@ -75,8 +75,8 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
 
   upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    needs: gumdrop-program-changes
+    if: ${{ (needs.gumdrop-program-changes.outputs.core == 'true' || needs.gumdrop-program-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-gumdrop

--- a/.github/workflows/program-metaplex.yml
+++ b/.github/workflows/program-metaplex.yml
@@ -16,7 +16,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  metaplex-program-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -36,8 +36,8 @@ jobs:
             - 'metaplex/**'
 
   build-and-test-metaplex:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: metaplex-program-changes
+    if: ${{ needs.metaplex-program-changes.outputs.core == 'true' || needs.metaplex-program-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-metaplex 
@@ -74,8 +74,8 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
 
   upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    needs: metaplex-program-changes
+    if: ${{ (needs.metaplex-program-changes.outputs.core == 'true' || needs.metaplex-program-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-metaplex

--- a/.github/workflows/program-nft-packs.yml
+++ b/.github/workflows/program-nft-packs.yml
@@ -15,7 +15,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  nft-packs-program-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -34,8 +34,8 @@ jobs:
             - 'nft-packs/**'
 
   build-and-test-nft-packs:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: nft-packs-program-changes
+    if: ${{ needs.nft-packs-program-changes.outputs.core == 'true' || needs.nft-packs-program-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-nft-packs 
@@ -74,8 +74,8 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
 
   upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    needs: nft-packs-program-changes
+    if: ${{ (needs.nft-packs-program-changes.outputs.core == 'true' || needs.nft-packs-program-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-nft-packs

--- a/.github/workflows/program-token-entangler.yml
+++ b/.github/workflows/program-token-entangler.yml
@@ -16,7 +16,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  token-entangler-program-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -35,8 +35,8 @@ jobs:
               - 'token-entangler/**'
 
   build-and-test-token-entangler:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: token-entangler-program-changes
+    if: ${{ needs.token-entangler-program-changes.outputs.core == 'true' || needs.token-entangler-program-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-token-entangler
@@ -79,8 +79,8 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
 
   upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    needs: token-entangler-program-changes
+    if: ${{ (needs.token-entangler-program-changes.outputs.core == 'true' || needs.token-entangler-program-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-token-entangler

--- a/.github/workflows/program-token-metadata.yml
+++ b/.github/workflows/program-token-metadata.yml
@@ -16,7 +16,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  token-metadata-program-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -35,8 +35,8 @@ jobs:
               - 'token-metadata/**'
 
   build-and-test-token-metadata:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: token-metadata-program-changes
+    if: ${{ needs.token-metadata-program-changes.outputs.core == 'true' || needs.token-metadata-program-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-token-metadata
@@ -83,8 +83,8 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
 
   upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    needs: token-metadata-program-changes
+    if: ${{ (needs.token-metadata-program-changes.outputs.core == 'true' || needs.token-metadata-program-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-token-metadata

--- a/.github/workflows/program-token-vault.yml
+++ b/.github/workflows/program-token-vault.yml
@@ -16,7 +16,7 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
-  changes:
+  token-vault-program-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -34,8 +34,8 @@ jobs:
           package:
             - 'token-vault/**'
   build-and-test-token-vault:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: token-vault-program-changes
+    if: ${{ needs.token-vault-program-changes.outputs.core == 'true' || needs.token-vault-program-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-token-vault 
@@ -72,8 +72,8 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
 
   upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+    needs: token-vault-program-changes
+    if: ${{ (needs.token-vault-program-changes.outputs.core == 'true' || needs.token-vault-program-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-token-vault

--- a/.github/workflows/sdk-auction-house.yml
+++ b/.github/workflows/sdk-auction-house.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  changes:
+  auction-house-sdk-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -30,8 +30,8 @@ jobs:
             - 'auction-house/**'
 
   build-lint-and-test-auction-house:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: auction-house-sdk-changes
+    if: ${{ needs.auction-house-sdk-changes.outputs.core == 'true' || needs.auction-house-sdk-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -43,9 +43,9 @@ jobs:
           skip_test: true
 
   upgrade-version-and-publish-binary:
-    needs: changes
+    needs: auction-house-sdk-changes
     if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+      ${{ (needs.auction-house-sdk-changes.outputs.core == 'true' || needs.auction-house-sdk-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-auction-house

--- a/.github/workflows/sdk-auction.yml
+++ b/.github/workflows/sdk-auction.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  changes:
+  auction-sdk-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -30,8 +30,8 @@ jobs:
             - 'auction/**'
 
   build-lint-and-test-auction:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: auction-sdk-changes
+    if: ${{ needs.auction-sdk-changes.outputs.core == 'true' || needs.auction-sdk-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -42,9 +42,9 @@ jobs:
           working_dir: ./auction/js
 
   upgrade-version-and-publish-binary:
-    needs: changes
+    needs: auction-sdk-changes
     if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+      ${{ (needs.auction-sdk-changes.outputs.core == 'true' || needs.auction-sdk-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-auction

--- a/.github/workflows/sdk-candy-machine.yml
+++ b/.github/workflows/sdk-candy-machine.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  changes:
+  candy-machine-sdk-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -30,8 +30,8 @@ jobs:
             - 'candy-machine/**'
 
   build-lint-and-test-candy-machine:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: candy-machine-sdk-changes
+    if: ${{ needs.candy-machine-sdk-changes.outputs.core == 'true' || needs.candy-machine-sdk-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -42,9 +42,9 @@ jobs:
           working_dir: ./candy-machine/js
 
   upgrade-version-and-publish-binary:
-    needs: changes
+    needs: candy-machine-sdk-changes
     if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+      ${{ (needs.candy-machine-sdk-changes.outputs.core == 'true' || needs.candy-machine-sdk-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-candy-machine

--- a/.github/workflows/sdk-core.yml
+++ b/.github/workflows/sdk-core.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  changes:
+  core-sdk-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -27,8 +27,8 @@ jobs:
             - 'core/**'
 
   build-lint-and-test-core:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' }}
+    needs: core-sdk-changes
+    if: ${{ needs.core-sdk-changes.outputs.core == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -40,9 +40,9 @@ jobs:
           build_core: false
 
   upgrade-version-and-publish-binary:
-    needs: changes
+    needs: core-sdk-changes
     if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+      ${{ (needs.core-sdk-changes.outputs.core == 'true' || needs.core-sdk-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-core

--- a/.github/workflows/sdk-fixed-price-sale.yml
+++ b/.github/workflows/sdk-fixed-price-sale.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  changes:
+  fixed-price-sale-sdk-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -30,8 +30,8 @@ jobs:
               - 'fixed-price-sale/**'
 
   build-lint-and-test-fixed-price-sale:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: fixed-price-sale-sdk-changes
+    if: ${{ needs.fixed-price-sale-sdk-changes.outputs.core == 'true' || needs.fixed-price-sale-sdk-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -44,9 +44,9 @@ jobs:
           skip_test: true
 
   upgrade-version-and-publish-binary:
-    needs: changes
+    needs: fixed-price-sale-sdk-changes
     if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+      ${{ (needs.fixed-price-sale-sdk-changes.outputs.core == 'true' || needs.fixed-price-sale-sdk-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-fixed-price-sale

--- a/.github/workflows/sdk-gumdrop.yml
+++ b/.github/workflows/sdk-gumdrop.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  changes:
+  gumdrop-sdk-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -30,8 +30,8 @@ jobs:
             - 'gumdrop/**'
 
   build-lint-and-test-gumdrop:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: gumdrop-sdk-changes
+    if: ${{ needs.gumdrop-sdk-changes.outputs.core == 'true' || needs.gumdrop-sdk-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -43,9 +43,9 @@ jobs:
           build_token_metadata: true
 
   upgrade-version-and-publish-binary:
-    needs: changes
+    needs: gumdrop-sdk-changes
     if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+      ${{ (needs.gumdrop-sdk-changes.outputs.core == 'true' || needs.gumdrop-sdk-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-gumdrop

--- a/.github/workflows/sdk-metaplex.yml
+++ b/.github/workflows/sdk-metaplex.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  changes:
+  metaplex-sdk-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -29,8 +29,8 @@ jobs:
           package:
             - 'metaplex/**'
   build-lint-and-test-metaplex:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: metaplex-sdk-changes
+    if: ${{ needs.metaplex-sdk-changes.outputs.core == 'true' || needs.metaplex-sdk-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -45,9 +45,9 @@ jobs:
           skip_test: true
 
   upgrade-version-and-publish-binary:
-    needs: changes
+    needs: metaplex-sdk-changes
     if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+      ${{ (needs.metaplex-sdk-changes.outputs.core == 'true' || needs.metaplex-sdk-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-metaplex

--- a/.github/workflows/sdk-token-entangler.yml
+++ b/.github/workflows/sdk-token-entangler.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  changes:
+  token-entangler-sdk-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -30,8 +30,8 @@ jobs:
             - 'token-entangler/**'
 
   build-lint-and-test-token-entangler:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: token-entangler-sdk-changes
+    if: ${{ needs.token-entangler-sdk-changes.outputs.core == 'true' || needs.token-entangler-sdk-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -43,9 +43,9 @@ jobs:
           build_token_metadata: true
 
   upgrade-version-and-publish-binary:
-    needs: changes
+    needs: token-entangler-sdk-changes
     if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+      ${{ (needs.token-entangler-sdk-changes.outputs.core == 'true' || needs.token-entangler-sdk-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-token-entangler

--- a/.github/workflows/sdk-token-metadata.yml
+++ b/.github/workflows/sdk-token-metadata.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  changes:
+  token-metadata-sdk-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -30,8 +30,8 @@ jobs:
             - 'token-metadata/**'
 
   build-lint-and-test-token-metadata:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    needs: token-metadata-sdk-changes
+    if: ${{ needs.token-metadata-sdk-changes.outputs.core == 'true' || needs.token-metadata-sdk-changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -43,9 +43,9 @@ jobs:
           skip_test: false
 
   upgrade-version-and-publish-binary:
-    needs: changes
+    needs: token-metadata-sdk-changes
     if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+      ${{ (needs.token-metadata-sdk-changes.outputs.core == 'true' || needs.token-metadata-sdk-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-token-metadata

--- a/.github/workflows/sdk-token-vault.yml
+++ b/.github/workflows/sdk-token-vault.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  changes:
+  token-vault-sdk-changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -32,8 +32,8 @@ jobs:
           workflow:
             - '.github/workflows/sdk-token-vault.yml'
   build-lint-and-test-token-vault:
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
+    needs: token-vault-sdk-changes
+    if: ${{ needs.token-vault-sdk-changes.outputs.core == 'true' || needs.token-vault-sdk-changes.outputs.package == 'true' || needs.token-vault-sdk-changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -46,9 +46,9 @@ jobs:
 
 
   upgrade-version-and-publish-binary:
-    needs: changes
+    needs: token-vault-sdk-changes
     if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
+      ${{ (needs.token-vault-sdk-changes.outputs.core == 'true' || needs.token-vault-sdk-changes.outputs.package == 'true') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
       cache_id: program-token-vault


### PR DESCRIPTION
@thlorenz pointed out that the `changes` label in all workflows is the same, making it hard to differentiate between packages (image below). This PR proposes a change to update labels from `changes` to a package and workflow specific, e.g. `<package>-<scope>-changes`.

Specifically, in `./github/workflows/sdk-token-metadata.yml`, `changes` is now `token-metadata-sdk-changes`.

![image](https://user-images.githubusercontent.com/10272973/175386486-26aa8864-5286-4a9c-a065-ed0ec8ddf72d.png)
