### PR TITLE
Add overflow-checks to the release profile

### DIFF
--- a/auction-house/program/Cargo.toml
+++ b/auction-house/program/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 name = "mpl-auction-house"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 description = "Decentralized Sales Protocol for Solana Tokens"
 authors = ["Metaplex Developers <dev@metaplex.com>"]

--- a/auction-house/program/Cargo.toml
+++ b/auction-house/program/Cargo.toml
@@ -40,3 +40,6 @@ mpl-testing-utils= {path="../../core/rust/testing-utils" }
 solana-program-test = "~1.9.28"
 solana-sdk = "~1.9.28"
 env_logger="~0.9.0"
+
+[profile.release]
+overflow-checks = true     # Disable integer overflow checks.

--- a/auction-house/program/Cargo.toml
+++ b/auction-house/program/Cargo.toml
@@ -42,4 +42,4 @@ solana-sdk = "~1.9.28"
 env_logger="~0.9.0"
 
 [profile.release]
-overflow-checks = true     # Disable integer overflow checks.
+overflow-checks = true     # Enable integer overflow checks.


### PR DESCRIPTION
This commit adds `overflow-checks=true` to the release profile of the Auction House contract as a security precaution against unexpected behaviour regarding unchecked arithmetic operations in the program in a release build.

The recommendation comes from an audit by Halborn.