### PR TITLE
build: enable version workflow for changes in forks

### DIFF
--- a/.github/actions/make-version-changes/action.yaml
+++ b/.github/actions/make-version-changes/action.yaml
@@ -7,8 +7,21 @@ inputs:
   versioning:
     description: 'Versioning command(s)'
     required: true
-  branch:
-    description: 'Branch to checkout'
+  from-branch:
+    description: 'From branch'
+    required: true
+  from-repository:
+    description: 'From full repo name'
+    required: true
+  to-branch:
+    description: 'To branch'
+    required: true
+  to-repository:
+    description: 'To full repo name'
+    required: true
+  pull-number:
+    description:
+      'Pull request numeric ID. If this is empty, expect a commit-sha with an associated PR.'
     required: true
 
 runs:
@@ -16,7 +29,8 @@ runs:
   steps:
     - uses: actions/checkout@v3
       with:
-        ref: ${{ inputs.branch }}
+        ref: ${{ inputs.from-branch }}
+        repository: ${{ inputs.from-repository }}
 
     # cache and install cargo release
     - uses: actions/cache@v2
@@ -53,4 +67,11 @@ runs:
       with:
         script: |
           const script = require('.github/actions/make-version-changes/script.js')
-          await script({github, context, core, glob, io}, ${{ inputs.changed-packages }}, ${{ inputs.versioning }})
+          const change_config = {
+            from_repository: '${{ inputs.from-repository }}',
+            from_branch: '${{ inputs.from-branch }}',
+            to_repository: '${{ inputs.to-repository }}',
+            to_branch: '${{ inputs.to-branch }}',
+            pull_number: '${{ inputs.pull-number }}'
+          }
+          await script({github, context, core, glob, io, change_config}, ${{ inputs.changed-packages }}, ${{ inputs.versioning }})

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -8,6 +8,8 @@ permissions:
   id-token: write
   contents: write
   packages: write
+  issues: write # make comment
+  pull-requests: write # open PR
 
 env:
   NODE_VERSION: 17.0.1
@@ -26,9 +28,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
 
   get-changes-scope:
-    if:
-      contains(fromJson('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.review.author_association) == true &&
-      contains(fromJson('["approved", "commented"]'), github.event.review.state) == true
+    if: contains(fromJson('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.review.author_association) == true && contains(fromJson('["approved", "commented"]'), github.event.review.state) == true
     runs-on: ubuntu-latest
     outputs:
       changed-packages: ${{ steps.get-changed-package-scope.outputs.result }}
@@ -61,9 +61,7 @@ jobs:
             return JSON.stringify(Array.from(Object.keys(uniqueFilesObj)).map((el) => `\"${el}\"`))
 
   get-version-scope:
-    if:
-      contains(fromJson('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.review.author_association) == true &&
-      contains(fromJson('["approved", "commented"]'), github.event.review.state) == true
+    if: contains(fromJson('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.review.author_association) == true && contains(fromJson('["approved", "commented"]'), github.event.review.state) == true
     runs-on: ubuntu-latest
     outputs:
       versioning: ${{ steps.parse-version-info.outputs.versioning }}
@@ -97,4 +95,8 @@ jobs:
         with:
           changed-packages: ${{ needs.get-changes-scope.outputs.changed-packages }}
           versioning: ${{ needs.get-version-scope.outputs.versioning }}
-          branch: ${{ github.event.pull_request.head.ref }}
+          to-branch: ${{ github.event.pull_request.base.ref }}
+          to-repository: ${{ github.event.pull_request.base.repo.full_name }}
+          from-branch: ${{ github.event.pull_request.head.ref }}
+          from-repository: ${{ github.event.pull_request.head.repo.full_name }}
+          pull-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Context

Whenever someone comments `version patch|minor|major` on a PR, the `Version updates` workflow kicks off to make a version update. As of now, that version update is just **pushed** to the source branch - this works fine for PRs coming from the same repo.

* **Problem**:  The above flow breaks for PRs coming from forks - example [here](https://github.com/metaplex-foundation/metaplex-program-library/runs/7350428294?check_suite_focus=true). We cannot simply push commits to forks in a workflow - https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token.
* **Proposed solution**: Instead, I'm thinking we can 
  1. make the same version changes as usual, 
  2. open a new PR in the fork repo against the original PR branch
  3. comment on the original PR with a request to merge the new version PR

### Testing

* I tested the ability to create a new PR & comment on an existing PR - still TBD on if this seamlessly works across source + fork. I was only able to test within my fork.
  * Note: I modified the code to always take the forked version route for testing purposes
* Original PR with version comment: https://github.com/jshiohaha/metaplex-program-library/pull/68
* Workflow: https://github.com/jshiohaha/metaplex-program-library/runs/7415723850
* New PR from workflow: https://github.com/jshiohaha/metaplex-program-library/pull/69