### PR TITLE
build: add workflow for manually syncing package versions

### DIFF
--- a/.github/actions/publish-version-changes/action.yaml
+++ b/.github/actions/publish-version-changes/action.yaml
@@ -1,0 +1,31 @@
+name: 'Publish version changes'
+description: 'Publish version changes via respective package managers'
+
+inputs:
+  changed-packages:
+    description: 'Changed packages - in format of <package>/<type>'
+    required: true
+  cargo-token:
+    description: 'Token with which we can publish crates'
+    required: true
+  npm-token:
+    description: 'Token with which we can publish NPM packages'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependency packages for script
+      run: |
+        yarn init --yes
+        yarn add @iarna/toml axios
+      shell: bash
+
+    - name: Make version changes
+      uses: actions/github-script@v4
+      with:
+        script: |
+          const script = require('.github/actions/publish-version-changes/script.js')
+          await script(${{ inputs.changed-packages }}, '${{ inputs.cargo-token }}', '${{ inputs.npm-token }}')

--- a/.github/actions/publish-version-changes/script.js
+++ b/.github/actions/publish-version-changes/script.js
@@ -1,0 +1,148 @@
+const fs = require('fs');
+const path = require('path');
+const toml = require('@iarna/toml');
+const axios = require('axios');
+
+const { execSync } = require('child_process');
+
+const wrappedExec = (cmd, cwd) => {
+  let args = { stdio: 'inherit' };
+
+  if (cwd) {
+    args['cwd'] = cwd;
+  } else {
+    // default to curernt dir
+    args['cwd'] = path.join(__dirname);
+  }
+
+  execSync(cmd, args);
+};
+
+const isPackageType = (actual, target) => actual === target;
+// additional equality checks can match other subdirs, e.g. `rust|test|cli|<etc>`
+const isCratesPackage = (actual) => isPackageType(actual, 'program');
+const isNpmPackage = (actual) => isPackageType(actual, 'js');
+
+// assume most basic versioning for now: `major.minor.patch`; only publish package if local != remote, assuming local >= remote
+const shouldPublishPackage = (localVersion, remoteVersion) => localVersion !== remoteVersion;
+
+// npm package helpers
+
+const getLocalNpmPackageInfo = (cwd) => {
+  const packageJsonPath = `${cwd}/package.json`;
+  console.log('reading configuration from ', packageJsonPath);
+  var json = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+  return [json.name, json.version];
+};
+
+const getLatestPublishedNpmVersion = async (packageName) => {
+  try {
+    const result = (await axios.get(`https://registry.npmjs.org/${packageName}/latest`)).data;
+    return result['version'];
+  } catch (e) {
+    throw new Error('No configuration found for package: ', packageName);
+  }
+};
+
+const tryPublishNpmPackage = async (npmToken, cwdArgs) => {
+  console.log('updating npm package');
+  const currentDir = cwdArgs.join('/');
+
+  const [packageName, localPackageVersion] = getLocalNpmPackageInfo(currentDir);
+  console.log(`[LOCAL] name: ${packageName}, version: ${localPackageVersion}`);
+  const remotePackageVersion = await getLatestPublishedNpmVersion(packageName);
+  console.log(`[REMOTE] name: ${packageName}, version: ${remotePackageVersion}`);
+
+  if (shouldPublishPackage(localPackageVersion, remotePackageVersion)) {
+    wrappedExec(`echo "//registry.npmjs.org/:_authToken=${npmToken}" > ~/.npmrc`, currentDir);
+    wrappedExec(`npm publish`, currentDir);
+  } else {
+    console.log('no publish needed');
+  }
+};
+
+// crates package helpers
+
+const getLocalCrateInfo = (cwd) => {
+  const cargoPath = `${cwd}/Cargo.toml`;
+  let tomlObj = toml.parse(fs.readFileSync(cargoPath, 'utf-8'));
+  if (!tomlObj.package) throw new Error('No package tag defined in Cargo.toml');
+
+  return [tomlObj.package.name, tomlObj.package.version];
+};
+
+const getLatestPublishedCrateVersion = async (crateName) => {
+  const result = (await axios.get(`https://crates.io/api/v1/crates/${crateName}/versions`)).data;
+  const versions = result['versions'];
+  if (versions.length === 0) {
+    throw new Error('No versions found for package. Is it published yet? ', crateName);
+  }
+
+  // packages are sorted in reverse chronological order
+  const latestVersion = versions[0];
+  console.log(`Found the following latest version info for crate ${crateName}`, latestVersion);
+  if (!versions[0]['num']) {
+    throw new Error('Could find version info for package: ', crateName);
+  }
+
+  return versions[0]['num'];
+};
+
+const tryPublishCratesPackage = async (cargoToken, cwdArgs) => {
+  console.log('updating rust package');
+  const currentDir = cwdArgs.join('/');
+
+  const [crateName, localCrateVersion] = getLocalCrateInfo(currentDir);
+  console.log(`[LOCAL] name: ${crateName}, version: ${localCrateVersion}`);
+  const remoteCrateVersion = await getLatestPublishedCrateVersion(crateName);
+  console.log(`[REMOTE] name: ${crateName}, version: ${remoteCrateVersion}`);
+
+  // only publish if local != remote crate version
+  if (shouldPublishPackage(localCrateVersion, remoteCrateVersion)) {
+    wrappedExec(`cargo publish --token ${cargoToken} -p ${crateName}`, currentDir);
+  } else {
+    console.log('no publish needed');
+  }
+};
+
+/**
+ * Iterate through all input packages publish via the respective package managers.
+ *
+ * @param {packages} arr List of packages to process in the form <pkg-name>/<sub-dir>
+ * @param {cargoToken} str token needed to publish Rust crates
+ * @param {npmToken} str token needed to publish NPM packages
+ * @return void
+ */
+module.exports = async (packages, cargoToken, npmToken) => {
+  if (packages.length === 0) {
+    console.log('No packges to publish. Exiting early.');
+    return;
+  }
+
+  const base = process.env.GITHUB_ACTION_PATH; // alt: path.join(__dirname);
+  const splitBase = base.split('/');
+  const parentDirsToHome = 4; // ~/<home>/./.github/actions/<name>
+  const cwdArgs = splitBase.slice(0, splitBase.length - parentDirsToHome);
+
+  for (let package of packages) {
+    // make sure package doesn't have extra quotes or spacing
+    package = package.replace(/\s+|\"|\'/g, '');
+    const [name, type] = package.split('/');
+    console.log(`Processing package [${name}] of type [${type}]`);
+    cwdArgs.push(...[name, type]);
+    console.log(`cwdArgs with new package: `, cwdArgs);
+
+    try {
+      if (isCratesPackage(type)) await tryPublishCratesPackage(cargoToken, cwdArgs, toml);
+      else if (isNpmPackage(type)) await tryPublishNpmPackage(npmToken, cwdArgs);
+      else continue;
+    } catch (e) {
+      console.log(`could not process ${name}/${type} - got error ${e}`);
+    } finally {
+      // chdir back two levels - back to root, should match original cwd
+      cwdArgs.pop();
+      cwdArgs.pop();
+    }
+  }
+};

--- a/.github/workflows/manually-sync-package-versions.yml
+++ b/.github/workflows/manually-sync-package-versions.yml
@@ -1,0 +1,34 @@
+name: Manually sync versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: 'List of packages and immediate subdir to udpate, e.g. ["candy-machine/js", "auction-house/program"]'
+        required: true
+        default: '["candy-machine/js"]'
+
+permissions:
+  id-token: write
+
+jobs:
+  dump-context:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+  sync-package-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Publish version changes
+        uses: ./.github/actions/publish-version-changes
+        id: publish-version-changes
+        with:
+          changed-packages: ${{ inputs.packages }}
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
### Context
* We will eventually use actions + workflows to help automate package publishing - supplementing the logic added here #558 
* It turns out we can re-purpose some shared code, with a manual package publishing workflow. Anyone can directly invoke this workflow from the GH UI, specifying the packages they want to sync, e.g. `["candy-machine/js"]`.

### How it works
* The workflow will go through each element in the list, check the local vs remote package versions. If they don't match, we will try to publish with the updated package with the respective package manager.

### Example
Example workflow of the run on my forked repo, with input = `["candy-machine/js", "token-metadata/program"]`: https://github.com/jshiohaha/metaplex-program-library/runs/7106341908?check_suite_focus=true