### PR TITLE
Remove versioning actions from rust and sdk workflows

### DIFF
--- a/.github/workflows/program-auction-house.yml
+++ b/.github/workflows/program-auction-house.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION_STABLE: 1.9.22
@@ -130,36 +126,3 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-auction-house
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to Crates and Github
-        uses: ./.github/actions/publish-to-crates
-        id: publish-to-crates
-        with:
-          cargo-token: ${{ secrets.CARGO_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: auction-house
-          path-to-cargo: ./auction-house/program/Cargo.toml
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}
-
-      - uses: ./.github/actions/setup-aws-env/
-      - name: Build and upload
-        uses: ./.github/actions/build-and-upload/
-        id: upload-binary-metadata
-        with:
-          # based on Cargo.toml package name
-          program-binary: mpl_auction_house.so
-          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
-          region: ${{ env.BINARY_STORAGE_REGION }}
-          role: ${{ env.BINARY_STORAGE_ROLE }}
-          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
-          prefix: auction-house

--- a/.github/workflows/program-auction.yml
+++ b/.github/workflows/program-auction.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.15
@@ -72,36 +68,3 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-auction
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to Crates and Github
-        uses: ./.github/actions/publish-to-crates
-        id: publish-to-crates
-        with:
-          cargo-token: ${{ secrets.CARGO_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: auction
-          path-to-cargo: ./auction/program/Cargo.toml
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}
-
-      - uses: ./.github/actions/setup-aws-env/
-      - name: Build and upload
-        uses: ./.github/actions/build-and-upload/
-        id: upload-binary-metadata
-        with:
-          # based on Cargo.toml package name
-          program-binary: mpl_auction.so
-          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
-          region: ${{ env.BINARY_STORAGE_REGION }}
-          role: ${{ env.BINARY_STORAGE_ROLE }}
-          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
-          prefix: auction

--- a/.github/workflows/program-candy-machine.yml
+++ b/.github/workflows/program-candy-machine.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.18
@@ -78,36 +74,3 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-candy-machine
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to Crates and Github
-        uses: ./.github/actions/publish-to-crates
-        id: publish-to-crates
-        with:
-          cargo-token: ${{ secrets.CARGO_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: candy-machine
-          path-to-cargo: ./candy-machine/program/Cargo.toml
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}
-
-      - uses: ./.github/actions/setup-aws-env/
-      - name: Build and upload
-        uses: ./.github/actions/build-and-upload/
-        id: upload-binary-metadata
-        with:
-          # based on Cargo.toml package name
-          program-binary: mpl_candy_machine.so
-          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
-          region: ${{ env.BINARY_STORAGE_REGION }}
-          role: ${{ env.BINARY_STORAGE_ROLE }}
-          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
-          prefix: candy-machine

--- a/.github/workflows/program-fixed-price-sale.yml
+++ b/.github/workflows/program-fixed-price-sale.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.22
@@ -72,35 +68,3 @@ jobs:
         working-directory: ./fixed-price-sale/program
         run: |
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --test-threads 1
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-fixed-price-sale
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to Crates and Github
-        uses: ./.github/actions/publish-to-crates
-        id: publish-to-crates
-        with:
-          cargo-token: ${{ secrets.CARGO_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: fixed-price-sale
-          path-to-cargo: ./fixed-price-sale/program/Cargo.toml
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}
-
-      - uses: ./.github/actions/setup-aws-env/
-      - name: Build and upload
-        uses: ./.github/actions/build-and-upload/
-        id: upload-binary-metadata
-        with:
-          program-binary: mpl_fixed_price_sale.so
-          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
-          region: ${{ env.BINARY_STORAGE_REGION }}
-          role: ${{ env.BINARY_STORAGE_ROLE }}
-          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
-          prefix: fixed-price-sale

--- a/.github/workflows/program-gumdrop.yml
+++ b/.github/workflows/program-gumdrop.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.14
@@ -73,36 +69,3 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-gumdrop
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to Crates and Github
-        uses: ./.github/actions/publish-to-crates
-        id: publish-to-crates
-        with:
-          cargo-token: ${{ secrets.CARGO_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: gumdrop
-          path-to-cargo: ./gumdrop/program/Cargo.toml
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}
-
-      - uses: ./.github/actions/setup-aws-env/
-      - name: Build and upload
-        uses: ./.github/actions/build-and-upload/
-        id: upload-binary-metadata
-        with:
-          # based on Cargo.toml package name
-          program-binary: mpl_gumdrop.so
-          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
-          region: ${{ env.BINARY_STORAGE_REGION }}
-          role: ${{ env.BINARY_STORAGE_ROLE }}
-          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
-          prefix: gumdrop

--- a/.github/workflows/program-metaplex.yml
+++ b/.github/workflows/program-metaplex.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.14
@@ -72,36 +68,3 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-metaplex
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to Crates and Github
-        uses: ./.github/actions/publish-to-crates
-        id: publish-to-crates
-        with:
-          cargo-token: ${{ secrets.CARGO_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: metaplex
-          path-to-cargo: ./metaplex/program/Cargo.toml
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}
-
-      - uses: ./.github/actions/setup-aws-env/
-      - name: Build and upload
-        uses: ./.github/actions/build-and-upload/
-        id: upload-binary-metadata
-        with:
-          # based on Cargo.toml package name
-          program-binary: mpl_metaplex.so
-          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
-          region: ${{ env.BINARY_STORAGE_REGION }}
-          role: ${{ env.BINARY_STORAGE_ROLE }}
-          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
-          prefix: metaplex

--- a/.github/workflows/program-nft-packs.yml
+++ b/.github/workflows/program-nft-packs.yml
@@ -5,9 +5,6 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-permissions:
-  id-token: write
-  contents: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -72,36 +69,3 @@ jobs:
         run: |
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-nft-packs
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to Crates and Github
-        uses: ./.github/actions/publish-to-crates
-        id: publish-to-crates
-        with:
-          cargo-token: ${{ secrets.CARGO_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: nft-packs
-          path-to-cargo: ./nft-packs/program/Cargo.toml
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}
-
-      - uses: ./.github/actions/setup-aws-env/
-      - name: Build and upload
-        uses: ./.github/actions/build-and-upload/
-        id: upload-binary-metadata
-        with:
-          # based on Cargo.toml package name
-          program-binary: mpl_nft_packs.so
-          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
-          region: ${{ env.BINARY_STORAGE_REGION }}
-          role: ${{ env.BINARY_STORAGE_ROLE }}
-          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
-          prefix: nft-packs

--- a/.github/workflows/program-token-entangler.yml
+++ b/.github/workflows/program-token-entangler.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.15
@@ -77,36 +73,3 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-token-entangler
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to Crates and Github
-        uses: ./.github/actions/publish-to-crates
-        id: publish-to-crates
-        with:
-          cargo-token: ${{ secrets.CARGO_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: token-entangler
-          path-to-cargo: ./token-entangler/program/Cargo.toml
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}
-
-      - uses: ./.github/actions/setup-aws-env/
-      - name: Build and upload
-        uses: ./.github/actions/build-and-upload/
-        id: upload-binary-metadata
-        with:
-          # based on Cargo.toml package name
-          program-binary: mpl_token_entangler.so
-          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
-          region: ${{ env.BINARY_STORAGE_REGION }}
-          role: ${{ env.BINARY_STORAGE_ROLE }}
-          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
-          prefix: token-entangler

--- a/.github/workflows/program-token-metadata.yml
+++ b/.github/workflows/program-token-metadata.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.22
@@ -81,36 +77,3 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-token-metadata
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to Crates and Github
-        uses: ./.github/actions/publish-to-crates
-        id: publish-to-crates
-        with:
-          cargo-token: ${{ secrets.CARGO_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: token-metadata
-          path-to-cargo: ./token-metadata/program/Cargo.toml
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}
-
-      - uses: ./.github/actions/setup-aws-env/
-      - name: Build and upload
-        uses: ./.github/actions/build-and-upload/
-        id: upload-binary-metadata
-        with:
-          # based on Cargo.toml package name
-          program-binary: mpl_token_metadata.so
-          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
-          region: ${{ env.BINARY_STORAGE_REGION }}
-          role: ${{ env.BINARY_STORAGE_ROLE }}
-          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
-          prefix: token-metadata

--- a/.github/workflows/program-token-vault.yml
+++ b/.github/workflows/program-token-vault.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: 1.9.14
@@ -70,36 +66,3 @@ jobs:
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf -- --nocapture --test-threads 1
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if: ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-token-vault
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to Crates and Github
-        uses: ./.github/actions/publish-to-crates
-        id: publish-to-crates
-        with:
-          cargo-token: ${{ secrets.CARGO_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: token-vault
-          path-to-cargo: ./token-vault/program/Cargo.toml
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}
-
-      - uses: ./.github/actions/setup-aws-env/
-      - name: Build and upload
-        uses: ./.github/actions/build-and-upload/
-        id: upload-binary-metadata
-        with:
-          # based on Cargo.toml package name
-          program-binary: mpl_token_vault.so
-          account-id: ${{ env.BINARY_STORAGE_ACCOUNT_ID }}
-          region: ${{ env.BINARY_STORAGE_REGION }}
-          role: ${{ env.BINARY_STORAGE_ROLE }}
-          bucket: ${{ env.BINARY_STORAGE_BUCKET }}
-          prefix: token-vault

--- a/.github/workflows/sdk-auction-house.yml
+++ b/.github/workflows/sdk-auction-house.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -41,23 +37,3 @@ jobs:
           cache_id: sdk-auction-house
           working_dir: ./auction-house/js
           skip_test: true
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-auction-house
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to NPM and Github
-        uses: ./.github/actions/publish-to-npm
-        id: publish-to-npm
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-package-dir: ./auction-house/js
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-auction.yml
+++ b/.github/workflows/sdk-auction.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -40,23 +36,3 @@ jobs:
         with: 
           cache_id: sdk-auction  
           working_dir: ./auction/js
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-auction
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to NPM and Github
-        uses: ./.github/actions/publish-to-npm
-        id: publish-to-npm
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-package-dir: ./auction/js
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-candy-machine.yml
+++ b/.github/workflows/sdk-candy-machine.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -40,23 +36,3 @@ jobs:
         with: 
           cache_id: sdk-candy-machine
           working_dir: ./candy-machine/js
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-candy-machine
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to NPM and Github
-        uses: ./.github/actions/publish-to-npm
-        id: publish-to-npm
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-package-dir: ./candy-machine/js
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-core.yml
+++ b/.github/workflows/sdk-core.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -38,23 +34,3 @@ jobs:
           cache_id: sdk-core  
           working_dir: ./core/js
           build_core: false
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-core
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to NPM and Github
-        uses: ./.github/actions/publish-to-npm
-        id: publish-to-npm
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-package-dir: ./core/js
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-fixed-price-sale.yml
+++ b/.github/workflows/sdk-fixed-price-sale.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -42,23 +38,3 @@ jobs:
           working_dir: ./fixed-price-sale/js
           build_token_metadata: true
           skip_test: true
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-fixed-price-sale
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to NPM and Github
-        uses: ./.github/actions/publish-to-npm
-        id: publish-to-npm
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-package-dir: ./fixed-price-sale/js
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-gumdrop.yml
+++ b/.github/workflows/sdk-gumdrop.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -41,23 +37,3 @@ jobs:
           cache_id: sdk-gumdrop
           working_dir: ./gumdrop/js
           build_token_metadata: true
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-gumdrop
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to NPM and Github
-        uses: ./.github/actions/publish-to-npm
-        id: publish-to-npm
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-package-dir: ./gumdrop/js
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-metaplex.yml
+++ b/.github/workflows/sdk-metaplex.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -43,23 +39,3 @@ jobs:
           build_token_vault: true
           build_token_metadata: true
           skip_test: true
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-metaplex
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to NPM and Github
-        uses: ./.github/actions/publish-to-npm
-        id: publish-to-npm
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-package-dir: ./metaplex/js
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-token-entangler.yml
+++ b/.github/workflows/sdk-token-entangler.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -41,23 +37,3 @@ jobs:
           cache_id: sdk-token-entangler
           working_dir: ./token-entangler/js
           build_token_metadata: true
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-token-entangler
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to NPM and Github
-        uses: ./.github/actions/publish-to-npm
-        id: publish-to-npm
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-package-dir: ./token-entangler/js
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-token-metadata.yml
+++ b/.github/workflows/sdk-token-metadata.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -41,23 +37,3 @@ jobs:
           cache_id: sdk-token-metadata
           working_dir: ./token-metadata/js
           skip_test: false
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-token-metadata
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to NPM and Github
-        uses: ./.github/actions/publish-to-npm
-        id: publish-to-npm
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-package-dir: ./token-metadata/js
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/sdk-token-vault.yml
+++ b/.github/workflows/sdk-token-vault.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  id-token: write
-  contents: write
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -43,24 +39,3 @@ jobs:
           cache_id: sdk-token-vault
           working_dir: ./token-vault/js
           skip_test: true
-
-
-  upgrade-version-and-publish-binary:
-    needs: changes
-    if:
-      ${{ (needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-token-vault
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish updated artifacts to NPM and Github
-        uses: ./.github/actions/publish-to-npm
-        id: publish-to-npm
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-package-dir: ./token-vault/js
-          commit-sha: ${{ github.sha }}
-          branch: ${{ github.ref }}


### PR DESCRIPTION
I recently discovered that `master` is push protected and that a GH action cannot (force) push a change - sources below. 

Thus, all workflows I added in PR #540 will not work since they try to push to master. This change removes the versioning actions from those workflows to prevent further failed workflows while I figure out a new approach.

I only removed lines that I previously added in #540, which are related to permissions and version/build actions.

Sources: 
https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101
https://github.community/t/allowing-github-actions-bot-to-push-to-protected-branch/16536
