### PR TITLE
build: add build:docs command for each package and use in an auto-build workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,106 @@
+name: Publish docs
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  dump-context:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+  get-changes-scope:
+    runs-on: ubuntu-latest
+    outputs:
+      changed-packages: ${{ steps.map-changed-files-to-pkg.outputs.result }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get PR for push event HEAD commit
+        uses: ./.github/actions/get-pr-for-commit
+        id: get-pr-for-commit
+        with:
+          commit-sha: ${{ github.sha }}
+
+      - name: List changed files
+        uses: ./.github/actions/list-changed-files
+        id: list-changed-files
+        with:
+          pull-number: ${{ steps.get-pr-for-commit.outputs.pull-number }}
+
+      - name: Get scope of changed packages
+        uses: actions/github-script@v4
+        id: map-changed-files-to-pkg
+        with:
+          script: |
+            const files = ${{ steps.list-changed-files.outputs.changed-files }}
+            // yarn doc flow only generates docs for JS
+            const regexp = /[a-zA-Z\-]+\/(js)/g
+            const uniqueFilesObj = files
+              .filter(f => regexp.test(f))
+              .reduce((p, file) => {
+                const pkgForFile = file.split("/")[0];
+                if (!p[pkgForFile]) p[pkgForFile] = 1
+                return p
+              }, {})
+            const result = Array.from(Object.keys(uniqueFilesObj))
+            return result.length > 0 ? result.join(" ") : null
+
+  build-docs:
+    needs: [get-changes-scope]
+    # note: checking for empty string doesn't work, so we explicitly return and check null
+    if: ${{ needs.get-changes-scope.outputs.changed-packages != 'null' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - run: |
+          git config --global user.name github-actions[bot]
+          git config --global user.email github-actions[bot]@users.noreply.github.com
+          git checkout HEAD^
+
+      - name: Generate docs for packages
+        # YARN_ENABLE_IMMUTABLE_INSTALLS=false is needed otherwise, we get this error:
+        # `The lockfile would have been modified by this install, which is explicitly forbidden.`
+        # Additionally, we aren't committing changes here.
+        run: |
+          git checkout gh-pages
+          git reset master --hard
+          echo ">> setup local package dependencies with yarn"
+          YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
+          pkgs=(${{ needs.get-changes-scope.outputs.changed-packages }})
+          pkgs=(${pkgs//\"})
+          udpatedPkgs=()
+          for pkg in "${pkgs[@]}"; do
+            echo "$pkg"
+            if [ ! -d "$pkg/js" ]; then
+              echo "$pkg/js does not exist - skipping"
+              continue
+            fi
+
+            echo ">> changing dir $pkg/js"
+            cd "$pkg/js"
+            udpatedPkgs+=("${pkg}")
+            echo ">> call build:docs script for $pkg"
+            yarn build:docs
+            echo ">> add new doc changes"
+            git add ../../docs/$pkg
+            echo ">> regress 2 dirs"
+            cd ../..
+          done
+
+          echo "generated docs for these packages: ${udpatedPkgs[@]}"
+          updatedPkgsStr=$(IFS=,; echo "${udpatedPkgs[*]}")
+          git commit -m "chore: update docs for $(echo $updatedPkgsStr)"
+          git push -f origin gh-pages

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -44,7 +44,7 @@ jobs:
           script: |
             const files = ${{ steps.list-changed-files.outputs.changed-files }}
             // yarn doc flow only generates docs for JS
-            const regexp = /[a-zA-Z\-]+\/(js)/g
+            const regexp = /*.ts/g
             const uniqueFilesObj = files
               .filter(f => regexp.test(f))
               .reduce((p, file) => {

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -44,7 +44,7 @@ jobs:
           script: |
             const files = ${{ steps.list-changed-files.outputs.changed-files }}
             // yarn doc flow only generates docs for JS
-            const regexp = /*.ts/g
+            const regexp = /.*.ts/g
             const uniqueFilesObj = files
               .filter(f => regexp.test(f))
               .reduce((p, file) => {

--- a/auction-house/js/package.json
+++ b/auction-house/js/package.json
@@ -10,7 +10,7 @@
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/auction-house; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "build:watch": "rimraf dist && tsc -p tsconfig.json --watch",
     "test": "esr ./test/*.test.ts",
@@ -53,6 +53,7 @@
     "rimraf": "^3.0.2",
     "spok": "^1.4.3",
     "tape": "^5.5.2",
+    "typedoc": "^0.22.11",
     "typescript": "^4.6.2"
   }
 }

--- a/auction/js/package.json
+++ b/auction/js/package.json
@@ -10,7 +10,7 @@
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/auction; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "test": "echo mpl-auction tests coming up ...",
     "lint": "eslint \"{src,test}/**/*.ts\" --format stylish",
@@ -44,6 +44,7 @@
   "devDependencies": {
     "eslint": "^8.3.0",
     "rimraf": "^3.0.2",
+    "typedoc": "^0.22.11",
     "typescript": "^4.6.2"
   }
 }

--- a/auctioneer/js/package.json
+++ b/auctioneer/js/package.json
@@ -10,7 +10,7 @@
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/auctioneer; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "build:watch": "rimraf dist && tsc -p tsconfig.json --watch",
     "test": "echo 'SDK not tested yet'",
@@ -50,6 +50,7 @@
     "eslint": "^8.3.0",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
+    "typedoc": "^0.22.11",
     "typescript": "^4.6.2"
   }
 }

--- a/bubblegum/js/package.json
+++ b/bubblegum/js/package.json
@@ -10,7 +10,7 @@
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/bubblegum; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "test": "tape dist/test/*.js",
     "api:gen": "DEBUG='(solita|rustbin):(info|error)' solita",

--- a/candy-machine/js/package.json
+++ b/candy-machine/js/package.json
@@ -11,7 +11,7 @@
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/candy-machine; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "test": "echo mpl-candy-machine tests coming up ...",
     "api:gen": "DEBUG='(solita|rustbin):(info|error)' solita",
@@ -50,6 +50,7 @@
     "eslint": "^8.3.0",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
+    "typedoc": "^0.22.11",
     "typescript": "^4.6.2"
   }
 }

