### PR TITLE
build: process PR review content body

### DIFF
--- a/.github/actions/parse-version-command/script.js
+++ b/.github/actions/parse-version-command/script.js
@@ -5,7 +5,8 @@ const VERSIONING_COMMAND = /^version/g;
 const parse = (body) => {
   const trimmedBody = body
     .toLowerCase()
-    .split('\n')
+    .split(/\n|\r/)
+    .map((t) => t.trim())
     .filter((t) => t.length > 0);
 
   const validVersionCmds = trimmedBody.filter((c) => VERSIONING_COMMAND.test(c.trim()));

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -68,11 +68,30 @@ jobs:
       has-versioning: ${{ steps.parse-version-info.outputs.has-versioning }}
     steps:
       - uses: actions/checkout@v3
+
+      # GH doesn't process or format body fields, so we do some light processing so that multiline comments will break inputs
+      - name: Process content body
+        id: process-content-body
+        run: |
+          REVIEW_CONTENT=$(cat << EOF
+          ${{ github.event.review.body }}
+          EOF
+          )
+          REVIEW_CONTENT="${REVIEW_CONTENT//\'/}"
+          REVIEW_CONTENT="${REVIEW_CONTENT//$'\n'/\\n}"
+          REVIEW_CONTENT="${REVIEW_CONTENT//$'\r'/\\r}"
+          echo "::set-output name=content::$REVIEW_CONTENT"
+        shell: bash
+
+      - name: Log processed content body
+        run: echo "${{ steps.process-content-body.outputs.content }}"
+        shell: bash
+
       - name: Parse version info from review
         uses: ./.github/actions/parse-version-command
         id: parse-version-info
         with:
-          body: ${{ github.event.review.body }}
+          body: ${{ steps.process-content-body.outputs.content }}
 
   update-pr-with-changes:
     needs: [get-changes-scope, get-version-scope]


### PR DESCRIPTION
GH doesn't provide out-of-the-box support for multi-line content bodies, so here we will replace actual returns & newlines with `\n\r` characters. Now, the workflow should work with comments like this

#### Sample input 1
```
This is a

multi-line

comment. Please don't break

the CI
```

#### Sample input 2 (https://github.com/metaplex-foundation/metaplex-program-library/runs/7679798500?check_suite_focus=true)
```
This looks good to me, 
  
my only question is a logic one should we allow them to set FungibleAsset if the mint has a higher than one max supply. I dont think that answer should be scoped to this PR
```

### Testing PR in my personal fork
* https://github.com/jshiohaha/metaplex-program-library/pull/127
 * Job 1 with **Sample input 1**: https://github.com/jshiohaha/metaplex-program-library/actions/runs/2802194714
 * Job 2 with **Sample input 2**: https://github.com/jshiohaha/metaplex-program-library/actions/runs/2802193373


