### PR TITLE
fix(candy-machine): add missing `mut`

### DIFF
--- a/candy-machine/js/idl/candy_machine.json
+++ b/candy-machine/js/idl/candy_machine.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0",
+  "version": "4.0.1",
   "name": "candy_machine",
   "instructions": [
     {
@@ -140,7 +140,7 @@
         },
         {
           "name": "authority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -150,7 +150,7 @@
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -333,12 +333,12 @@
         },
         {
           "name": "metadata",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -394,7 +394,7 @@
         },
         {
           "name": "authority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         }
       ],
@@ -865,6 +865,11 @@
       "code": 6034,
       "name": "CandyCollectionRequiresRetainAuthority",
       "msg": "Retain authority must be true for Candy Machines with a collection set"
+    },
+    {
+      "code": 6035,
+      "name": "GatewayProgramError",
+      "msg": "Error within Gateway program"
     }
   ],
   "metadata": {

--- a/candy-machine/js/src/generated/accounts/CandyMachine.ts
+++ b/candy-machine/js/src/generated/accounts/CandyMachine.ts
@@ -23,7 +23,7 @@ export type CandyMachineArgs = {
   data: CandyMachineData;
 };
 
-const candyMachineDiscriminator = [51, 173, 177, 113, 25, 241, 109, 189];
+export const candyMachineDiscriminator = [51, 173, 177, 113, 25, 241, 109, 189];
 /**
  * Holds the data for the {@link CandyMachine} Account and provides de/serialization
  * functionality for that data

--- a/candy-machine/js/src/generated/accounts/CollectionPDA.ts
+++ b/candy-machine/js/src/generated/accounts/CollectionPDA.ts
@@ -19,7 +19,7 @@ export type CollectionPDAArgs = {
   candyMachine: web3.PublicKey;
 };
 
-const collectionPDADiscriminator = [203, 128, 119, 125, 234, 89, 232, 157];
+export const collectionPDADiscriminator = [203, 128, 119, 125, 234, 89, 232, 157];
 /**
  * Holds the data for the {@link CollectionPDA} Account and provides de/serialization
  * functionality for that data

--- a/candy-machine/js/src/generated/errors/index.ts
+++ b/candy-machine/js/src/generated/errors/index.ts
@@ -756,6 +756,26 @@ createErrorFromNameLookup.set(
 );
 
 /**
+ * GatewayProgramError: 'Error within Gateway program'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class GatewayProgramErrorError extends Error {
+  readonly code: number = 0x1793;
+  readonly name: string = 'GatewayProgramError';
+  constructor() {
+    super('Error within Gateway program');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, GatewayProgramErrorError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x1793, () => new GatewayProgramErrorError());
+createErrorFromNameLookup.set('GatewayProgramError', () => new GatewayProgramErrorError());
+
+/**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors
  * @category generated

--- a/candy-machine/js/src/generated/instructions/addConfigLines.ts
+++ b/candy-machine/js/src/generated/instructions/addConfigLines.ts
@@ -23,7 +23,7 @@ export type AddConfigLinesInstructionArgs = {
  * @category AddConfigLines
  * @category generated
  */
-const addConfigLinesStruct = new beet.FixableBeetArgsStruct<
+export const addConfigLinesStruct = new beet.FixableBeetArgsStruct<
   AddConfigLinesInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -49,7 +49,7 @@ export type AddConfigLinesInstructionAccounts = {
   authority: web3.PublicKey;
 };
 
-const addConfigLinesInstructionDiscriminator = [223, 50, 224, 227, 151, 8, 115, 106];
+export const addConfigLinesInstructionDiscriminator = [223, 50, 224, 227, 151, 8, 115, 106];
 
 /**
  * Creates a _AddConfigLines_ instruction.
@@ -64,28 +64,27 @@ const addConfigLinesInstructionDiscriminator = [223, 50, 224, 227, 151, 8, 115, 
 export function createAddConfigLinesInstruction(
   accounts: AddConfigLinesInstructionAccounts,
   args: AddConfigLinesInstructionArgs,
+  programId = new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
 ) {
-  const { candyMachine, authority } = accounts;
-
   const [data] = addConfigLinesStruct.serialize({
     instructionDiscriminator: addConfigLinesInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: candyMachine,
+      pubkey: accounts.candyMachine,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: true,
     },
   ];
 
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+    programId,
     keys,
     data,
   });

--- a/candy-machine/js/src/generated/instructions/initializeCandyMachine.ts
+++ b/candy-machine/js/src/generated/instructions/initializeCandyMachine.ts
@@ -22,7 +22,7 @@ export type InitializeCandyMachineInstructionArgs = {
  * @category InitializeCandyMachine
  * @category generated
  */
-const initializeCandyMachineStruct = new beet.FixableBeetArgsStruct<
+export const initializeCandyMachineStruct = new beet.FixableBeetArgsStruct<
   InitializeCandyMachineInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -49,9 +49,13 @@ export type InitializeCandyMachineInstructionAccounts = {
   wallet: web3.PublicKey;
   authority: web3.PublicKey;
   payer: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
 };
 
-const initializeCandyMachineInstructionDiscriminator = [142, 137, 167, 107, 47, 39, 240, 124];
+export const initializeCandyMachineInstructionDiscriminator = [
+  142, 137, 167, 107, 47, 39, 240, 124,
+];
 
 /**
  * Creates a _InitializeCandyMachine_ instruction.
@@ -66,48 +70,47 @@ const initializeCandyMachineInstructionDiscriminator = [142, 137, 167, 107, 47, 
 export function createInitializeCandyMachineInstruction(
   accounts: InitializeCandyMachineInstructionAccounts,
   args: InitializeCandyMachineInstructionArgs,
+  programId = new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
 ) {
-  const { candyMachine, wallet, authority, payer } = accounts;
-
   const [data] = initializeCandyMachineStruct.serialize({
     instructionDiscriminator: initializeCandyMachineInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: candyMachine,
+      pubkey: accounts.candyMachine,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: payer,
+      pubkey: accounts.payer,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+    programId,
     keys,
     data,
   });

--- a/candy-machine/js/src/generated/instructions/mintNft.ts
+++ b/candy-machine/js/src/generated/instructions/mintNft.ts
@@ -22,7 +22,7 @@ export type MintNftInstructionArgs = {
  * @category MintNft
  * @category generated
  */
-const mintNftStruct = new beet.BeetArgsStruct<
+export const mintNftStruct = new beet.BeetArgsStruct<
   MintNftInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -64,12 +64,15 @@ export type MintNftInstructionAccounts = {
   updateAuthority: web3.PublicKey;
   masterEdition: web3.PublicKey;
   tokenMetadataProgram: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
   clock: web3.PublicKey;
   recentBlockhashes: web3.PublicKey;
   instructionSysvarAccount: web3.PublicKey;
 };
 
-const mintNftInstructionDiscriminator = [211, 57, 6, 167, 15, 219, 35, 251];
+export const mintNftInstructionDiscriminator = [211, 57, 6, 167, 15, 219, 35, 251];
 
 /**
  * Creates a _MintNft_ instruction.
@@ -84,112 +87,97 @@ const mintNftInstructionDiscriminator = [211, 57, 6, 167, 15, 219, 35, 251];
 export function createMintNftInstruction(
   accounts: MintNftInstructionAccounts,
   args: MintNftInstructionArgs,
+  programId = new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
 ) {
-  const {
-    candyMachine,
-    candyMachineCreator,
-    payer,
-    wallet,
-    metadata,
-    mint,
-    mintAuthority,
-    updateAuthority,
-    masterEdition,
-    tokenMetadataProgram,
-    clock,
-    recentBlockhashes,
-    instructionSysvarAccount,
-  } = accounts;
-
   const [data] = mintNftStruct.serialize({
     instructionDiscriminator: mintNftInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: candyMachine,
+      pubkey: accounts.candyMachine,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: candyMachineCreator,
+      pubkey: accounts.candyMachineCreator,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: payer,
+      pubkey: accounts.payer,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: mint,
+      pubkey: accounts.mint,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: mintAuthority,
+      pubkey: accounts.mintAuthority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: updateAuthority,
+      pubkey: accounts.updateAuthority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: masterEdition,
+      pubkey: accounts.masterEdition,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenMetadataProgram,
+      pubkey: accounts.tokenMetadataProgram,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: clock,
+      pubkey: accounts.clock,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: recentBlockhashes,
+      pubkey: accounts.recentBlockhashes,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: instructionSysvarAccount,
+      pubkey: accounts.instructionSysvarAccount,
       isWritable: false,
       isSigner: false,
     },
   ];
 
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+    programId,
     keys,
     data,
   });

--- a/candy-machine/js/src/generated/instructions/removeCollection.ts
+++ b/candy-machine/js/src/generated/instructions/removeCollection.ts
@@ -13,7 +13,7 @@ import * as web3 from '@solana/web3.js';
  * @category RemoveCollection
  * @category generated
  */
-const removeCollectionStruct = new beet.BeetArgsStruct<{
+export const removeCollectionStruct = new beet.BeetArgsStruct<{
   instructionDiscriminator: number[] /* size: 8 */;
 }>(
   [['instructionDiscriminator', beet.uniformFixedSizeArray(beet.u8, 8)]],
@@ -43,7 +43,7 @@ export type RemoveCollectionInstructionAccounts = {
   tokenMetadataProgram: web3.PublicKey;
 };
 
-const removeCollectionInstructionDiscriminator = [223, 52, 106, 217, 61, 220, 36, 160];
+export const removeCollectionInstructionDiscriminator = [223, 52, 106, 217, 61, 220, 36, 160];
 
 /**
  * Creates a _RemoveCollection_ instruction.
@@ -53,60 +53,53 @@ const removeCollectionInstructionDiscriminator = [223, 52, 106, 217, 61, 220, 36
  * @category RemoveCollection
  * @category generated
  */
-export function createRemoveCollectionInstruction(accounts: RemoveCollectionInstructionAccounts) {
-  const {
-    candyMachine,
-    authority,
-    collectionPda,
-    metadata,
-    mint,
-    collectionAuthorityRecord,
-    tokenMetadataProgram,
-  } = accounts;
-
+export function createRemoveCollectionInstruction(
+  accounts: RemoveCollectionInstructionAccounts,
+  programId = new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+) {
   const [data] = removeCollectionStruct.serialize({
     instructionDiscriminator: removeCollectionInstructionDiscriminator,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: candyMachine,
+      pubkey: accounts.candyMachine,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: collectionPda,
+      pubkey: accounts.collectionPda,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: mint,
+      pubkey: accounts.mint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: collectionAuthorityRecord,
+      pubkey: accounts.collectionAuthorityRecord,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenMetadataProgram,
+      pubkey: accounts.tokenMetadataProgram,
       isWritable: false,
       isSigner: false,
     },
   ];
 
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+    programId,
     keys,
     data,
   });

--- a/candy-machine/js/src/generated/instructions/setCollection.ts
+++ b/candy-machine/js/src/generated/instructions/setCollection.ts
@@ -13,7 +13,7 @@ import * as web3 from '@solana/web3.js';
  * @category SetCollection
  * @category generated
  */
-const setCollectionStruct = new beet.BeetArgsStruct<{
+export const setCollectionStruct = new beet.BeetArgsStruct<{
   instructionDiscriminator: number[] /* size: 8 */;
 }>(
   [['instructionDiscriminator', beet.uniformFixedSizeArray(beet.u8, 8)]],
@@ -23,9 +23,9 @@ const setCollectionStruct = new beet.BeetArgsStruct<{
  * Accounts required by the _setCollection_ instruction
  *
  * @property [_writable_] candyMachine
- * @property [**signer**] authority
+ * @property [_writable_, **signer**] authority
  * @property [_writable_] collectionPda
- * @property [**signer**] payer
+ * @property [_writable_, **signer**] payer
  * @property [] metadata
  * @property [] mint
  * @property [] edition
@@ -40,6 +40,8 @@ export type SetCollectionInstructionAccounts = {
   authority: web3.PublicKey;
   collectionPda: web3.PublicKey;
   payer: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
   metadata: web3.PublicKey;
   mint: web3.PublicKey;
   edition: web3.PublicKey;
@@ -47,7 +49,7 @@ export type SetCollectionInstructionAccounts = {
   tokenMetadataProgram: web3.PublicKey;
 };
 
-const setCollectionInstructionDiscriminator = [192, 254, 206, 76, 168, 182, 59, 223];
+export const setCollectionInstructionDiscriminator = [192, 254, 206, 76, 168, 182, 59, 223];
 
 /**
  * Creates a _SetCollection_ instruction.
@@ -57,82 +59,73 @@ const setCollectionInstructionDiscriminator = [192, 254, 206, 76, 168, 182, 59, 
  * @category SetCollection
  * @category generated
  */
-export function createSetCollectionInstruction(accounts: SetCollectionInstructionAccounts) {
-  const {
-    candyMachine,
-    authority,
-    collectionPda,
-    payer,
-    metadata,
-    mint,
-    edition,
-    collectionAuthorityRecord,
-    tokenMetadataProgram,
-  } = accounts;
-
+export function createSetCollectionInstruction(
+  accounts: SetCollectionInstructionAccounts,
+  programId = new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+) {
   const [data] = setCollectionStruct.serialize({
     instructionDiscriminator: setCollectionInstructionDiscriminator,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: candyMachine,
+      pubkey: accounts.candyMachine,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
-      isWritable: false,
+      pubkey: accounts.authority,
+      isWritable: true,
       isSigner: true,
     },
     {
-      pubkey: collectionPda,
+      pubkey: accounts.collectionPda,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: payer,
-      isWritable: false,
+      pubkey: accounts.payer,
+      isWritable: true,
       isSigner: true,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: mint,
+      pubkey: accounts.mint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: edition,
+      pubkey: accounts.edition,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: collectionAuthorityRecord,
+      pubkey: accounts.collectionAuthorityRecord,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenMetadataProgram,
+      pubkey: accounts.tokenMetadataProgram,
       isWritable: false,
       isSigner: false,
     },
   ];
 
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+    programId,
     keys,
     data,
   });

--- a/candy-machine/js/src/generated/instructions/setCollectionDuringMint.ts
+++ b/candy-machine/js/src/generated/instructions/setCollectionDuringMint.ts
@@ -13,7 +13,7 @@ import * as web3 from '@solana/web3.js';
  * @category SetCollectionDuringMint
  * @category generated
  */
-const setCollectionDuringMintStruct = new beet.BeetArgsStruct<{
+export const setCollectionDuringMintStruct = new beet.BeetArgsStruct<{
   instructionDiscriminator: number[] /* size: 8 */;
 }>(
   [['instructionDiscriminator', beet.uniformFixedSizeArray(beet.u8, 8)]],
@@ -23,8 +23,8 @@ const setCollectionDuringMintStruct = new beet.BeetArgsStruct<{
  * Accounts required by the _setCollectionDuringMint_ instruction
  *
  * @property [] candyMachine
- * @property [] metadata
- * @property [**signer**] payer
+ * @property [_writable_] metadata
+ * @property [_writable_, **signer**] payer
  * @property [_writable_] collectionPda
  * @property [] tokenMetadataProgram
  * @property [] instructions
@@ -51,7 +51,7 @@ export type SetCollectionDuringMintInstructionAccounts = {
   collectionAuthorityRecord: web3.PublicKey;
 };
 
-const setCollectionDuringMintInstructionDiscriminator = [103, 17, 200, 25, 118, 95, 125, 61];
+export const setCollectionDuringMintInstructionDiscriminator = [103, 17, 200, 25, 118, 95, 125, 61];
 
 /**
  * Creates a _SetCollectionDuringMint_ instruction.
@@ -63,84 +63,71 @@ const setCollectionDuringMintInstructionDiscriminator = [103, 17, 200, 25, 118, 
  */
 export function createSetCollectionDuringMintInstruction(
   accounts: SetCollectionDuringMintInstructionAccounts,
+  programId = new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
 ) {
-  const {
-    candyMachine,
-    metadata,
-    payer,
-    collectionPda,
-    tokenMetadataProgram,
-    instructions,
-    collectionMint,
-    collectionMetadata,
-    collectionMasterEdition,
-    authority,
-    collectionAuthorityRecord,
-  } = accounts;
-
   const [data] = setCollectionDuringMintStruct.serialize({
     instructionDiscriminator: setCollectionDuringMintInstructionDiscriminator,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: candyMachine,
+      pubkey: accounts.candyMachine,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: metadata,
-      isWritable: false,
-      isSigner: false,
-    },
-    {
-      pubkey: payer,
-      isWritable: false,
-      isSigner: true,
-    },
-    {
-      pubkey: collectionPda,
+      pubkey: accounts.metadata,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenMetadataProgram,
+      pubkey: accounts.payer,
+      isWritable: true,
+      isSigner: true,
+    },
+    {
+      pubkey: accounts.collectionPda,
+      isWritable: true,
+      isSigner: false,
+    },
+    {
+      pubkey: accounts.tokenMetadataProgram,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: instructions,
+      pubkey: accounts.instructions,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: collectionMint,
+      pubkey: accounts.collectionMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: collectionMetadata,
+      pubkey: accounts.collectionMetadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: collectionMasterEdition,
+      pubkey: accounts.collectionMasterEdition,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: collectionAuthorityRecord,
+      pubkey: accounts.collectionAuthorityRecord,
       isWritable: false,
       isSigner: false,
     },
   ];
 
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+    programId,
     keys,
     data,
   });

--- a/candy-machine/js/src/generated/instructions/updateAuthority.ts
+++ b/candy-machine/js/src/generated/instructions/updateAuthority.ts
@@ -22,7 +22,7 @@ export type UpdateAuthorityInstructionArgs = {
  * @category UpdateAuthority
  * @category generated
  */
-const updateAuthorityStruct = new beet.FixableBeetArgsStruct<
+export const updateAuthorityStruct = new beet.FixableBeetArgsStruct<
   UpdateAuthorityInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -49,7 +49,7 @@ export type UpdateAuthorityInstructionAccounts = {
   wallet: web3.PublicKey;
 };
 
-const updateAuthorityInstructionDiscriminator = [32, 46, 64, 28, 149, 75, 243, 88];
+export const updateAuthorityInstructionDiscriminator = [32, 46, 64, 28, 149, 75, 243, 88];
 
 /**
  * Creates a _UpdateAuthority_ instruction.
@@ -64,33 +64,32 @@ const updateAuthorityInstructionDiscriminator = [32, 46, 64, 28, 149, 75, 243, 8
 export function createUpdateAuthorityInstruction(
   accounts: UpdateAuthorityInstructionAccounts,
   args: UpdateAuthorityInstructionArgs,
+  programId = new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
 ) {
-  const { candyMachine, authority, wallet } = accounts;
-
   const [data] = updateAuthorityStruct.serialize({
     instructionDiscriminator: updateAuthorityInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: candyMachine,
+      pubkey: accounts.candyMachine,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: false,
     },
   ];
 
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+    programId,
     keys,
     data,
   });

--- a/candy-machine/js/src/generated/instructions/updateCandyMachine.ts
+++ b/candy-machine/js/src/generated/instructions/updateCandyMachine.ts
@@ -22,7 +22,7 @@ export type UpdateCandyMachineInstructionArgs = {
  * @category UpdateCandyMachine
  * @category generated
  */
-const updateCandyMachineStruct = new beet.FixableBeetArgsStruct<
+export const updateCandyMachineStruct = new beet.FixableBeetArgsStruct<
   UpdateCandyMachineInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -49,7 +49,7 @@ export type UpdateCandyMachineInstructionAccounts = {
   wallet: web3.PublicKey;
 };
 
-const updateCandyMachineInstructionDiscriminator = [243, 251, 124, 156, 211, 211, 118, 239];
+export const updateCandyMachineInstructionDiscriminator = [243, 251, 124, 156, 211, 211, 118, 239];
 
 /**
  * Creates a _UpdateCandyMachine_ instruction.
@@ -64,33 +64,32 @@ const updateCandyMachineInstructionDiscriminator = [243, 251, 124, 156, 211, 211
 export function createUpdateCandyMachineInstruction(
   accounts: UpdateCandyMachineInstructionAccounts,
   args: UpdateCandyMachineInstructionArgs,
+  programId = new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
 ) {
-  const { candyMachine, authority, wallet } = accounts;
-
   const [data] = updateCandyMachineStruct.serialize({
     instructionDiscriminator: updateCandyMachineInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: candyMachine,
+      pubkey: accounts.candyMachine,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: false,
     },
   ];
 
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+    programId,
     keys,
     data,
   });

--- a/candy-machine/js/src/generated/instructions/withdrawFunds.ts
+++ b/candy-machine/js/src/generated/instructions/withdrawFunds.ts
@@ -13,7 +13,7 @@ import * as web3 from '@solana/web3.js';
  * @category WithdrawFunds
  * @category generated
  */
-const withdrawFundsStruct = new beet.BeetArgsStruct<{
+export const withdrawFundsStruct = new beet.BeetArgsStruct<{
   instructionDiscriminator: number[] /* size: 8 */;
 }>(
   [['instructionDiscriminator', beet.uniformFixedSizeArray(beet.u8, 8)]],
@@ -23,7 +23,7 @@ const withdrawFundsStruct = new beet.BeetArgsStruct<{
  * Accounts required by the _withdrawFunds_ instruction
  *
  * @property [_writable_] candyMachine
- * @property [**signer**] authority
+ * @property [_writable_, **signer**] authority
  * @category Instructions
  * @category WithdrawFunds
  * @category generated
@@ -33,7 +33,7 @@ export type WithdrawFundsInstructionAccounts = {
   authority: web3.PublicKey;
 };
 
-const withdrawFundsInstructionDiscriminator = [241, 36, 29, 111, 208, 31, 104, 217];
+export const withdrawFundsInstructionDiscriminator = [241, 36, 29, 111, 208, 31, 104, 217];
 
 /**
  * Creates a _WithdrawFunds_ instruction.
@@ -43,27 +43,28 @@ const withdrawFundsInstructionDiscriminator = [241, 36, 29, 111, 208, 31, 104, 2
  * @category WithdrawFunds
  * @category generated
  */
-export function createWithdrawFundsInstruction(accounts: WithdrawFundsInstructionAccounts) {
-  const { candyMachine, authority } = accounts;
-
+export function createWithdrawFundsInstruction(
+  accounts: WithdrawFundsInstructionAccounts,
+  programId = new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+) {
   const [data] = withdrawFundsStruct.serialize({
     instructionDiscriminator: withdrawFundsInstructionDiscriminator,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: candyMachine,
+      pubkey: accounts.candyMachine,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
-      isWritable: false,
+      pubkey: accounts.authority,
+      isWritable: true,
       isSigner: true,
     },
   ];
 
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+    programId,
     keys,
     data,
   });

--- a/candy-machine/program/src/processor/collection/set_collection.rs
+++ b/candy-machine/program/src/processor/collection/set_collection.rs
@@ -16,10 +16,12 @@ use crate::{
 pub struct SetCollection<'info> {
     #[account(mut, has_one = authority)]
     candy_machine: Account<'info, CandyMachine>,
+    #[account(mut)]
     authority: Signer<'info>,
     /// CHECK: account constraints checked in account trait
     #[account(mut, seeds = [b"collection".as_ref(), candy_machine.to_account_info().key.as_ref()], bump)]
     collection_pda: UncheckedAccount<'info>,
+    #[account(mut)]
     payer: Signer<'info>,
     system_program: Program<'info, System>,
     rent: Sysvar<'info, Rent>,
@@ -96,7 +98,7 @@ pub fn handle_set_collection(ctx: Context<SetCollection>) -> Result<()> {
             &ctx.accounts.collection_pda.to_account_info(),
             &ctx.accounts.rent.to_account_info(),
             &ctx.accounts.system_program.to_account_info(),
-            &ctx.accounts.authority.to_account_info(),
+            &ctx.accounts.payer.to_account_info(),
             COLLECTION_PDA_SIZE,
             &[
                 b"collection".as_ref(),

--- a/candy-machine/program/src/processor/collection/set_collection_during_mint.rs
+++ b/candy-machine/program/src/processor/collection/set_collection_during_mint.rs
@@ -12,7 +12,9 @@ pub struct SetCollectionDuringMint<'info> {
     #[account(has_one = authority)]
     candy_machine: Account<'info, CandyMachine>,
     /// CHECK: account checked in CPI/instruction sysvar
+    #[account(mut)]
     metadata: UncheckedAccount<'info>,
+    #[account(mut)]
     payer: Signer<'info>,
     #[account(mut, seeds = [b"collection".as_ref(), candy_machine.to_account_info().key.as_ref()], bump)]
     collection_pda: Account<'info, CollectionPDA>,

--- a/candy-machine/program/src/processor/withdraw.rs
+++ b/candy-machine/program/src/processor/withdraw.rs
@@ -7,7 +7,7 @@ use crate::{cmp_pubkeys, CandyError, CandyMachine};
 pub struct WithdrawFunds<'info> {
     #[account(mut, has_one = authority)]
     candy_machine: Account<'info, CandyMachine>,
-    #[account(address = candy_machine.authority)]
+    #[account(mut)]
     authority: Signer<'info>,
     // > Only if collection
     // CollectionPDA account


### PR DESCRIPTION
- `SetCollection`: `authority` and `payer` need to be mutable to invoke [ApproveCollectionAuthority](https://docs.metaplex.com/programs/token-metadata/instructions#approve-a-new-collection-authority). also made `payer` to pay for account creation because it's more appropriate than `authority`
- `SetCollectionDuringMint`: `metadata` and `payer` need to be mutable to invoke [SetAndVerifyCollection](https://docs.metaplex.com/programs/token-metadata/instructions#set-and-verify-the-collection)
- `WithdrawFunds`: `authority` needs to be mutable to receive funds. also removing address check since there is an identical `has_one` above