### PR TITLE
fix: revoking collection authority only needs one signer

### DIFF
--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -409,7 +409,7 @@ pub enum MetadataInstruction {
 
     /// Revoke account to call [verify_collection] on this NFT.
     #[account(0, writable, name="collection_authority_record", desc="Collection Authority Record PDA")]
-    #[account(1, signer, writable, name="delegate_authority", desc="Delegated Collection Authority")]
+    #[account(1, writable, name="delegate_authority", desc="Delegated Collection Authority")]
     #[account(2, signer, writable, name="revoke_authority", desc="Update Authority, or Delegated Authority, of Collection NFT")]
     #[account(3, name="metadata", desc="Metadata account")]
     #[account(4, name="mint", desc="Mint of Metadata")]


### PR DESCRIPTION
Slight issue with the Shank macro of the `RevokeCollectionAuthority` instruction which bubbles up to the generated libraries used by the SDK.

We do not need the `delegate_authority` as a signer since the `revoke_authority` already plays that role.

See account meta below.

https://github.com/metaplex-foundation/metaplex-program-library/blob/4ff5133d416795234103486f76291e9e72dc40de/token-metadata/program/src/instruction.rs#L1254
