### PR TITLE
build: append version to pr flow

### DIFF
--- a/.github/actions/install-anchor/action.yml
+++ b/.github/actions/install-anchor/action.yml
@@ -1,12 +1,12 @@
 name: Setup Anchor CLI
-description: 'Setup Anchor VLI'
+description: 'Setup Anchor CLI'
 
 runs:
   using: 'composite'
   steps:
     - uses: actions/cache@v2
       name: Cache Anchor CLI
-      id: cache-anchor
+      id: cache-anchor-cli
       with:
         path: |
           ~/.cargo/bin/
@@ -16,7 +16,6 @@ runs:
           ./target/
         key: anchor-cli-${{ runner.os }}-v0000-${{ env.ANCHOR_VERSION }}
     - run:
-        cargo install --git https://github.com/project-serum/anchor --tag "v$ANCHOR_VERSION"
-        anchor-cli --locked
+        cargo install --git https://github.com/project-serum/anchor --tag "v$ANCHOR_VERSION" anchor-cli --locked
       shell: bash
       if: steps.cache-anchor-cli.outputs.cache-hit != 'true'

--- a/.github/actions/install-solana/action.yml
+++ b/.github/actions/install-solana/action.yml
@@ -17,23 +17,23 @@ runs:
         key: ${{ runner.os }}-Solana-v${{ inputs.solana_version  }}
 
     - name: Install Solana
-      if: ${{ !env.ACT }} && steps.cache-solana-install.cache-hit != 'true'
-      run: | 
+      if: ${{ !env.ACT }} && steps.cache-solana-install.outputs.cache-hit != 'true'
+      run: |
         sh -c "$(curl -sSfL https://release.solana.com/v${{ inputs.solana_version }}/install)"
       shell: bash
 
-    - name: Set Active Solana Version 
+    - name: Set Active Solana Version
       run: |
         rm -f "$HOME/.local/share/solana/install/active_release"
         ln -s "$HOME/.local/share/solana/install/releases/${{ inputs.solana_version }}/solana-release" "$HOME/.local/share/solana/install/active_release"
       shell: bash
 
-    - name: Add Solana bin to Path 
+    - name: Add Solana bin to Path
       run: |
         echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       shell: bash
 
-    - name: Verify Solana install 
+    - name: Verify Solana install
       run: |
         solana --version
       shell: bash

--- a/.github/actions/list-changed-files/action.yaml
+++ b/.github/actions/list-changed-files/action.yaml
@@ -1,0 +1,28 @@
+name: 'List changed files in a PR'
+description: 'List changed files in a PR'
+inputs:
+  pull-number:
+    description: 'PR number'
+    required: true
+
+outputs:
+  changed-files:
+    description: Version
+    value: ${{ steps.set-changed-files.outputs.changed-files }}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+    - name: List changed files in a PR
+      uses: actions/github-script@v4
+      with:
+        script: |
+          const script = require('.github/actions/list-changed-files/script.js')
+          await script({github, context, core}, ${{ inputs.pull-number }})
+
+    - name: Set changed-files from PR
+      id: set-changed-files
+      # env.CHANGED_FILES exported from script.js
+      run: echo "::set-output name=changed-files::${{ env.CHANGED_FILES }}"
+      shell: bash

--- a/.github/actions/list-changed-files/script.js
+++ b/.github/actions/list-changed-files/script.js
@@ -1,0 +1,59 @@
+// add to action input params at some point
+const PATHS_TO_IGNORE = [
+  '.github',
+  'Cargo.lock',
+  'Cargo.toml',
+  'js/idl',
+  'packge.json',
+  'yarn.lock',
+];
+
+const fetchAllChangedFiles = async (
+  github,
+  owner,
+  repo,
+  pull_number,
+  excludePaths = [],
+  per_page = 100,
+) => {
+  let page = 0;
+  let files = new Set();
+
+  while (true) {
+    const { data } = await github.pulls.listFiles({
+      owner,
+      repo,
+      pull_number,
+      direction: 'asc',
+      per_page,
+      page,
+    });
+
+    if (data.length === 0) break;
+    data.map((f) => f.filename).forEach((f) => files.add(f));
+    console.log(`fetched page ${page}`);
+    page += 1;
+  }
+
+  return Array.from(files).filter((f) => {
+    return excludePaths.reduce((prev, path) => {
+      return prev && !f.includes(path);
+    }, true);
+  });
+};
+
+module.exports = async ({ github, context, core }, pull_number) => {
+  const changedFiles = await fetchAllChangedFiles(
+    github,
+    context.repo.owner,
+    context.repo.repo,
+    pull_number,
+    PATHS_TO_IGNORE,
+  );
+
+  core.exportVariable(
+    'CHANGED_FILES',
+    // explicitly add quotation marks for later parsing
+    JSON.stringify(Array.from(changedFiles).map((el) => `\"${el}\"`)),
+  );
+};

