### PR TITLE
fix: change all instances of prepublish to prepublishOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ commiting and pushing the version bump.
 - `preversion`: ensures that the package builds and its tests pass
 - `postversion`: adds and commits the version bump and adds a tag indicating package name and new
   version, i.e. `@metaplex-foundation/mp-core@v0.0.1`
-- `prepublish`: ensures that the package builds and its tests pass again (just to be _really_ sure)
+- `prepublishOnly`: ensures that the package builds and its tests pass again (just to be _really_ sure)
 - `postpublish`: pushes the committed change and new tag to github
 
 In order to version and then publish a package just run the following commands from the folder of

--- a/auction/js/package.json
+++ b/auction/js/package.json
@@ -8,7 +8,7 @@
     "check:publish-ready": "yarn build && yarn test",
     "preversion": "yarn check:publish-ready",
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
-    "prepublish": "yarn check:publish-ready",
+    "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
     "build:docs": "typedoc",
     "build": "rimraf dist && tsc -p tsconfig.json",

--- a/bubblegum/js/package.json
+++ b/bubblegum/js/package.json
@@ -8,7 +8,7 @@
     "check:publish-ready": "yarn build && yarn test",
     "preversion": "yarn check:publish-ready",
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
-    "prepublish": "yarn check:publish-ready",
+    "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
     "build:docs": "typedoc",
     "build": "rimraf dist && tsc -p tsconfig.json",

--- a/candy-machine/js/package.json
+++ b/candy-machine/js/package.json
@@ -9,7 +9,7 @@
     "check:publish-ready": "yarn build && yarn test",
     "preversion": "yarn check:publish-ready",
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
-    "prepublish": "yarn check:publish-ready",
+    "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
     "build:docs": "typedoc",
     "build": "rimraf dist && tsc -p tsconfig.json",

--- a/core/js/package.json
+++ b/core/js/package.json
@@ -8,7 +8,7 @@
     "check:publish-ready": "yarn build && yarn test",
     "preversion": "yarn check:publish-ready",
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
-    "prepublish": "yarn check:publish-ready",
+    "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
     "build:docs": "typedoc",
     "build": "rimraf dist && tsc -p tsconfig.json",

--- a/gumdrop/js/package.json
+++ b/gumdrop/js/package.json
@@ -8,7 +8,7 @@
     "check:publish-ready": "yarn build && yarn test",
     "preversion": "yarn check:publish-ready",
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
-    "prepublish": "yarn check:publish-ready",
+    "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
     "build:docs": "typedoc",
     "build": "rimraf dist && tsc -p tsconfig.json",

--- a/metaplex/js/package.json
+++ b/metaplex/js/package.json
@@ -8,7 +8,7 @@
     "check:publish-ready": "yarn build && yarn test",
     "preversion": "yarn check:publish-ready",
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
-    "prepublish": "yarn check:publish-ready",
+    "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
     "build:docs": "typedoc",
     "build": "rimraf dist && tsc -p tsconfig.json",

--- a/token-entangler/js/package.json
+++ b/token-entangler/js/package.json
@@ -8,7 +8,7 @@
     "check:publish-ready": "yarn build && yarn test",
     "preversion": "yarn check:publish-ready",
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
-    "prepublish": "yarn check:publish-ready",
+    "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
     "build:docs": "typedoc",
     "build": "rimraf dist && tsc -p tsconfig.json",

--- a/token-vault/js/package.json
+++ b/token-vault/js/package.json
@@ -8,7 +8,7 @@
     "check:publish-ready": "yarn build && yarn test",
     "preversion": "yarn check:publish-ready",
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
-    "prepublish": "yarn check:publish-ready",
+    "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
     "build:docs": "typedoc",
     "build": "rimraf dist && tsc -p tsconfig.json",


### PR DESCRIPTION
### Change
Update all instances of `prepublish` to `prepublishOnly` because prepublish is deprecated - https://docs.npmjs.com/cli/v8/using-npm/scripts

### Context
The publish CI flow published [@metaplex-foundation/mpl-candy-machine](https://www.npmjs.com/package/@metaplex-foundation/mpl-candy-machine) version [4.4.0](https://unpkg.com/browse/@metaplex-foundation/mpl-candy-machine@4.4.0) be published without a `dist/` folder, creating problems for consumers. The expected layout can be seen in [v4.3.0](https://unpkg.com/browse/@metaplex-foundation/mpl-candy-machine@4.3.0).

We are thinking this happened because the publish flow did **not** validate the package was buildable before publishing. The JS packages rely on pre/post scripts to help with this sort of functionality, and some packages were using the now deprecated `prepublish` command.

@thlorenz found a console error after running `yarn build` in his local repo, which we are thinking should have happened and prevented a bad publish in the CI publish flow.

```
❯ yarn build
src/CandyMachineProgram.ts:1:25 - error TS2307: Cannot find module '@metaplex-foundation/mpl-core' or its corresponding type declarations.

1 import { Program } from '@metaplex-foundation/mpl-core';
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Found 1 error in src/CandyMachineProgram.ts:1
```

### Local testing
I added an unused import in a file and then tried to run publish - the expectation being, the pre-hook would execute and fail

**Results**
```
cd candy-machine/js && npm publish
total 68
-rw-r--r--@ 1 jacobshiohira  staff   6.0K Aug 15 11:46 .DS_Store
-rw-r--r--  1 jacobshiohira  staff   220B Aug  8 16:21 .ammanrc.js
drwxr-xr-x  5 jacobshiohira  staff   160B Jun 29 23:36 .crates/
-rw-r--r--  1 jacobshiohira  staff    29B Jun 28 10:52 .eslintignore
-rw-r--r--  1 jacobshiohira  staff    45B Jun 28 10:52 .eslintrc.js
-rw-r--r--  1 jacobshiohira  staff    18B Jun 28 10:52 .gitignore
-rw-r--r--  1 jacobshiohira  staff    18B Jun 28 10:52 .prettierignore
-rw-r--r--  1 jacobshiohira  staff    48B Jun 28 10:52 .prettierrc.js
-rw-r--r--  1 jacobshiohira  staff   469B Jun 28 10:52 .solitarc.js
-rw-r--r--  1 jacobshiohira  staff    11K Jun 28 10:52 LICENSE
-rw-r--r--  1 jacobshiohira  staff   473B Jun 28 10:52 README.md
drwxr-xr-x  3 jacobshiohira  staff    96B Aug 15 15:09 dist/
drwxr-xr-x  3 jacobshiohira  staff    96B Aug 15 11:20 idl/
drwxr-xr-x  6 jacobshiohira  staff   192B Aug 15 11:24 node_modules/
-rw-r--r--  1 jacobshiohira  staff   2.0K Aug 15 15:01 package.json
drwxr-xr-x  6 jacobshiohira  staff   192B Jul 15 16:18 src/
-rw-r--r--  1 jacobshiohira  staff   195B Jun 28 10:52 tsconfig.build.json
-rw-r--r--  1 jacobshiohira  staff   120B Jun 28 10:52 tsconfig.json
-rw-r--r--  1 jacobshiohira  staff   122B Jun 28 10:52 typedoc.json

> @metaplex-foundation/mpl-candy-machine@4.4.0 prepublishOnly
> yarn check:publish-ready

src/CandyMachineProgram.ts:7:1 - error TS6133: 'cusper' is declared but its value is never read.

7 import { cusper } from './errors';
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Found 1 error in src/CandyMachineProgram.ts:7
```