### PR TITLE
build: dump event context on event invocation

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -16,6 +16,15 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
+  dump-context:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
   get-changes-scope:
     if:
       contains(fromJson('["OWNER", "MEMBER"]'), github.event.review.author_association) == true &&


### PR DESCRIPTION
This change will dump event context to the console on every invocation. This is useful in debugging.