### PR TITLE
fix: for anchor-client 0.24 works well

### DIFF
--- a/candy-machine/program/src/processor/collection/remove_collection.rs
+++ b/candy-machine/program/src/processor/collection/remove_collection.rs
@@ -4,7 +4,7 @@ use solana_program::program::invoke;
 
 use crate::{
     cmp_pubkeys, constants::COLLECTIONS_FEATURE_INDEX, remove_feature_flag, CandyError,
-    CandyMachine, CollectionPDA,
+    CandyMachine, CollectionPda,
 };
 
 /// Set the collection PDA for the candy machine
@@ -14,7 +14,7 @@ pub struct RemoveCollection<'info> {
     candy_machine: Account<'info, CandyMachine>,
     authority: Signer<'info>,
     #[account(mut, seeds = [b"collection".as_ref(), candy_machine.to_account_info().key.as_ref()], bump, close=authority)]
-    collection_pda: Account<'info, CollectionPDA>,
+    collection_pda: Account<'info, CollectionPda>,
     /// CHECK: account checked in CPI
     metadata: UncheckedAccount<'info>,
     /// CHECK: account checked in CPI

--- a/candy-machine/program/src/processor/collection/set_collection.rs
+++ b/candy-machine/program/src/processor/collection/set_collection.rs
@@ -8,7 +8,7 @@ use solana_program::program::invoke;
 use crate::{
     cmp_pubkeys,
     constants::{COLLECTIONS_FEATURE_INDEX, COLLECTION_PDA_SIZE},
-    set_feature_flag, CandyError, CandyMachine, CollectionPDA,
+    set_feature_flag, CandyError, CandyMachine, CollectionPda,
 };
 
 /// Set the collection PDA for the candy machine
@@ -106,7 +106,7 @@ pub fn handle_set_collection(ctx: Context<SetCollection>) -> Result<()> {
         )?;
     }
     let mut data_ref: &mut [u8] = &mut ctx.accounts.collection_pda.try_borrow_mut_data()?;
-    let mut collection_pda_object: CollectionPDA = AnchorDeserialize::deserialize(&mut &*data_ref)?;
+    let mut collection_pda_object: CollectionPda = AnchorDeserialize::deserialize(&mut &*data_ref)?;
     collection_pda_object.mint = mint.key();
     collection_pda_object.candy_machine = candy_machine.key();
     collection_pda_object.try_serialize(&mut data_ref)?;

--- a/candy-machine/program/src/processor/collection/set_collection_during_mint.rs
+++ b/candy-machine/program/src/processor/collection/set_collection_during_mint.rs
@@ -4,7 +4,7 @@ use solana_program::{
     program::invoke_signed, sysvar, sysvar::instructions::get_instruction_relative,
 };
 
-use crate::{cmp_pubkeys, CandyMachine, CollectionPDA};
+use crate::{cmp_pubkeys, CandyMachine, CollectionPda};
 
 /// Sets and verifies the collection during a candy machine mint
 #[derive(Accounts)]
@@ -15,7 +15,7 @@ pub struct SetCollectionDuringMint<'info> {
     metadata: UncheckedAccount<'info>,
     payer: Signer<'info>,
     #[account(mut, seeds = [b"collection".as_ref(), candy_machine.to_account_info().key.as_ref()], bump)]
-    collection_pda: Account<'info, CollectionPDA>,
+    collection_pda: Account<'info, CollectionPda>,
     /// CHECK: account constraints checked in account trait
     #[account(address = mpl_token_metadata::id())]
     token_metadata_program: UncheckedAccount<'info>,

--- a/candy-machine/program/src/state.rs
+++ b/candy-machine/program/src/state.rs
@@ -18,7 +18,7 @@ pub struct CandyMachine {
 /// Collection PDA account
 #[account]
 #[derive(Default, Debug)]
-pub struct CollectionPDA {
+pub struct CollectionPda {
     pub mint: Pubkey,
     pub candy_machine: Pubkey,
 }


### PR DESCRIPTION
with anchor 0.24，decode/encode check the account name，and its `camelcase(name, { pascalCase: true })`

https://github.com/coral-xyz/anchor/blob/master/ts/src/coder/borsh/accounts.ts#L45-L64
https://github.com/coral-xyz/anchor/blob/master/ts/src/coder/borsh/accounts.ts#L97-L100