### PR TITLE
fix: drop spl-associated-token-account to 1.0.3

### DIFF
--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.9.13"
 mpl-token-vault = { version = "0.1.0", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.2.0", features = [ "no-entrypoint" ] }
-spl-associated-token-account = { version = "1.0.5", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "1.0.3", features = ["no-entrypoint"] }
 thiserror = "1.0"
 borsh = "0.9.2"
 shank = { version = "~0.0.4" }


### PR DESCRIPTION
I missed this last dependency conflict on my other changes. [spl-associated-token-account 1.0.5](https://crates.io/crates/spl-associated-token-account/1.0.5/dependencies) depends on spl-token ^3.3.0 which causes conflicts when clients try to use the Rust package with other Solana dependencies which are pinned to spl-token 3.2. We need to stay on 3.2 until we bump everything to the 1.10 series.