### PR TITLE
fix(auction/metaplex): replace saturating subs with checked_sub

### DIFF
--- a/auction/program/src/processor/place_bid.rs
+++ b/auction/program/src/processor/place_bid.rs
@@ -121,7 +121,6 @@ fn parse_accounts<'a, 'b: 'a>(
     Ok(accounts)
 }
 
-#[allow(clippy::absurd_extreme_comparisons)]
 pub fn place_bid<'r, 'b: 'r>(
     program_id: &Pubkey,
     accounts: &'r [AccountInfo<'b>],
@@ -304,7 +303,7 @@ pub fn place_bid<'r, 'b: 'r>(
 
     // Confirm payers SPL token balance is enough to pay the bid.
     let account: Account = Account::unpack_from_slice(&accounts.bidder_token.data.borrow())?;
-    if account.amount.saturating_sub(bid_price) < 0 {
+    if account.amount.checked_sub(bid_price).is_none() {
         msg!(
             "Amount is too small: {:?}, compared to account amount of {:?}",
             bid_price,

--- a/metaplex/program/src/processor/redeem_participation_bid.rs
+++ b/metaplex/program/src/processor/redeem_participation_bid.rs
@@ -206,9 +206,10 @@ fn charge_for_participation<'a>(
         }
     }
 
-    if bidder_token.amount.saturating_sub(price) < 0 as u64 {
-        return Err(MetaplexError::NotEnoughBalanceForParticipation.into());
-    }
+    bidder_token
+        .amount
+        .checked_sub(price)
+        .ok_or(MetaplexError::NotEnoughBalanceForParticipation)?;
 
     if price > 0 {
         auction_manager.add_to_collected_payment(safety_deposit_config_info, price)?;
@@ -226,7 +227,7 @@ fn charge_for_participation<'a>(
 }
 
 #[allow(clippy::unnecessary_cast)]
-#[allow(clippy::absurd_extreme_comparisons)]
+// #[allow(clippy::absurd_extreme_comparisons)]
 pub fn process_redeem_participation_bid<'a>(
     program_id: &'a Pubkey,
     accounts: &'a [AccountInfo<'a>],


### PR DESCRIPTION
There are a couple places in our code that use `saturating_sub` and then immediately compare against a value of less than 0. This is useless code since `saturating_sub` bottoms on the type's bound which is 0 for a `u64`. Thanks to Sissou for the report.