### PR TITLE
build: disable immutable installs in verify package workflow

### DIFF
--- a/.github/workflows/verify-lib-on-pr-open.yml
+++ b/.github/workflows/verify-lib-on-pr-open.yml
@@ -73,6 +73,9 @@ jobs:
 
       - name: Generate library for modified packages
         id: generate-package-lib
+        # YARN_ENABLE_IMMUTABLE_INSTALLS=false is needed otherwise, we get this error:
+        # `The lockfile would have been modified by this install, which is explicitly forbidden.`
+        # Additionally, we aren't committing changes here.
         run: |
           pkgs=${{ needs.get-changes-scope.outputs.packages }}
           pkgs=(${pkgs//\"})
@@ -80,10 +83,12 @@ jobs:
             echo ">> changing dir $pkg/js"
             cd "$pkg/js"
             echo ">> setup local pcakage dependencies with yarn"
-            yarn
+            YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
             echo ">> generate library"
             yarn api:gen
             echo ">> git status"
+            # ignore any possible yarn.lock changes
+            git restore ../../yarn.lock
             git status
             if [[ $(git diff --stat) != '' ]]; then
               echo ">> $pkg needs changes - breaking early"


### PR DESCRIPTION
Recent runs of `verify-lib-on-pr-open` have been failing ([link](https://github.com/metaplex-foundation/metaplex-program-library/actions/workflows/verify-lib-on-pr-open.yml)) due to yarn updating yarn.lock on `yarn` command.

The only way I know how to fix this is adding `YARN_ENABLE_IMMUTABLE_INSTALLS=false` and then ignoring any yarn.lock changes.

Tested run here in my local fork: https://github.com/jshiohaha/metaplex-program-library/runs/7325387492?check_suite_focus=true