--- a/.github/actions/make-version-changes/action.yaml
+++ b/.github/actions/make-version-changes/action.yaml
@@ -1,0 +1,56 @@
+name: 'Make version changes'
+description: 'Make version changes'
+inputs:
+  changed-packages:
+    description: 'Changed packages - in format of <package>/<type>'
+    required: true
+  versioning:
+    description: 'Versioning command(s)'
+    required: true
+  branch:
+    description: 'Branch to checkout'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.branch }}
+
+    # cache and install cargo release
+    - uses: actions/cache@v2
+      name: Cache Cargo Release
+      id: cache-cargo-release
+      with:
+        path: |
+          ~/.cargo/bin/cargo-release
+        key: cargo-release-${{ runner.os }}
+
+    - name: Install Cargo Release
+      if: steps.cache-cargo-release.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cargo install cargo-release
+
+    # cache and install shank cli
+    - uses: actions/cache@v2
+      name: Cache Shank CLI
+      id: cache-shank-cli
+      with:
+        path: |
+          ~/.cargo/bin/shank
+        key: shank-cli-${{ runner.os }}
+
+    - name: Install Cargo Shank
+      if: steps.cache-shank-cli.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cargo install shank-cli
+
+    - name: Make version changes
+      uses: actions/github-script@v4
+      with:
+        script: |
+          const script = require('.github/actions/make-version-changes/script.js')
+          await script({github, context, core, glob, io}, ${{ inputs.changed-packages }}, ${{ inputs.versioning }})

