### PR TITLE
build: use replace with a global modifier

### DIFF
--- a/.github/actions/make-version-changes/script.js
+++ b/.github/actions/make-version-changes/script.js
@@ -106,7 +106,7 @@ const updateCratesPackage = async (io, cwdArgs, pkg, semvar) => {
   // generate IDL
   if (packageHasIdl(pkg)) {
     // replace all instances of - with _
-    let idlName = `${pkg.replaceAll('-', '_')}.json`;
+    let idlName = `${pkg.replace(/\-/g, '_')}.json`;
     if (packageUsesAnchor(pkg)) {
       console.log(
         'generate IDL via anchor',


### PR DESCRIPTION
RIP - apparently `replaceAll` is only implemented as of **Node v14.15.0** ([source](https://stackoverflow.com/questions/65295584/jest-typeerror-replaceall-is-not-a-function)). So, the solution is to revert **back** to `replace` with a regex global modifier instead of a string.

I created a temporary PR to reproduce the error & test: https://github.com/metaplex-foundation/metaplex-program-library/pull/572

Build with error ❌ https://github.com/metaplex-foundation/metaplex-program-library/runs/7118169485?check_suite_focus=true

Build with success ✅ https://github.com/metaplex-foundation/metaplex-program-library/runs/7118550342?check_suite_focus=true

