### PR TITLE
build: modify name for crate tag on publish

### DIFF
--- a/.github/actions/publish-version-changes/script.js
+++ b/.github/actions/publish-version-changes/script.js
@@ -100,7 +100,7 @@ const getLatestPublishedCrateVersion = async (crateName) => {
   return versions[0]['num'];
 };
 
-const formatCrateTag = (name, version) => `${name}-v${version}`;
+const formatCrateTag = (name, version) => `${name}-prog-v${version}`;
 
 const tryPublishCratesPackage = async (cargoToken, cwdArgs) => {
   console.log('updating rust package');


### PR DESCRIPTION
update tag name format for rust crates. see prev tags here https://github.com/metaplex-foundation/metaplex-program-library/tags