### PR TITLE
Refactor `assert_data_valid` in `token-metadata`

### DIFF
--- a/token-metadata/program/src/deprecated_processor.rs
+++ b/token-metadata/program/src/deprecated_processor.rs
@@ -83,7 +83,6 @@ pub fn process_deprecated_update_metadata_accounts(
                 &metadata,
                 false,
                 update_authority_info.is_signer,
-                true,
             )?;
             metadata.data = data;
         } else {

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -345,7 +345,6 @@ pub fn process_update_metadata_accounts_v2(
                 &metadata,
                 false,
                 update_authority_info.is_signer,
-                true,
             )?;
             metadata.data = compatible_data;
             assert_collection_update_is_valid(false, &metadata.collection, &data.collection)?;

--- a/token-metadata/program/src/state.rs
+++ b/token-metadata/program/src/state.rs
@@ -552,7 +552,7 @@ impl TokenMetadataAccount for Edition {
 
 #[repr(C)]
 #[cfg_attr(feature = "serde-feature", derive(Serialize, Deserialize))]
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone, Eq, Hash)]
 pub struct Creator {
     #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub address: Pubkey,

--- a/token-metadata/program/src/utils.rs
+++ b/token-metadata/program/src/utils.rs
@@ -74,12 +74,11 @@ pub fn assert_data_valid(
         }
 
         // If there is an existing creator's array, store this in a hashmap as well.
-        let existing_creators_map: Option<HashMap<&Pubkey, &Creator>> =
-            if let Some(existing_creators) = &existing_metadata.data.creators {
-                Some(existing_creators.iter().map(|c| (&c.address, c)).collect())
-            } else {
-                None
-            };
+        let existing_creators_map: Option<HashMap<&Pubkey, &Creator>> = existing_metadata
+            .data
+            .creators
+            .as_ref()
+            .map(|existing_creators| existing_creators.iter().map(|c| (&c.address, c)).collect());
 
         // Loop over new creator's map.
         let mut share_total: u8 = 0;

--- a/token-metadata/program/src/utils.rs
+++ b/token-metadata/program/src/utils.rs
@@ -4,8 +4,8 @@ use crate::{
     error::MetadataError,
     pda::find_master_edition_account,
     state::{
-        get_reservation_list, CollectionDetails, Data, DataV2, Edition, EditionMarker, Key,
-        MasterEditionV1, MasterEditionV2, Metadata, TokenMetadataAccount, TokenStandard, Uses,
+        get_reservation_list, CollectionDetails, Creator, Data, DataV2, Edition, EditionMarker,
+        Key, MasterEditionV1, MasterEditionV2, Metadata, TokenMetadataAccount, TokenStandard, Uses,
         EDITION, EDITION_MARKER_BIT_SIZE, MAX_CREATOR_LIMIT, MAX_EDITION_LEN,
         MAX_EDITION_MARKER_SIZE, MAX_MASTER_EDITION_LEN, MAX_METADATA_LEN, MAX_NAME_LENGTH,
         MAX_SYMBOL_LENGTH, MAX_URI_LENGTH, PREFIX,
@@ -30,7 +30,7 @@ use spl_token::{
     instruction::{set_authority, AuthorityType},
     state::{Account, Mint},
 };
-use std::convert::TryInto;
+use std::{collections::HashMap, convert::TryInto};
 
 pub fn assert_data_valid(
     data: &Data,
@@ -38,7 +38,6 @@ pub fn assert_data_valid(
     existing_metadata: &Metadata,
     allow_direct_creator_writes: bool,
     update_authority_is_signer: bool,
-    is_updating: bool,
 ) -> ProgramResult {
     if data.name.len() > MAX_NAME_LENGTH {
         return Err(MetadataError::NameTooLong.into());
@@ -55,79 +54,103 @@ pub fn assert_data_valid(
     if data.seller_fee_basis_points > 10000 {
         return Err(MetadataError::InvalidBasisPoints.into());
     }
-    if data.creators.is_some() {
-        if let Some(creators) = &data.creators {
-            if creators.len() > MAX_CREATOR_LIMIT {
-                return Err(MetadataError::CreatorsTooLong.into());
+
+    if let Some(creators) = &data.creators {
+        if creators.len() > MAX_CREATOR_LIMIT {
+            return Err(MetadataError::CreatorsTooLong.into());
+        }
+
+        if creators.is_empty() {
+            return Err(MetadataError::CreatorsMustBeAtleastOne.into());
+        }
+
+        // Store caller-supplied creator's array into a hashmap for direct lookup.
+        let new_creators_map: HashMap<&Pubkey, &Creator> =
+            creators.iter().map(|c| (&c.address, c)).collect();
+
+        // Do not allow duplicate entries in the creator's array.
+        if new_creators_map.len() != creators.len() {
+            return Err(MetadataError::DuplicateCreatorAddress.into());
+        }
+
+        // If there is an existing creator's array, store this in a hashmap as well.
+        let existing_creators_map: Option<HashMap<&Pubkey, &Creator>> =
+            if let Some(existing_creators) = &existing_metadata.data.creators {
+                Some(existing_creators.iter().map(|c| (&c.address, c)).collect())
+            } else {
+                None
+            };
+
+        // Loop over new creator's map.
+        let mut share_total: u8 = 0;
+        for (address, creator) in &new_creators_map {
+            // Add up creator shares.  After looping through all creators, will
+            // verify it adds up to 100%.
+            share_total = share_total
+                .checked_add(creator.share)
+                .ok_or(MetadataError::NumericalOverflowError)?;
+
+            // If this flag is set we are allowing any and all creators to be marked as verified
+            // without further checking.  This can only be done in special circumstances when the
+            // metadata is fully trusted such as when minting a limited edition.  Note we are still
+            // checking that creator share adds up to 100%.
+            if allow_direct_creator_writes {
+                continue;
             }
 
-            if creators.is_empty() {
-                return Err(MetadataError::CreatorsMustBeAtleastOne.into());
-            } else {
-                let mut found = false;
-                let mut total: u8 = 0;
-                for i in 0..creators.len() {
-                    let creator = &creators[i];
-                    for iter in creators.iter().skip(i + 1) {
-                        if iter.address == creator.address {
-                            return Err(MetadataError::DuplicateCreatorAddress.into());
-                        }
-                    }
+            // If this specific creator (of this loop iteration) is a signer and an update
+            // authority, then we are fine with this creator either setting or clearing its
+            // own `creator.verified` flag.
+            if update_authority_is_signer && **address == *update_authority {
+                continue;
+            }
 
-                    total = total
-                        .checked_add(creator.share)
-                        .ok_or(MetadataError::NumericalOverflowError)?;
-
-                    if creator.address == *update_authority {
-                        found = true;
+            // If the previous two conditions are not true then we check the state in the existing
+            // metadata creators array (if it exists) before allowing `creator.verified` to be set.
+            if let Some(existing_creators_map) = &existing_creators_map {
+                if existing_creators_map.contains_key(address) {
+                    // If this specific creator (of this loop iteration) is in the existing
+                    // creator's array, then it's `creator.verified` flag must match the existing
+                    // state.
+                    if creator.verified && !existing_creators_map[address].verified {
+                        return Err(MetadataError::CannotVerifyAnotherCreator.into());
+                    } else if !creator.verified && existing_creators_map[address].verified {
+                        return Err(MetadataError::CannotUnverifyAnotherCreator.into());
                     }
-
-                    // Dont allow metadata owner to unilaterally say a creator verified...
-                    // cross check with array, only let them say verified=true here if
-                    // it already was true and in the array.
-                    // Conversely, dont let a verified creator be wiped.
-                    if (!update_authority_is_signer || creator.address != *update_authority)
-                        && !allow_direct_creator_writes
-                    {
-                        if let Some(existing_creators) = &existing_metadata.data.creators {
-                            match existing_creators
-                                .iter()
-                                .find(|c| c.address == creator.address)
-                            {
-                                Some(existing_creator) => {
-                                    if creator.verified && !existing_creator.verified {
-                                        return Err(
-                                            MetadataError::CannotVerifyAnotherCreator.into()
-                                        );
-                                    } else if !creator.verified && existing_creator.verified {
-                                        return Err(
-                                            MetadataError::CannotUnverifyAnotherCreator.into()
-                                        );
-                                    }
-                                }
-                                None => {
-                                    if creator.verified {
-                                        return Err(
-                                            MetadataError::CannotVerifyAnotherCreator.into()
-                                        );
-                                    }
-                                }
-                            }
-                        } else if creator.verified {
-                            return Err(MetadataError::CannotVerifyAnotherCreator.into());
-                        }
-                    }
+                } else if creator.verified {
+                    // If this specific creator is not in the existing creator's array, then we
+                    // cannot set `creator.verified`.
+                    return Err(MetadataError::CannotVerifyAnotherCreator.into());
                 }
+            } else if creator.verified {
+                // If there is no existing creators array, we cannot set `creator.verified`.
+                return Err(MetadataError::CannotVerifyAnotherCreator.into());
+            }
+        }
 
-                if !found && !allow_direct_creator_writes && !is_updating {
-                    return Err(MetadataError::MustBeOneOfCreators.into());
-                }
-                if total != 100 {
-                    return Err(MetadataError::ShareTotalMustBe100.into());
+        // Ensure share total is 100%.
+        if share_total != 100 {
+            return Err(MetadataError::ShareTotalMustBe100.into());
+        }
+
+        // Next make sure there were not any existing creators that were already verified but not
+        // listed in the new creator's array.
+        if allow_direct_creator_writes {
+            return Ok(());
+        } else if let Some(existing_creators_map) = &existing_creators_map {
+            for (address, existing_creator) in existing_creators_map {
+                // If this specific existing creator (of this loop iteration is a signer and an
+                // update authority, then we are fine with this creator clearing its own
+                // `creator.verified` flag.
+                if update_authority_is_signer && **address == *update_authority {
+                    continue;
+                } else if !new_creators_map.contains_key(address) && existing_creator.verified {
+                    return Err(MetadataError::CannotUnverifyAnotherCreator.into());
                 }
             }
         }
     }
+
     Ok(())
 }
 
@@ -599,7 +622,8 @@ pub fn mint_limited_edition<'a>(
             total: u.total,
         }),
     };
-    // create the metadata the normal way...
+    // create the metadata the normal way, except `allow_direct_creator_writes` is set to true
+    // because we are directly copying from the Master Edition metadata.
 
     process_create_metadata_accounts_logic(
         program_id,
@@ -946,7 +970,6 @@ pub fn process_create_metadata_accounts_logic(
         &metadata,
         allow_direct_creator_writes,
         update_authority_info.is_signer,
-        false,
     )?;
 
     let mint_decimals = get_mint_decimals(mint_info)?;

--- a/token-metadata/program/tests/create_metadata_account.rs
+++ b/token-metadata/program/tests/create_metadata_account.rs
@@ -424,6 +424,23 @@ mod create_meta_accounts {
 
         pass_creators(context, creators).await;
     }
+
+    #[tokio::test]
+    async fn two_unverified_creators_update_authority_not_creator() {
+        let context = program_test().start_with_context().await;
+        let (creator1, creator2) = (Keypair::new(), Keypair::new());
+        let creators = vec![&creator1, &creator2]
+            .into_iter()
+            .map(|creator| Creator {
+                address: creator.pubkey(),
+                share: 50,
+                verified: false,
+            })
+            .collect::<Vec<Creator>>();
+
+        pass_creators(context, creators).await;
+    }
+
     // -----------------
     // Uses Failures
     // -----------------

--- a/token-metadata/program/tests/update_metadata_account_v2.rs
+++ b/token-metadata/program/tests/update_metadata_account_v2.rs
@@ -667,6 +667,7 @@ mod update_metadata_account_v2 {
         let creator2 = Keypair::new();
         let creator3 = Keypair::new();
         let creator4 = Keypair::new();
+        let creator5 = Keypair::new();
 
         let creators = vec![
             Creator {
@@ -689,9 +690,8 @@ mod update_metadata_account_v2 {
                 verified: false,
                 share: 20,
             },
-            // Context key must be in array or we get an error.
             Creator {
-                address: context.payer.pubkey(),
+                address: creator5.pubkey(),
                 verified: false,
                 share: 20,
             },
@@ -801,4 +801,185 @@ mod update_metadata_account_v2 {
 
         assert_custom_error!(result, MetadataError::InvalidUseMethod);
     }
+
+    #[tokio::test]
+    async fn fail_cannot_unverify_another_creator_by_changing_array() {
+        let mut context = program_test().start_with_context().await;
+        let creators = vec![
+            Creator {
+                address: context.payer.pubkey(),
+                verified: true,
+                share: 100,
+            },
+        ];
+
+        // Create metadata with one verified creator.
+        let test_metadata = Metadata::new();
+        test_metadata
+            .create_v2(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                Some(creators),
+                10,
+                true,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Update authority.
+        let new_update_authority = Keypair::new();
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::update_metadata_accounts_v2(
+                id(),
+                test_metadata.pubkey,
+                context.payer.pubkey(),
+                Some(new_update_authority.pubkey()),
+                None,
+                None,
+                None,
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+        context.banks_client.process_transaction(tx).await.unwrap();
+
+        // Try to update metadata with a different verified creator.
+        let new_creators = vec![
+            Creator {
+                address: context.payer.pubkey(),
+                verified: false,
+                share: 50,
+            },
+            Creator {
+                address: new_update_authority.pubkey(),
+                verified: true,
+                share: 50,
+            },
+        ];
+
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::update_metadata_accounts_v2(
+                id(),
+                test_metadata.pubkey,
+                new_update_authority.pubkey(),
+                None,
+                Some(DataV2 {
+                    name: "Test".to_string(),
+                    symbol: "TST".to_string(),
+                    uri: "uri".to_string(),
+                    creators: Some(new_creators),
+                    seller_fee_basis_points: 10,
+                    collection: None,
+                    uses: None
+                }),
+                None,
+                None,
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &new_update_authority],
+            context.last_blockhash,
+        );
+
+        let result = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
+
+        assert_custom_error!(result, MetadataError::CannotUnverifyAnotherCreator);
+    }
+}
+
+#[tokio::test]
+async fn fail_cannot_unverify_another_creator_by_removing_from_array() {
+    let mut context = program_test().start_with_context().await;
+    let creators = vec![
+        Creator {
+            address: context.payer.pubkey(),
+            verified: true,
+            share: 100,
+        },
+    ];
+
+    // Create metadata with one verified creator.
+    let test_metadata = Metadata::new();
+    test_metadata
+        .create_v2(
+            &mut context,
+            "Test".to_string(),
+            "TST".to_string(),
+            "uri".to_string(),
+            Some(creators),
+            10,
+            true,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Update authority.
+    let new_update_authority = Keypair::new();
+    let tx = Transaction::new_signed_with_payer(
+        &[instruction::update_metadata_accounts_v2(
+            id(),
+            test_metadata.pubkey,
+            context.payer.pubkey(),
+            Some(new_update_authority.pubkey()),
+            None,
+            None,
+            None,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Try to update metadata with a different verified creator.
+    let new_creators = vec![
+        Creator {
+            address: new_update_authority.pubkey(),
+            verified: true,
+            share: 100,
+        },
+    ];
+
+    let tx = Transaction::new_signed_with_payer(
+        &[instruction::update_metadata_accounts_v2(
+            id(),
+            test_metadata.pubkey,
+            new_update_authority.pubkey(),
+            None,
+            Some(DataV2 {
+                name: "Test".to_string(),
+                symbol: "TST".to_string(),
+                uri: "uri".to_string(),
+                creators: Some(new_creators),
+                seller_fee_basis_points: 10,
+                collection: None,
+                uses: None
+            }),
+            None,
+            None,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &new_update_authority],
+        context.last_blockhash,
+    );
+
+    let result = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    assert_custom_error!(result, MetadataError::CannotUnverifyAnotherCreator);
 }

--- a/token-metadata/program/tests/update_metadata_account_v2.rs
+++ b/token-metadata/program/tests/update_metadata_account_v2.rs
@@ -805,13 +805,11 @@ mod update_metadata_account_v2 {
     #[tokio::test]
     async fn fail_cannot_unverify_another_creator_by_changing_array() {
         let mut context = program_test().start_with_context().await;
-        let creators = vec![
-            Creator {
-                address: context.payer.pubkey(),
-                verified: true,
-                share: 100,
-            },
-        ];
+        let creators = vec![Creator {
+            address: context.payer.pubkey(),
+            verified: true,
+            share: 100,
+        }];
 
         // Create metadata with one verified creator.
         let test_metadata = Metadata::new();
@@ -876,7 +874,7 @@ mod update_metadata_account_v2 {
                     creators: Some(new_creators),
                     seller_fee_basis_points: 10,
                     collection: None,
-                    uses: None
+                    uses: None,
                 }),
                 None,
                 None,
@@ -899,13 +897,11 @@ mod update_metadata_account_v2 {
 #[tokio::test]
 async fn fail_cannot_unverify_another_creator_by_removing_from_array() {
     let mut context = program_test().start_with_context().await;
-    let creators = vec![
-        Creator {
-            address: context.payer.pubkey(),
-            verified: true,
-            share: 100,
-        },
-    ];
+    let creators = vec![Creator {
+        address: context.payer.pubkey(),
+        verified: true,
+        share: 100,
+    }];
 
     // Create metadata with one verified creator.
     let test_metadata = Metadata::new();
@@ -944,13 +940,11 @@ async fn fail_cannot_unverify_another_creator_by_removing_from_array() {
     context.banks_client.process_transaction(tx).await.unwrap();
 
     // Try to update metadata with a different verified creator.
-    let new_creators = vec![
-        Creator {
-            address: new_update_authority.pubkey(),
-            verified: true,
-            share: 100,
-        },
-    ];
+    let new_creators = vec![Creator {
+        address: new_update_authority.pubkey(),
+        verified: true,
+        share: 100,
+    }];
 
     let tx = Transaction::new_signed_with_payer(
         &[instruction::update_metadata_accounts_v2(
@@ -965,7 +959,7 @@ async fn fail_cannot_unverify_another_creator_by_removing_from_array() {
                 creators: Some(new_creators),
                 seller_fee_basis_points: 10,
                 collection: None,
-                uses: None
+                uses: None,
             }),
             None,
             None,


### PR DESCRIPTION
### Notes
- Remove requirement that one of the creators is the update authority
when metadata account is being created.
- Flatten some of the logic and use positive conditionals that
should be easier to understand.
- Use hashmaps instead of nested loops/iterators to look for duplicates
in one Vec or common addresses between multiple Vecs.
- Add new check for existing verified creators in assert_data_valid.

### Tests
- Adding tests for:
  - allow update authority to not be creator.
  - cannot unverify another creator by changing the verified flag.
  - cannot unverify another creator by removing them from the array.