### PR TITLE
build: run api:gen against head ref instead of master

### DIFF
--- a/.github/workflows/verify-lib-on-pr-open.yml
+++ b/.github/workflows/verify-lib-on-pr-open.yml
@@ -82,7 +82,12 @@ jobs:
     if: ${{ needs.get-changes-scope.outputs.packages != 'null' }}
     runs-on: ubuntu-latest
     steps:
+      # branch should be the branch from which the PR is opened
       - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
       - uses: ./.github/actions/install-linux-build-deps
       - uses: ./.github/actions/install-rust
         with:


### PR DESCRIPTION
When running `Verify package library` workflow, we were running `api:gen` against master when we should have been running against the PR head ref. This change makes sure we checkout the code on the same branch as the PR when performing the lib diff.

### Testing
I tested in my personal fork

* PR: https://github.com/jshiohaha/metaplex-program-library/pull/136
* Workflow **before** `api:gen` ended with a diff & PR message: https://github.com/jshiohaha/metaplex-program-library/runs/8005248662?check_suite_focus=true
* Workflow **after** `api:gen` ended with no diff & no message: https://github.com/jshiohaha/metaplex-program-library/runs/8005374148?check_suite_focus=true