### PR TITLE
build: pull out get solana version logic into an action and reuse across workflows

### DIFF
--- a/.github/actions/get-solana-versions/action.yaml
+++ b/.github/actions/get-solana-versions/action.yaml
@@ -1,0 +1,24 @@
+name: 'Get Solana network versions'
+description: 'Returns unique solana versions (mainnet-beta, devnet)'
+
+outputs:
+  value:
+    description: Solana devnet and mainnet versions
+    value: ${{ steps.fetch-solana-versions.outputs.value }}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+    - name: Invoke getVersions to get current Solana network versions
+      id: fetch-solana-versions
+      shell: bash
+      run: |
+        sudo apt-get install -y jq && \
+        MAINNET=$(curl https://api.mainnet-beta.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
+        DEVNET=$(curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
+        VERSIONS=($MAINNET $DEVNET) && \
+        echo "${VERSIONS[@]}" && \
+        VERSION_JSON=$(echo "${VERSIONS[@]}" | jq -s -c 'unique') && \
+        echo $VERSION_JSON && \
+        echo "::set-output name=value::$VERSION_JSON"

--- a/.github/workflows/integration-fixed-price-sale.yml
+++ b/.github/workflows/integration-fixed-price-sale.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.5
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -32,12 +31,30 @@ jobs:
             - 'fixed-price-sale/**'
           workflow:
             - '.github/workflows/integration-fixed-price-sale.yml '
-  build-and-integration-test-fixed-price-sale:
+
+  setup-versions:
+    needs: [changes]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+  build-and-integration-test-fixed-price-sale:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-fixed-price-sale
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
+
     steps:
       # Setup Deps
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-metaplex.yml
+++ b/.github/workflows/integration-metaplex.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.14
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -29,12 +28,30 @@ jobs:
             - 'core/**'
           package:
             - 'metaplex/**'
-  build-and-integration-test-metaplex:
-    runs-on: ubuntu-latest
-    env:
-      cache_id: program-metaplex 
-    needs: changes
+
+  setup-versions:
+    needs: [changes]
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+  build-and-integration-test-metaplex:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
+    env:
+      cache_id: program-metaplex
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
+
     steps:
       # Setup Deps
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-token-vault.yml
+++ b/.github/workflows/integration-token-vault.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.14
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -32,12 +31,30 @@ jobs:
             - 'token-vault/**'
           workflow:
             - '.github/workflows/integration-token-vault.yml'
-  build-and-integration-test-token-vault:
+
+  setup-versions:
+    needs: [changes]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+  build-and-integration-test-token-vault:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-token-vault 
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
+
     steps:
       # Setup Deps
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-token-vault.yml
+++ b/.github/workflows/integration-token-vault.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  SOLANA_VERSION: 1.10.0
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -32,29 +33,12 @@ jobs:
           workflow:
             - '.github/workflows/integration-token-vault.yml'
 
-  setup-versions:
-    needs: [changes]
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
-    runs-on: ubuntu-latest
-    outputs:
-      versions: ${{ steps.get-solana-versions.outputs.value }}
-    steps:
-      - uses: actions/checkout@v3
-      - id: get-solana-versions
-        uses: ./.github/actions/get-solana-versions
-
   build-and-integration-test-token-vault:
-    needs: [changes, setup-versions]
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-token-vault 
-      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
-
+    needs: changes
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
     steps:
       # Setup Deps
       - uses: actions/checkout@v2

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -13,8 +13,8 @@ permissions:
 
 env:
   NODE_VERSION: 17.0.1
+  # todo: pull from package's Cargo.toml?
   ANCHOR_VERSION: 0.22.0
-  SOLANA_VERSION_STABLE: 1.9.22
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -27,8 +27,23 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
 
+  qualify-workflow-run:
+    runs-on: ubuntu-latest
+    outputs:
+      output: ${{ steps.qualify-run.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: qualify-run
+        shell: bash
+        run: |
+          WORKFLOW_QUALIFIER=${{ contains(fromJson('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.review.author_association) == true }}
+          WORKFLOW_QUALIFIER=$WORKFLOW_QUALIFIER && ${{ contains(fromJson('["approved", "commented"]'), github.event.review.state) == true }}
+          WORKFLOW_QUALIFIER=$WORKFLOW_QUALIFIER && ${{ github.event.pull_request.number > 0 }}
+          echo "::set-output name=value::$WORKFLOW_QUALIFIER"
+
   get-changes-scope:
-    if: contains(fromJson('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.review.author_association) == true && contains(fromJson('["approved", "commented"]'), github.event.review.state) == true
+    needs: [qualify-workflow-run]
+    if: ${{ needs.qualify-workflow-run.outputs.output == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       changed-packages: ${{ steps.get-changed-package-scope.outputs.result }}
@@ -61,7 +76,8 @@ jobs:
             return JSON.stringify(Array.from(Object.keys(uniqueFilesObj)).map((el) => `\"${el}\"`))
 
   get-version-scope:
-    if: contains(fromJson('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.review.author_association) == true && contains(fromJson('["approved", "commented"]'), github.event.review.state) == true
+    needs: [qualify-workflow-run]
+    if: ${{ needs.qualify-workflow-run.outputs.output == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       versioning: ${{ steps.parse-version-info.outputs.versioning }}
@@ -93,16 +109,34 @@ jobs:
         with:
           body: ${{ steps.process-content-body.outputs.content }}
 
+  setup-versions:
+    needs: [qualify-workflow-run]
+    if: ${{ needs.qualify-workflow-run.outputs.output == 'true' }}
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
   update-pr-with-changes:
-    needs: [get-changes-scope, get-version-scope]
+    needs: [get-changes-scope, get-version-scope, setup-versions]
     if: ${{ needs.get-version-scope.outputs.has-versioning == 'true' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
+    env:
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
+
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-linux-build-deps
       - uses: ./.github/actions/install-solana
         with:
-          solana_version: ${{ env.SOLANA_VERSION_STABLE }}
+          solana_version: ${{ env.SOLANA_VERSION }}
       - uses: ./.github/actions/install-rust
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}

--- a/.github/workflows/program-auction-house.yml
+++ b/.github/workflows/program-auction-house.yml
@@ -15,20 +15,12 @@ jobs:
   setup-versions:
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.matrix.outputs.value }}
+      versions: ${{ steps.get-solana-versions.outputs.value }}
     steps:
-      - id: matrix
-        run: |
-          sudo apt-get install -y jq && \
-          MAINNET=$(curl https://api.mainnet-beta.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
-          DEVNET=$(curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
-          VERSIONS=($MAINNET $DEVNET) && \
-          echo "${VERSIONS[@]}" && \
-          VERSION_JSON=$(echo "${VERSIONS[@]}" | jq -s -c) && \
-          echo $VERSION_JSON && \
-          echo "::set-output name=value::$VERSION_JSON"
-        shell: bash
-  
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
   setup-tests:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/program-auction.yml
+++ b/.github/workflows/program-auction.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.15
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -29,12 +28,29 @@ jobs:
               - 'core/**'
             package:
               - 'auction/**'
-  build-and-test-auction:
-    needs: changes
+
+  setup-versions:
+    needs: [changes]
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+  build-and-test-auction:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-auction
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
 
     steps:
       # Setup Deps

--- a/.github/workflows/program-auctioneer.yml
+++ b/.github/workflows/program-auctioneer.yml
@@ -15,20 +15,12 @@ jobs:
   setup-versions:
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.matrix.outputs.value }}
+      versions: ${{ steps.get-solana-versions.outputs.value }}
     steps:
-      - id: matrix
-        run: |
-          sudo apt-get install -y jq && \
-          MAINNET=$(curl https://api.mainnet-beta.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
-          DEVNET=$(curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' | jq '.result["solana-core"]') && \
-          VERSIONS=($MAINNET $DEVNET) && \
-          echo "${VERSIONS[@]}" && \
-          VERSION_JSON=$(echo "${VERSIONS[@]}" | jq -s -c) && \
-          echo $VERSION_JSON && \
-          echo "::set-output name=value::$VERSION_JSON"
-        shell: bash
-  
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
   setup-tests:
     runs-on: ubuntu-latest
     outputs:
@@ -104,8 +96,7 @@ jobs:
             ~/.cargo/git/db/
             ./rust/target
           key:
-            ${{ env.cache_id }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{
-            env.RUSTC_HASH }}
+            ${{ env.cache_id }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUSTC_HASH }}
 
       # Run lint checks
       - uses: ./.github/actions/verify-rust
@@ -116,7 +107,7 @@ jobs:
       - uses: ./.github/actions/build-token-metadata
       - uses: ./.github/actions/build-auction-house
 
-       # Run test
+      # Run test
       - name: test-auctioneer-program
         id: run_test
         working-directory: ./auctioneer/program

--- a/.github/workflows/program-candy-machine.yml
+++ b/.github/workflows/program-candy-machine.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.18
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -29,12 +28,29 @@ jobs:
             - 'core/**'
           package:
             - 'candy-machine/**'
-  build-and-test-candy-machine:
-    needs: changes
+
+  setup-versions:
+    needs: [changes]
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+  build-and-test-candy-machine:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-candy-machine
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
 
     steps:
       # Setup Deps

--- a/.github/workflows/program-fixed-price-sale.yml
+++ b/.github/workflows/program-fixed-price-sale.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.22
   RUST_TOOLCHAIN: stable
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -31,22 +31,39 @@ jobs:
               - 'fixed-price-sale/**'
             workflow:
               - '.github/workflows/program-fixed-price-sale.yml'
-  build-and-test-fixed-price-sale:
-    needs: changes
+
+  setup-versions:
+    needs: [changes]
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+  build-and-test-fixed-price-sale:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-fixed-price-sale
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
 
     steps:
       # Setup Deps
       - uses: actions/checkout@v2
       - uses: ./.github/actions/install-linux-build-deps
       - uses: ./.github/actions/install-solana
-        with: 
+        with:
           solana_version: ${{ env.SOLANA_VERSION }}
       - uses: ./.github/actions/install-rust
-        with: 
+        with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       # Restore Cache from previous build/test
@@ -58,10 +75,13 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ./rust/target
-          key: ${{ env.cache_id }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUSTC_HASH }}
+          key:
+            ${{ env.cache_id }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{
+            env.RUSTC_HASH }}
 
       # Build deps
       - uses: ./.github/actions/build-token-metadata
+
       # Run test
       - name: test-fixed-price-sale-program
         id: run_test

--- a/.github/workflows/program-gumdrop.yml
+++ b/.github/workflows/program-gumdrop.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.14
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -29,12 +28,29 @@ jobs:
             - 'core/**'
           package:
             - 'gumdrop/**'
-  build-and-test-gumdrop:
-    needs: changes
+
+  setup-versions:
+    needs: [changes]
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+  build-and-test-gumdrop:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-gumdrop
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
 
     steps:
       # Setup Deps

--- a/.github/workflows/program-metaplex.yml
+++ b/.github/workflows/program-metaplex.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.14
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -31,12 +30,29 @@ jobs:
           package:
             - 'metaplex/**'
 
-  build-and-test-metaplex:
-    needs: changes
+  setup-versions:
+    needs: [changes]
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+
+  build-and-test-metaplex:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-metaplex 
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
 
     steps:
       # Setup Deps

--- a/.github/workflows/program-nft-packs.yml
+++ b/.github/workflows/program-nft-packs.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.14
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -30,12 +29,28 @@ jobs:
           package:
             - 'nft-packs/**'
 
-  build-and-test-nft-packs:
-    needs: changes
+  setup-versions:
+    needs: [changes]
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+  build-and-test-nft-packs:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-nft-packs 
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
 
     steps:
       # Setup Deps

--- a/.github/workflows/program-token-entangler.yml
+++ b/.github/workflows/program-token-entangler.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.15
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -30,12 +29,28 @@ jobs:
             package:
               - 'token-entangler/**'
 
-  build-and-test-token-entangler:
-    needs: changes
+  setup-versions:
+    needs: [changes]
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+  build-and-test-token-entangler:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-token-entangler
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
 
     steps:
       # Setup Deps

--- a/.github/workflows/program-token-metadata.yml
+++ b/.github/workflows/program-token-metadata.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.22
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -30,12 +29,28 @@ jobs:
             package:
               - 'token-metadata/**'
 
-  build-and-test-token-metadata:
-    needs: changes
+  setup-versions:
+    needs: [changes]
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+  build-and-test-token-metadata:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-token-metadata
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
 
     steps:
       # Setup Deps

--- a/.github/workflows/program-token-vault.yml
+++ b/.github/workflows/program-token-vault.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.9.14
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -29,12 +28,29 @@ jobs:
             - 'core/**'
           package:
             - 'token-vault/**'
-  build-and-test-token-vault:
-    needs: changes
+
+  setup-versions:
+    needs: [changes]
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-solana-versions.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+
+  build-and-test-token-vault:
+    needs: [changes, setup-versions]
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
     env:
       cache_id: program-token-vault 
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
 
     steps:
       # Setup Deps

--- a/.github/workflows/publish-on-pr-merge.yml
+++ b/.github/workflows/publish-on-pr-merge.yml
@@ -10,8 +10,6 @@ permissions:
 
 env:
   NODE_VERSION: 17.0.1
-  ANCHOR_VERSION: 0.22.0
-  SOLANA_VERSION_STABLE: 1.9.22
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -24,25 +22,30 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
 
+  commit-sha-to-pull-number:
+    runs-on: ubuntu-latest
+    outputs:
+      pull-number: ${{ steps.get-pr-for-commit.outputs.pull-number }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/get-pr-for-commit
+        id: get-pr-for-commit
+        with:
+          commit-sha: ${{ github.sha }}
+
   # alt: on version, publish comment or label and then parse here.
   get-changes-scope:
+    needs: [commit-sha-to-pull-number]
+    if: ${{ needs.commit-sha-to-pull-number.outputs.pull-number > 0 }}
     runs-on: ubuntu-latest
     outputs:
       changed-packages: ${{ steps.get-changed-package-scope.outputs.result }}
     steps:
       - uses: actions/checkout@v3
-
-      - name: Get PR for push event HEAD commit
-        uses: ./.github/actions/get-pr-for-commit
-        id: get-pr-for-commit
-        with:
-          commit-sha: ${{ github.sha }}
-
-      - name: List changed files
-        uses: ./.github/actions/list-changed-files
+      - uses: ./.github/actions/list-changed-files
         id: list-changed-files
         with:
-          pull-number: ${{ steps.get-pr-for-commit.outputs.pull-number }}
+          pull-number: ${{ needs.commit-sha-to-pull-number.outputs.pull-number }}
           # only include files which might contain version bumps
           include: '["package.json", "Cargo.toml"]'
 

--- a/.github/workflows/verify-lib-on-pr-open.yml
+++ b/.github/workflows/verify-lib-on-pr-open.yml
@@ -14,8 +14,6 @@ permissions:
 
 env:
   NODE_VERSION: 17.0.1
-  ANCHOR_VERSION: 0.22.0
-  SOLANA_VERSION_STABLE: 1.9.22
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -27,6 +25,24 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
+
+  # only pull the first version from the `get-solana-versions` because we don't want to run the workflow multiple times
+  setup-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-first-solana-version.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-solana-versions
+        uses: ./.github/actions/get-solana-versions
+      - id: get-first-solana-version
+        shell: bash
+        run: |
+          sudo apt-get install -y jq && \
+          echo "${{toJson(steps.get-solana-versions.outputs.value)}}" && \
+          FIRST_VERSION=$(echo "${{toJson(steps.get-solana-versions.outputs.value)}}" | jq -s -c '.[0]') && \
+          echo $FIRST_VERSION && \
+          echo "::set-output name=value::$FIRST_VERSION"
 
   get-changes-scope:
     # only listen for PRs opened against master
@@ -77,10 +93,17 @@ jobs:
         shell: bash
 
   verify-package-library:
-    needs: [get-changes-scope]
+    needs: [setup-versions, get-changes-scope]
     # note: checking for empty string just doesn't work, so we explicitly return and check null in the case that there's nothing to verify
     if: ${{ needs.get-changes-scope.outputs.packages != 'null' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SOLANA_VERSION: ${{fromJson(needs.setup-versions.outputs.versions)}}
+    env:
+      SOLANA_VERSION: ${{ matrix.SOLANA_VERSION }}
+
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-linux-build-deps
@@ -89,7 +112,7 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: ./.github/actions/install-solana
         with:
-          solana_version: ${{ env.SOLANA_VERSION_STABLE }}
+          solana_version: ${{ env.SOLANA_VERSION }}
 
       - name: Generate library for modified packages
         id: generate-package-lib


### PR DESCRIPTION
### Context
There is an [outstanding PR](https://github.com/metaplex-foundation/metaplex-program-library/pull/599) to upgrade Anchor to 0.25.x and Solana to 1.10.x. To avoid breaking the CI, we need to also upgrade the Solana version used across our workflows. Previously, it was hard-coded but is now dynamic based on network versions. 

### Changes
* Remove all hard-coded solana version environment variables 🤗
* Pull out @blockiosaurus's dynamic getVersion logic from AH / Auctioneer workflows to be re-used across all program workflows. The benefit of this approach is that we can continuously test against versions on the specific networks - as opposed to hard-coded values 👌🏼
* The get version action will only return unique values so that we don't run workflows over the same versions
  * Right now, stable = mainnet, unstable = devnet?
* In `.github/workflows/pr-comment.yml`, extract should execute job logic to its own job so we can re-use the output var and don't have repeated multi-boolean statements 
* Update `.github/workflows/publish-on-pr-merge.yml` so that it doesn't fail if there is no PR attached to the merged commit (e.g. direct push)
* Update `.github/workflows/verify-lib-on-pr-open.yml` so that it only uses the first version to generate the package's library

### Todo 🔨
* ~Debug `Program Token Metadata` failure: https://github.com/jshiohaha/metaplex-program-library/runs/7739820555?check_suite_focus=true~ retry worked, likely a transient failure
* Debug `Integration Token Vault` failure: https://github.com/jshiohaha/metaplex-program-library/runs/7739821465?check_suite_focus=true
  * The workflow doesn't seem to work with the latest Solana versions. Everything builds as expected, but 4 tests fail. Since this program is on the path to deprecation ☠️, I'm going to mostly leave the workflow as is - just upgrade to the highest version I could with it still passing.
  * Note; this needs the changes in https://github.com/metaplex-foundation/metaplex-program-library/pull/599 to pass