### PR TITLE
build: add contributor to valid author_assocation in pr_comment workflow

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -27,7 +27,7 @@ jobs:
 
   get-changes-scope:
     if:
-      contains(fromJson('["OWNER", "MEMBER"]'), github.event.review.author_association) == true &&
+      contains(fromJson('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.review.author_association) == true &&
       contains(fromJson('["approved", "commented"]'), github.event.review.state) == true
     runs-on: ubuntu-latest
     outputs:
@@ -61,7 +61,7 @@ jobs:
 
   get-version-scope:
     if:
-      contains(fromJson('["OWNER", "MEMBER"]'), github.event.review.author_association) == true &&
+      contains(fromJson('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.review.author_association) == true &&
       contains(fromJson('["approved", "commented"]'), github.event.review.state) == true
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Version workflows aren't running because some review authors are categorized as `CONTRIBUTOR`- e.g. https://github.com/metaplex-foundation/metaplex-program-library/runs/7096506124?check_suite_focus=true.

This change adds the `CONTRIBUTOR` role as a valid value.