### PR TITLE
build: use existing yarn workspace inside publish version workflow

### DIFF
--- a/.github/actions/publish-version-changes/action.yaml
+++ b/.github/actions/publish-version-changes/action.yaml
@@ -18,9 +18,9 @@ runs:
     - uses: actions/checkout@v3
 
     - name: Install dependency packages for script
+      # YARN_ENABLE_IMMUTABLE_INSTALLS=false so that we can temporarily use the packages for the action.
       run: |
-        yarn init --yes
-        yarn add @iarna/toml axios
+        YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn && yarn add -D @iarna/toml axios
       shell: bash
 
     - name: Make version changes
@@ -29,3 +29,10 @@ runs:
         script: |
           const script = require('.github/actions/publish-version-changes/script.js')
           await script(${{ inputs.changed-packages }}, '${{ inputs.cargo-token }}', '${{ inputs.npm-token }}')
+
+    - name: Cleanup dependency installs
+      # remove dependencies from package.json and then reset yarn.lock
+      run: |
+        yarn remove @iarna/toml axios
+        git restore yarn.lock
+      shell: bash


### PR DESCRIPTION
### Problem
Running `yarn init --yes` will overwrite the existing `package.json` with information about workplace packages. We can see this in a problematic workflows related to @samuelvanderwaal PR (#579):

1. `Sync versions on PR merge `: https://github.com/metaplex-foundation/metaplex-program-library/runs/7259707927?check_suite_focus=true
```
Usage Error: The nearest package directory (/home/runner/work/metaplex-program-library/metaplex-program-library/token-metadata/js) doesn't seem to be part of the project declared in /home/runner/work/metaplex-program-library/metaplex-program-library.
- If the project directory is right, it might be that you forgot to list token-metadata/js as a workspace.
- If it isn't, it's likely because you have a yarn.lock or package.json file there, confusing the project root detection.
```
2. `SDK Token Metadata`: https://github.com/metaplex-foundation/metaplex-program-library/runs/7259767991?check_suite_focus=true#logs
```
  ➤YN0000: │ 
  ➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
➤YN0000: └ Completed in 17m 56s
➤ YN0000: Failed with errors in 18m 49s
```

Because the error in (1), we didn't publish the most up-to-date [mpl-token-metadata](https://www.npmjs.com/package/@metaplex-foundation/mpl-token-metadata) package. The error in (2) happens when adding new dependencies in builds (from my experience) - [source](https://stackoverflow.com/questions/67062308/getting-yn0028-the-lockfile-would-have-been-modified-by-this-install-which-is-e). This is the same error I get when trying to run the [manual sync workflow](https://github.com/metaplex-foundation/metaplex-program-library/runs/7261174654?check_suite_focus=true). 

### Solution
Install dependency packages and then cleanup afterwards.

### Test

Even though publish didn't work (missing credentials), the upload almost worked in my personal fork: https://github.com/jshiohaha/metaplex-program-library/runs/7261279238?check_suite_focus=true