### PR TITLE
Fix spl token gating in Buy instruction

### DIFF
--- a/fixed-price-sale/program/src/processor/buy.rs
+++ b/fixed-price-sale/program/src/processor/buy.rs
@@ -262,7 +262,7 @@ impl<'info> Buy<'info> {
             return Err(ErrorCode::WrongOwnerInTokenGatingAcc.into());
         }
 
-        if user_token_acc_data.mint != *collection {
+        if user_token_acc_data.mint != *collection || user_token_acc_data.amount == 0 {
             return Err(ErrorCode::WrongGatingToken.into());
         }
 


### PR DESCRIPTION
## What
This PR contains fix of gating feature via spl token in fixed-price-sale program

## Why
There was an issue which allowed to buy NFT from gated sale if you have token account with zero balance

## How
Was added balance check to Buy instruction