--- a/.github/actions/make-version-changes/script.js
+++ b/.github/actions/make-version-changes/script.js
@@ -1,0 +1,223 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// todo: move somewhere, like a separate config/constants file.
+const MPL_PROGRAM_CONFIG = {
+  'auction-house': {
+    has_idl: true,
+    uses_anchor: true,
+  },
+  auction: {
+    has_idl: false,
+    uses_anchor: false,
+  },
+  auctioneer: {
+    has_idl: true,
+    uses_anchor: true,
+  },
+  core: {
+    has_idl: false,
+    uses_anchor: false,
+  },
+  'candy-machine': {
+    has_idl: true,
+    uses_anchor: true,
+  },
+  'fixed-price-sale': {
+    has_idl: true,
+    uses_anchor: true,
+  },
+  gumdrop: {
+    has_idl: false,
+    uses_anchor: false,
+  },
+  metaplex: {
+    has_idl: false,
+    uses_anchor: false,
+  },
+  'nft-packs': {
+    has_idl: false,
+    uses_anchor: false,
+  },
+  'token-entangler': {
+    has_idl: true,
+    uses_anchor: true,
+  },
+  // uses shank
+  'token-metadata': {
+    has_idl: true,
+    uses_anchor: false,
+  },
+  // uses shank
+  'token-vault': {
+    has_idl: true,
+    uses_anchor: false,
+  },
+};
+
+const wrappedExec = (cmd, cwd) => {
+  let args = {
+    stdio: 'inherit',
+  };
+
+  if (cwd) {
+    args['cwd'] = cwd;
+  } else {
+    // default to curernt dir
+    args['cwd'] = path.join(__dirname);
+  }
+
+  execSync(cmd, args);
+};
+
+const packageUsesAnchor = (pkg) => {
+  const result = MPL_PROGRAM_CONFIG[pkg]['uses_anchor'];
+  console.log(`${pkg} uses anchor: ${result}`);
+  return result;
+};
+
+const packageHasIdl = (pkg) => {
+  const result = MPL_PROGRAM_CONFIG[pkg]['has_idl'];
+  console.log(`${pkg} has idl: ${result}`);
+  return result;
+};
+
+const isPackageType = (actual, target) => actual === target;
+// additional equality checks can match other subdirs, e.g. `rust|test|cli|<etc>`
+const isCratesPackage = (actual) => isPackageType(actual, 'program');
+const isNpmPackage = (actual) => isPackageType(actual, 'js');
+
+const parseVersioningCommand = (cmd) => cmd.split(':');
+const shouldUpdate = (actual, target) => target === '*' || target === actual;
+
+const updateCratesPackage = async (io, cwdArgs, pkg, semvar) => {
+  console.log('updating rust package');
+  const currentDir = cwdArgs.join('/');
+
+  // adds git info automatically
+  wrappedExec(
+    `cargo release --no-publish --no-push --no-confirm --verbose --execute --no-verify --no-tag --config ../../release.toml ${semvar}`,
+    currentDir,
+  );
+
+  const sourceIdlDir = [...cwdArgs.slice(0, cwdArgs.length - 2), 'target', 'idl'].join('/');
+
+  // generate IDL
+  if (packageHasIdl(pkg)) {
+    let idlName = `${pkg.replace('-', '_')}.json`;
+    if (packageUsesAnchor(pkg)) {
+      console.log(
+        'generate IDL via anchor',
+        wrappedExec(`~/.cargo/bin/anchor build --skip-lint --idl ${sourceIdlDir}`, currentDir),
+      );
+    } else {
+      console.log(
+        'generate IDL via shank',
+        wrappedExec(`~/.cargo/bin/shank idl --out-dir ${sourceIdlDir}  --crate-root .`, currentDir),
+      );
+      idlName = `mpl_${idlName}`;
+    }
+
+    // create ../js/idl dir if it does not exist; back one dir + js dir + idl dir
+    // note: cwdArgs == currentDir.split("/")
+    const destIdlDir = [...cwdArgs.slice(0, cwdArgs.length - 1), 'js', 'idl'].join('/');
+
+    if (!fs.existsSync(destIdlDir)) {
+      console.log(`creating ${destIdlDir} because it DNE`, await io.mkdirP(destIdlDir));
+    }
+
+    console.log('final IDL name: ', idlName);
+    // cp IDL to js dir
+    wrappedExec(`cp ${sourceIdlDir}/${idlName} ${destIdlDir}`, currentDir);
+    // append IDL change to rust version bump commit
+    wrappedExec(`git add ${destIdlDir} && git commit --amend -C HEAD && git push`);
+  }
+};
+
+const updateNpmPackage = (cwdArgs, _pkg, semvar) => {
+  console.log(
+    'updating js package',
+    wrappedExec(`yarn install && npm version ${semvar} && git push`, cwdArgs.join('/')),
+  );
+};
+
+/**
+ * Iterate through all input packages and version commands and process version updates. NPM
+ * changes will use `npm version <semvar>` commands. Crates changes will use the cargo release
+ * crate to update a crate version. After each update is committed, it will be appended to the
+ * branch that invoked this action.
+ *
+ * @param {github} obj An @actions/github object
+ * @param {context} obj An @actions/context object
+ * @param {core} obj An @actions/core object
+ * @param {glob} obj An @actions/glob object
+ * @param {io} obj An @actions/io object
+ * @param {packages} arr List of packages to process in the form <pkg-name>/<sub-dir>
+ * @param {versioning} arr List of version commands in the form semvar:pkg:type where type = `program|js`
+ * @return void
+ */
+module.exports = async ({ github, context, core, glob, io }, packages, versioning) => {
+  const base = process.env.GITHUB_ACTION_PATH; // alt: path.join(__dirname);
+  const splitBase = base.split('/');
+  const parentDirsToHome = 4; // ~/<home>/./.github/actions/<name>
+  const cwdArgs = splitBase.slice(0, splitBase.length - parentDirsToHome);
+
+  if (versioning.length === 0) {
+    console.log('No versioning updates to make. Exiting early.');
+    return;
+  }
+
+  // setup git user config
+  wrappedExec('git config user.name github-actions[bot]');
+  wrappedExec('git config user.email github-actions[bot]@users.noreply.github.com');
+
+  // versioning = [semvar:pkg:type]
+  for (const version of versioning) {
+    const [semvar, targetPkg, targetType] = parseVersioningCommand(version);
+    if (semvar === 'none') {
+      console.log('No versioning updates to make when semvar === none. Continuing.');
+      continue;
+    }
+
+    for (let package of JSON.parse(packages)) {
+      // make sure package doesn't have extra quotes or spacing
+      package = package.replace(/\s+|\"|\'/g, '');
+
+      if (!shouldUpdate(package, targetPkg)) {
+        console.log(`No updates for package ${package} based on version command ${version}`);
+        continue;
+      }
+
+      const [name, type] = package.split('/');
+      console.log(
+        `Processing versioning [${semvar}:${targetPkg}:${targetType}] for package [${name}] of type [${type}]`,
+      );
+
+      if (!fs.existsSync(name)) {
+        console.log('could not find dir: ', name);
+        continue;
+      }
+
+      // cd to package
+      cwdArgs.push(name);
+
+      if (shouldUpdate(type, targetType)) {
+        cwdArgs.push(type);
+
+        if (isCratesPackage(type)) {
+          await updateCratesPackage(io, cwdArgs, name, semvar);
+        } else if (isNpmPackage(type)) {
+          updateNpmPackage(cwdArgs, name, semvar);
+        } else continue;
+      } else {
+        console.log(`no update required for package = ${name} of type = ${type}`);
+        continue;
+      }
+
+      // chdir back two levels - back to root, should match original cwd
+      cwdArgs.pop();
+      cwdArgs.pop();
+    }
+  }
+};

--- a/.github/actions/parse-version-command/action.yaml
+++ b/.github/actions/parse-version-command/action.yaml
@@ -1,0 +1,32 @@
+name: "Get version command from review body"
+description: "Get version command from review body"
+inputs:
+  body:
+    description: "Review body"
+    required: true
+
+outputs:
+  versioning:
+    description: Parsed versioning info
+    value: ${{ steps.set-output.outputs.versioning }}
+  has-versioning:
+    description: Command has versioning info
+    value: ${{ steps.set-output.outputs.has-versioning }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+    - name: Parse version commands
+      uses: actions/github-script@v4
+      with:
+        script: |
+          const script = require('.github/actions/parse-version-command/script.js')
+          await script({github, context, core}, '${{ inputs.body }}')
+
+    - name: Set Output
+      id: set-output
+      run: |
+        echo "::set-output name=versioning::${{ env.VERSIONING }}"
+        echo "::set-output name=has-versioning::${{ env.HAS_VERSIONING }}"
+      shell: bash

--- a/.github/actions/parse-version-command/script.js
+++ b/.github/actions/parse-version-command/script.js
@@ -1,0 +1,50 @@
+// https://github.com/octokit/octokit.graphql.net/blob/master/Octokit.GraphQL/Model/CommentAuthorAssociation.cs
+const SEMVAR_COMMAND = /^(patch|minor|major)$/;
+const VERSIONING_COMMAND = /^version/g;
+
+const parse = (body) => {
+  const trimmedBody = body
+    .toLowerCase()
+    .split('\n')
+    .filter((t) => t.length > 0);
+
+  const validVersionCmds = trimmedBody.filter((c) => VERSIONING_COMMAND.test(c.trim()));
+
+  if (validVersionCmds.length === 0) {
+    console.log('no valid version commands');
+    return []; // emtpy list
+  }
+
+  console.log(
+    `found ${validVersionCmds.length} version commands. only the first will be processed.`,
+  );
+  // does \s+ or \w+ work in js
+  const cmd = validVersionCmds[0].split(' ').slice(1);
+
+  if (!SEMVAR_COMMAND.test(cmd)) {
+    throw new Error('Invalid command: ', cmd);
+  }
+
+  // formatted for => 0: semvar, 1: package, 2: language
+  return [[cmd, '*', '*'].join(':')];
+};
+
+/**
+ * Parse the input for version info
+ *
+ * @param {github} obj An @actions/github object
+ * @param {context} obj An @actions/context object
+ * @param {core} obj An @actions/core object
+ * @param {body} str Body to parse for version commands
+ * @return void
+ */
+module.exports = async ({ github, context, core }, body) => {
+  const versioning = parse(body);
+
+  // explicit formatting for CI
+  core.exportVariable(
+    'VERSIONING',
+    versioning.map((v) => `\"${v}\"`),
+  );
+  core.exportVariable('HAS_VERSIONING', versioning.length > 0);
+};

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,90 @@
+name: Version updates
+
+on:
+  pull_request_review:
+    types: [submitted, edited]
+
+permissions:
+  id-token: write
+  contents: write
+  packages: write
+
+env:
+  NODE_VERSION: 17.0.1
+  ANCHOR_VERSION: 0.22.0
+  SOLANA_VERSION_STABLE: 1.9.22
+  RUST_TOOLCHAIN: stable
+
+jobs:
+  get-changes-scope:
+    if:
+      contains(fromJson('["OWNER", "MEMBER"]'), github.event.review.author_association) == true &&
+      contains(fromJson('["approved", "commented"]'), github.event.review.state) == true
+    runs-on: ubuntu-latest
+    outputs:
+      changed-packages: ${{ steps.get-changed-package-scope.outputs.result }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: List changed files
+        uses: ./.github/actions/list-changed-files
+        id: list-changed-files
+        with:
+          pull-number: ${{ github.event.pull_request.number }}
+
+      # map fetched changed files to package / lang (list)
+      - name: Get scope of changed packages
+        uses: actions/github-script@v4
+        id: get-changed-package-scope
+        with:
+          # update regexp to consider other subdirs - e.g. `rust|test|cli|<etc>`
+          script: |
+            const files = ${{ steps.list-changed-files.outputs.changed-files }}
+            const regexp = /[a-zA-Z\-]+\/(js|program)/g
+            const uniqueFilesObj = files.reduce((p, file) => {
+              const match = file.match(regexp)
+              if (match) {
+                // use first match result
+                if (!p[match[0]]) p[match[0]] = 1
+              }
+              return p
+            }, {})
+            return JSON.stringify(Array.from(Object.keys(uniqueFilesObj)).map((el) => `\"${el}\"`))
+
+  get-version-scope:
+    if:
+      contains(fromJson('["OWNER", "MEMBER"]'), github.event.review.author_association) == true &&
+      contains(fromJson('["approved", "commented"]'), github.event.review.state) == true
+    runs-on: ubuntu-latest
+    outputs:
+      versioning: ${{ steps.parse-version-info.outputs.versioning }}
+      has-versioning: ${{ steps.parse-version-info.outputs.has-versioning }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Parse version info from review
+        uses: ./.github/actions/parse-version-command
+        id: parse-version-info
+        with:
+          body: ${{ github.event.review.body }}
+
+  update-pr-with-changes:
+    needs: [get-changes-scope, get-version-scope]
+    if: ${{ needs.get-version-scope.outputs.has-versioning == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install-linux-build-deps
+      - uses: ./.github/actions/install-solana
+        with:
+          solana_version: ${{ env.SOLANA_VERSION_STABLE }}
+      - uses: ./.github/actions/install-rust
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - uses: ./.github/actions/install-anchor/
+
+      - name: Make version changes
+        uses: ./.github/actions/make-version-changes
+        id: make-version-changes
+        with:
+          changed-packages: ${{ needs.get-changes-scope.outputs.changed-packages }}
+          versioning: ${{ needs.get-version-scope.outputs.versioning }}
+          branch: ${{ github.event.pull_request.head.ref }}

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,4 @@
+consolidate-commits = false
+consolidate-pushes = false
+dependent-version = "ignore"
+pre-release-commit-message = "(cargo-release) {{crate_name}} v{{version}}"


### PR DESCRIPTION
Address auto-versioning and publishing outlined in #123 and #124. 

### Context
* The first approach in #515 and #540 failed because `master` is write-protected. Thus, we couldn't update and push changes **after** a PR was merged.
* If merged, this is part 1️⃣ of 2️⃣.
  * Part 1️⃣: track version comments (`version patch|minor|major`), perform the version bump and append the commit to the PR. Note: this is done by pushing the commit to the same branch as the PR. 
  * Part 2️⃣: track when a PR was actually merged, and process any package publishing if needed.
* Version command that triggers the workflow right now is = `version patch|minor|major`. But, the workflow is setup to handle more detailed commands in the future - e.g. `version patch:rust minor:auction-house:js` or something like that.

### Proposed Workflow
* Someone opens PR
* People review, and add comment to trigger versioning
* Workflow runs, makes version updates (i.e. in package.json, Cargo.toml, etc) & pushes commit(s) to PR
* People review version change & merge if looks good
* On merge, another workflow (_not in this PR_) will run and publish updated changes to respective package managers

_Note_: @thlorenz helped brainstorm this workflow via a conversation on Slack. There is another async workflow I had in mind using mergify, but the concern was that might be too complex with too many failure paths. The main benefit of this workflow is you can see the version updates that will be applied before merge.

### Upgrading Rust crate details
* We use `cargo-release` to update Rust crate versions (thanks @samuelvanderwaal). There is a new file in the repo root called `release.toml`.
* When a rust crate is upgraded, we also generate a new IDL - this works for both anchor and non-anchor programs. In the case of the latter, we use `shank-cli` to generate the new IDL. After the IDL is generated, we copy if over to the corresponding `js/idl` directory.

### Other nuanced details
* The only version command that triggers the workflow right now is = `version patch|minor|major`. This is extensible in the future though.
* We utilize the `<pkg>/js` and `<pkg>/program` path structure. Anything else (`rust`, `cli`, `test`) is ignored for now.
* We ignore `core/rust` for now because this caused a few weird failure errors in test.
* You can run multiple version commands PR.
* Because each version update is a separate commit, we can revert each if it doesn't work as expected.
* We install (and cache) `cargo-release` and `shank-cli`. On instances when the cache isn't hit, this makes the build time quite slow.
* We only use a single workflow file 🙂 
