### PR TITLE
Bubblegum support and refactor `assert_data_valid` in `token-metadata`

### DIFF
--- a/token-metadata/Cargo.lock
+++ b/token-metadata/Cargo.lock
@@ -1691,6 +1691,7 @@ version = "1.3.3"
 dependencies = [
  "arrayref",
  "borsh",
+ "itertools",
  "mpl-token-vault",
  "num-derive",
  "num-traits",

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -26,6 +26,7 @@ borsh = "0.9.2"
 shank = { version = "~0.0.4" }
 serde = { version = "1.0.136", optional = true }
 serde_with = { version = "1.12.0", optional = true }
+itertools = "0.10.3"
 
 [dev-dependencies]
 solana-sdk = "1.9.13"

--- a/token-metadata/program/src/deprecated_processor.rs
+++ b/token-metadata/program/src/deprecated_processor.rs
@@ -18,7 +18,6 @@ pub fn process_deprecated_create_metadata_accounts<'a>(
     program_id: &'a Pubkey,
     accounts: &'a [AccountInfo<'a>],
     data: Data,
-    allow_direct_creator_writes: bool,
     is_mutable: bool,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
@@ -50,7 +49,7 @@ pub fn process_deprecated_create_metadata_accounts<'a>(
             collection: None,
             uses: None,
         },
-        allow_direct_creator_writes,
+        false,
         is_mutable,
         false,
         false,
@@ -83,7 +82,6 @@ pub fn process_deprecated_update_metadata_accounts(
                 &metadata,
                 false,
                 update_authority_info.is_signer,
-                true,
             )?;
             metadata.data = data;
         } else {

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -63,7 +63,6 @@ pub fn process_instruction<'a>(
                 program_id,
                 accounts,
                 args.data,
-                false,
                 args.is_mutable,
             )
         }
@@ -83,7 +82,6 @@ pub fn process_instruction<'a>(
                 program_id,
                 accounts,
                 args.data,
-                false,
                 args.is_mutable,
             )
         }
@@ -93,7 +91,6 @@ pub fn process_instruction<'a>(
                 program_id,
                 accounts,
                 args.data,
-                false,
                 args.is_mutable,
                 args.collection_details,
             )
@@ -249,7 +246,6 @@ pub fn process_create_metadata_accounts_v2<'a>(
     program_id: &'a Pubkey,
     accounts: &'a [AccountInfo<'a>],
     data: DataV2,
-    allow_direct_creator_writes: bool,
     is_mutable: bool,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
@@ -273,7 +269,7 @@ pub fn process_create_metadata_accounts_v2<'a>(
             rent_info,
         },
         data,
-        allow_direct_creator_writes,
+        false,
         is_mutable,
         false,
         true,
@@ -285,7 +281,6 @@ pub fn process_create_metadata_accounts_v3<'a>(
     program_id: &'a Pubkey,
     accounts: &'a [AccountInfo<'a>],
     data: DataV2,
-    allow_direct_creator_writes: bool,
     is_mutable: bool,
     collection_details: Option<CollectionDetails>,
 ) -> ProgramResult {
@@ -310,7 +305,7 @@ pub fn process_create_metadata_accounts_v3<'a>(
             rent_info,
         },
         data,
-        allow_direct_creator_writes,
+        false,
         is_mutable,
         false,
         true,
@@ -345,7 +340,6 @@ pub fn process_update_metadata_accounts_v2(
                 &metadata,
                 false,
                 update_authority_info.is_signer,
-                true,
             )?;
             metadata.data = compatible_data;
             assert_collection_update_is_valid(false, &metadata.collection, &data.collection)?;

--- a/token-metadata/program/src/state.rs
+++ b/token-metadata/program/src/state.rs
@@ -552,7 +552,7 @@ impl TokenMetadataAccount for Edition {
 
 #[repr(C)]
 #[cfg_attr(feature = "serde-feature", derive(Serialize, Deserialize))]
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone, Eq, Hash)]
 pub struct Creator {
     #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub address: Pubkey,

--- a/token-metadata/program/tests/create_metadata_account.rs
+++ b/token-metadata/program/tests/create_metadata_account.rs
@@ -424,6 +424,23 @@ mod create_meta_accounts {
 
         pass_creators(context, creators).await;
     }
+
+    #[tokio::test]
+    async fn two_unverified_creators_update_authority_not_creator() {
+        let context = program_test().start_with_context().await;
+        let (creator1, creator2) = (Keypair::new(), Keypair::new());
+        let creators = vec![&creator1, &creator2]
+            .into_iter()
+            .map(|creator| Creator {
+                address: creator.pubkey(),
+                share: 50,
+                verified: false,
+            })
+            .collect::<Vec<Creator>>();
+
+        pass_creators(context, creators).await;
+    }
+
     // -----------------
     // Uses Failures
     // -----------------


### PR DESCRIPTION
### Notes
- Remove requirement that one of the creators is the update authority
when metadata account is being created.
- Flatten some of the logic and use positive conditionals that
should be easier to understand.
- Use an iterator and hashmap instead of nested for loop to look for
duplicates.
- Allow Bubblegum program to create metadata with Verified Creators
 (feature currently hardcoded to inactive).

### Testing
- Added test to allow update authority to not be creato.
- Still working on testing the Bubblegum CPI (I don't think I can do that with the Banks client so looking to test it in Candyland repo).