### PR TITLE
Removing testnet tests

### DIFF
--- a/.github/workflows/program-auction-house.yml
+++ b/.github/workflows/program-auction-house.yml
@@ -74,6 +74,7 @@ jobs:
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         TEST: ${{fromJson(needs.setup-tests.outputs.tests)}}
         SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}

--- a/.github/workflows/program-auction-house.yml
+++ b/.github/workflows/program-auction-house.yml
@@ -21,9 +21,8 @@ jobs:
         run: |
           sudo apt-get install -y jq && \
           MAINNET=$(curl https://api.mainnet-beta.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
-          TESTNET=$(curl https://api.testnet.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
           DEVNET=$(curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
-          VERSIONS=($MAINNET $TESTNET $DEVNET) && \
+          VERSIONS=($MAINNET $DEVNET) && \
           echo "${VERSIONS[@]}" && \
           VERSION_JSON=$(echo "${VERSIONS[@]}" | jq -s -c) && \
           echo $VERSION_JSON && \

--- a/.github/workflows/program-auctioneer.yml
+++ b/.github/workflows/program-auctioneer.yml
@@ -21,9 +21,8 @@ jobs:
         run: |
           sudo apt-get install -y jq && \
           MAINNET=$(curl https://api.mainnet-beta.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
-          TESTNET=$(curl https://api.testnet.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
           DEVNET=$(curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
-          VERSIONS=($MAINNET $TESTNET $DEVNET) && \
+          VERSIONS=($MAINNET $DEVNET) && \
           echo "${VERSIONS[@]}" && \
           VERSION_JSON=$(echo "${VERSIONS[@]}" | jq -s -c) && \
           echo $VERSION_JSON && \

--- a/.github/workflows/program-auctioneer.yml
+++ b/.github/workflows/program-auctioneer.yml
@@ -75,6 +75,7 @@ jobs:
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         TEST: ${{fromJson(needs.setup-tests.outputs.tests)}}
         SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}


### PR DESCRIPTION
The testnet cluster uses 1.11 which requires cargo-test-sbf which doesn't seem to work with the installed Solana runtime. I'm punting and removing it from the test matrix.