### PR TITLE
build: update NPM secret name

### DIFF
--- a/.github/workflows/manually-sync-package-versions.yml
+++ b/.github/workflows/manually-sync-package-versions.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           changed-packages: ${{ inputs.packages }}
           cargo-token: ${{ secrets.CARGO_TOKEN }}
-          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Issue
I used the wrong value for the NPM secret stored in GH 🤦🏼‍♂️ double checked here https://github.com/metaplex-foundation/metaplex-program-library/settings/secrets/actions

The [last manual sync workflow run](https://github.com/metaplex-foundation/metaplex-program-library/runs/7261794106?check_suite_focus=true) failed due to missing permissions - we can see the script was invoked with an empty secret: 

```
  with:
    script: const script = require('.github/actions/publish-version-changes/script.js')
  await script(["token-metadata/js"], '***', '')
```

This caused issues with permissions

```
npm ERR! code ENEEDAUTH
npm ERR! need auth This command requires you to be logged in to https://registry.npmjs.org/
npm ERR! need auth You need to authorize this machine using `npm adduser`
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2022-07-09T05_49_09_319Z-debug-0.log
could not process token-metadata/js - got error Error: Command failed: npm publish
```

### Solution

Update secret variable name
