### PR TITLE
build: use replaceAll instead of replace

### DIFF
--- a/.github/actions/make-version-changes/script.js
+++ b/.github/actions/make-version-changes/script.js
@@ -105,7 +105,8 @@ const updateCratesPackage = async (io, cwdArgs, pkg, semvar) => {
 
   // generate IDL
   if (packageHasIdl(pkg)) {
-    let idlName = `${pkg.replace('-', '_')}.json`;
+    // replace all instances of - with _
+    let idlName = `${pkg.replaceAll('-', '_')}.json`;
     if (packageUsesAnchor(pkg)) {
       console.log(
         'generate IDL via anchor',


### PR DESCRIPTION
### Context
This [version build](https://github.com/metaplex-foundation/metaplex-program-library/runs/7114734718?check_suite_focus=true) failed because the expected didn't match the actual IDL. `fixed_price-sale.json` should have been `fixed_price_sale.json` - in this case, we'll use `replace` in favor of `replaceAll`.

```
Error: Unhandled error: Error: Command failed: cp /home/runner/work/metaplex-program-library/metaplex-program-library/target/idl/fixed_price-sale.json /home/runner/work/metaplex-program-library/metaplex-program-library/fixed-price-sale/js/idl
```

### Verification
I ran `anchor build --skip-lint --idl ../../target/idl` from `<path-to-mpl>/metaplex-program-library/fixed-price-sale/program` and the command generated an IDL named `fixed_price_sale.json`