--- a/core/js/package.json
+++ b/core/js/package.json
@@ -10,7 +10,7 @@
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/core; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "test": "echo mpl-core tests coming up ...",
     "lint": "eslint \"{src,test}/**/*.ts\" --format stylish",
@@ -44,6 +44,7 @@
     "@types/bs58": "^4.0.1",
     "eslint": "^8.3.0",
     "rimraf": "^3.0.2",
+    "typedoc": "^0.22.11",
     "typescript": "^4.6.2"
   }
 }

--- a/fixed-price-sale/js/package.json
+++ b/fixed-price-sale/js/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/fixed-price-sale; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "amman:start": "DEBUG=\"amman*\" amman validator",
     "amman:stop": "pkill -f solana-test-validator",
@@ -58,6 +58,7 @@
     "rimraf": "^3.0.2",
     "supports-color": "^9.2.1",
     "tape": "^5.5.2",
+    "typedoc": "^0.22.11",
     "typescript": "^4.6.2"
   }
 }

--- a/gumdrop/js/package.json
+++ b/gumdrop/js/package.json
@@ -10,7 +10,7 @@
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/gumdrop; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "test": "tape dist/test/*.js",
     "api:gen": "node scripts/api-gen-ts.js && prettier --write ./src/**/*.ts",
@@ -49,6 +49,7 @@
     "rimraf": "^3.0.2",
     "spok": "^1.4.3",
     "tape": "^5.5.2",
+    "typedoc": "^0.22.11",
     "typescript": "^4.6.2"
   }
 }

--- a/metaplex/js/package.json
+++ b/metaplex/js/package.json
@@ -10,7 +10,7 @@
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/metaplex; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "pretest": "yarn build",
     "test:build": "esr ./test/setup/build.ts",
@@ -56,6 +56,7 @@
     "eslint": "^8.3.0",
     "rimraf": "^3.0.2",
     "tape": "^5.5.2",
+    "typedoc": "^0.22.11",
     "typescript": "^4.6.2"
   }
 }

--- a/token-entangler/js/package.json
+++ b/token-entangler/js/package.json
@@ -10,7 +10,7 @@
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/token-entangler; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "test": "tape dist/test/*.js",
     "api:gen": "DEBUG='(solita|rustbin):(info|error)' solita",
@@ -48,6 +48,7 @@
     "eslint": "^8.3.0",
     "rimraf": "^3.0.2",
     "tape": "^5.5.2",
+    "typedoc": "^0.22.11",
     "typescript": "^4.6.2"
   }
 }

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -11,7 +11,7 @@
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/token-metadata; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "api:gen": "DEBUG='(solita|rustbin):(info|error)' solita",
     "test": "cpr test/fixtures dist/test/fixtures && tape dist/test/*.js",
@@ -58,6 +58,7 @@
     "spok": "^1.4.3",
     "supports-color": "^9.2.1",
     "tape": "^5.5.3",
+    "typedoc": "^0.22.11",
     "typescript": "^4.6.2"
   }
 }

--- a/token-vault/js/package.json
+++ b/token-vault/js/package.json
@@ -10,7 +10,7 @@
     "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
     "prepublishOnly": "yarn check:publish-ready",
     "postpublish": "git push origin && git push origin --tags",
-    "build:docs": "typedoc",
+    "build:docs": "docsdir=../../docs/token-vault; rimraf $docsdir && typedoc --out $docsdir",
     "build": "rimraf dist && tsc -p tsconfig.json",
     "api:gen": "DEBUG='(solita|rustbin):(info|error)' solita",
     "amman:start": "DEBUG='amman*' amman validator",


### PR DESCRIPTION
### Changes

* Update every `package.json` `build:docs` script to call typedoc and output to a common ancestor `docs` dir
  * Output is similar to what we see in https://github.com/metaplex-foundation/beet
* Add workflow file to update docs when there is a change in the `js` dir - logic inspired by https://github.com/metaplex-foundation/beet/blob/master/sh/update-docs

### How the workflow works

1. On push to master, we get the commit SHA and try to associate with a PR
2. We map files changed to the higher level packages, e.g. candy-machine, token-metadata, etc.
3. We checkout the `gh-pages` and sync with `master`
4. For every changed package, we run `yarn build:docs` to re-generate that package's docs
5. We call `git add` so that git tracks the updates
6. We call `git push` to push the changes to the `gh-pages` branch
   * 🚧 note: pushing directly to `master` from a workflow doesn't work because it's write-protected. Since `gh-pages` is not write-protected, I think we should be able to push directly to that branch as long as token permissions allow writes.

### Testing

* token-metadata: https://github.com/jshiohaha/metaplex-program-library/runs/7945457822?check_suite_focus=true
* candy-machine: https://github.com/jshiohaha/metaplex-program-library/runs/7945236866?check_suite_focus=true