### PR TITLE
build: publish version changes on PR merge

### DIFF
--- a/.github/actions/list-changed-files/action.yaml
+++ b/.github/actions/list-changed-files/action.yaml
@@ -4,6 +4,12 @@ inputs:
   pull-number:
     description: 'PR number'
     required: true
+  include:
+    description: 'Matching files and paths will to include. Any non-matches will be excluded.'
+    required: false
+  exclude:
+    description: 'Matching files and paths will to exclude'
+    required: false
 
 outputs:
   changed-files:
@@ -19,7 +25,7 @@ runs:
       with:
         script: |
           const script = require('.github/actions/list-changed-files/script.js')
-          await script({github, context, core}, ${{ inputs.pull-number }})
+          await script({github, context, core}, ${{ inputs.pull-number }}, '${{ inputs.include }}', '${{ inputs.exclude }}')
 
     - name: Set changed-files from PR
       id: set-changed-files

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -39,6 +39,7 @@ jobs:
         id: list-changed-files
         with:
           pull-number: ${{ github.event.pull_request.number }}
+          exclude: '[".github", "Cargo.lock", "Cargo.toml", "js/idl", "packge.json", "yarn.lock"]'
 
       # map fetched changed files to package / lang (list)
       - name: Get scope of changed packages

--- a/.github/workflows/publish-on-pr-merge.yml
+++ b/.github/workflows/publish-on-pr-merge.yml
@@ -1,0 +1,79 @@
+name: Sync versions on PR merge
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  id-token: write
+  contents: write
+
+env:
+  NODE_VERSION: 17.0.1
+  ANCHOR_VERSION: 0.22.0
+  SOLANA_VERSION_STABLE: 1.9.22
+  RUST_TOOLCHAIN: stable
+
+jobs:
+  dump-context:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+  # alt: on version, publish comment or label and then parse here.
+  get-changes-scope:
+    runs-on: ubuntu-latest
+    outputs:
+      changed-packages: ${{ steps.get-changed-package-scope.outputs.result }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get PR for push event HEAD commit
+        uses: ./.github/actions/get-pr-for-commit
+        id: get-pr-for-commit
+        with:
+          commit-sha: ${{ github.sha }}
+
+      - name: List changed files
+        uses: ./.github/actions/list-changed-files
+        id: list-changed-files
+        with:
+          pull-number: ${{ steps.get-pr-for-commit.outputs.pull-number }}
+          # only include files which might contain version bumps
+          include: '["package.json", "Cargo.toml"]'
+
+      # map fetched changed files to package / lang (list)
+      - name: Get scope of changed packages
+        uses: actions/github-script@v4
+        id: get-changed-package-scope
+        with:
+          # update regexp to consider other subdirs - e.g. `rust|test|cli|<etc>`
+          script: |
+            const files = ${{ steps.list-changed-files.outputs.changed-files }}
+            const regexp = /[a-zA-Z\-]+\/(js|program)/g
+            const uniqueFilesObj = files.reduce((p, file) => {
+              const match = file.match(regexp)
+              if (match) {
+                // use first match result
+                if (!p[match[0]]) p[match[0]] = 1
+              }
+              return p
+            }, {})
+            return Array.from(Object.keys(uniqueFilesObj))
+
+  publish-version-changes:
+    needs: [get-changes-scope]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Publish version changes
+        uses: ./.github/actions/publish-version-changes
+        id: publish-version-changes
+        with:
+          changed-packages: ${{ needs.get-changes-scope.outputs.changed-packages }}
+          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Context
* version changes (original change in #558) are requested & added to PRs while they are open.
* after merge, this workflow will trigger and try to sync the updated version on master with the package manager.
* simultaneously, we add and push tags based on the upgraded package(s).

### Testing
* test pr: https://github.com/jshiohaha/metaplex-program-library/pull/25
* version flow: https://github.com/jshiohaha/metaplex-program-library/runs/7143773815?check_suite_focus=true
* publish & tag: https://github.com/jshiohaha/metaplex-program-library/runs/7143997677?check_suite_focus=true
  * note: this test didn't actually publish the packages to npm/crates + tag the repo because i used dummy tokens
