### PR TITLE
build: reduce workflow runtime by modifying IDL version directly

### DIFF
--- a/.github/actions/make-version-changes/action.yaml
+++ b/.github/actions/make-version-changes/action.yaml
@@ -33,24 +33,16 @@ runs:
       run: |
         cargo install cargo-release
 
-    # cache and install shank cli
-    - uses: actions/cache@v2
-      name: Cache Shank CLI
-      id: cache-shank-cli
-      with:
-        path: |
-          ~/.cargo/bin/shank
-        key: shank-cli-${{ runner.os }}
-
-    - name: Install Cargo Shank
-      if: steps.cache-shank-cli.outputs.cache-hit != 'true'
-      shell: bash
+    - name: Install dependency packages for script
+      # we don't commit *.lock files, so we don't need to require immutable installs. if this isn't set to false,
+      # we will get an error like `lockfile would have been modified by this install, which is explicitly forbidden.`
       run: |
-        cargo install shank-cli
+        YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install && yarn add @iarna/toml
+      shell: bash
 
     - name: Make version changes
       uses: actions/github-script@v4
       with:
         script: |
           const script = require('.github/actions/make-version-changes/script.js')
-          await script({github, context, core, glob, io}, ${{ inputs.changed-packages }}, ${{ inputs.versioning }})
+          await script(${{ inputs.changed-packages }}, ${{ inputs.versioning }})

--- a/.github/workflows/version-update-on-pr-comment.yml.yml
+++ b/.github/workflows/version-update-on-pr-comment.yml.yml
@@ -82,13 +82,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-linux-build-deps
-      - uses: ./.github/actions/install-solana
-        with:
-          solana_version: ${{ env.SOLANA_VERSION_STABLE }}
       - uses: ./.github/actions/install-rust
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - uses: ./.github/actions/install-anchor/
 
       - name: Make version changes
         uses: ./.github/actions/make-version-changes


### PR DESCRIPTION
### Context
* after chatting with @thlorenz about #558, he suggested editing the IDL directly since we are only updating version based on the associated crate's version.
* nothing changes here, functionally. the main win of this change is we remove a bunch of `cargo install <pkg>` commands and reduce overall workflow runtime. at worst, i think this will reduce runtime from 15-17 min to 5-7 min 🕐 
* the modified package's SDK is validated when the PR is (re)opened and synchronized (aka updated) based on this change #576 

### Testing from jshiohaha/metaplex-program-library fork
PR (see bot commits): https://github.com/jshiohaha/metaplex-program-library/pull/18
Action for `version patch`: https://github.com/jshiohaha/metaplex-program-library/runs/7139333038?check_suite_focus=true