### PR TITLE
build: add workflow to integrate sugar cli test

### DIFF
--- a/.github/workflows/run-sugar-cli-test.yml
+++ b/.github/workflows/run-sugar-cli-test.yml
@@ -1,0 +1,48 @@
+name: Run Sugar CLI Test
+
+on:
+  workflow_dispatch:
+
+env:
+  SOLANA_VERSION: 1.9.22
+  RUST_TOOLCHAIN: stable
+
+jobs:
+  run-sugar-cli-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install-linux-build-deps
+      - uses: ./.github/actions/install-solana
+        with:
+          solana_version: ${{ env.SOLANA_VERSION }}
+      - uses: ./.github/actions/install-rust
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+      - run: solana-keygen new -o $GITHUB_WORKSPACE/kp --no-bip39-passphrase
+        shell: bash
+
+      - run: solana config set --url https://api.devnet.solana.com --keypair $GITHUB_WORKSPACE/kp
+        shell: bash
+
+      # note: must specify config before this command, or directly specify network. otherwise, airdrop might fail.
+      - run: solana airdrop 1 $(solana address -k $GITHUB_WORKSPACE/kp)
+        shell: bash
+
+      - run: solana balance $(solana address -k $GITHUB_WORKSPACE/kp)
+        shell: bash
+
+      # install the publicly available binary for the lifetime of the workflow
+      - name: Install Stable Sugar
+        run: bash <(curl -sSf https://sugar.metaplex.com/install.sh)
+        shell: bash
+
+      # we need to actually reference the test script to run it, so we'll clone the repo and launch the script from there
+      - name: Pull in test script from Sugar repository (outside of MPL)
+        shell: bash
+        run: cd .. && git clone https://github.com/metaplex-foundation/sugar.git && cd sugar
+
+      - name: Run test script from sugar directory
+        shell: bash
+        run: cd ../sugar && echo | ./script/sugar-cli-test.sh


### PR DESCRIPTION
Per Linear task, add [Sugar CLI test script](https://github.com/metaplex-foundation/sugar/blob/main/script/sugar-cli-test.sh) from [Sugar](https://github.com/metaplex-foundation/sugar) repository.

Right now, it's manually invoked and runs against candy machine deployed on devnet (default config). 

We need to decide what (if any) events should invoke the workflow, e.g. push to master with candy machine change. I think we could also convert it to an action and integrate with the existing candy machine program workflow.