### PR TITLE
Replacing asserts with explicit errors + more

### DIFF
--- a/bubblegum/js/idl/bubblegum.json
+++ b/bubblegum/js/idl/bubblegum.json
@@ -31,12 +31,12 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         }
@@ -85,7 +85,7 @@
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": false,
           "isSigner": false
         }
@@ -126,7 +126,7 @@
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": false,
           "isSigner": false
         }
@@ -157,7 +157,7 @@
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": false,
           "isSigner": false
         }
@@ -188,7 +188,7 @@
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": false,
           "isSigner": false
         }
@@ -209,7 +209,7 @@
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": false,
           "isSigner": false
         },
@@ -240,7 +240,7 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
@@ -260,7 +260,7 @@
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         }
@@ -308,12 +308,12 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         }
@@ -396,12 +396,12 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         }
@@ -513,12 +513,12 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         },
@@ -635,12 +635,12 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         },
@@ -757,12 +757,12 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         },
@@ -854,12 +854,12 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         }
@@ -931,12 +931,12 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         }
@@ -993,7 +993,7 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
@@ -1008,7 +1008,7 @@
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         }
@@ -1065,7 +1065,7 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
@@ -1080,7 +1080,7 @@
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         },
@@ -1147,12 +1147,12 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": true,
           "isSigner": false
         },
@@ -1261,7 +1261,7 @@
           "isSigner": false
         },
         {
-          "name": "merkleSlab",
+          "name": "merkleTree",
           "isMut": false,
           "isSigner": false
         },
@@ -1321,7 +1321,7 @@
           "isSigner": false
         },
         {
-          "name": "gummyrollProgram",
+          "name": "compressionProgram",
           "isMut": false,
           "isSigner": false
         }
@@ -1394,7 +1394,7 @@
             "type": "u32"
           },
           {
-            "name": "merkleSlab",
+            "name": "merkleTree",
             "type": "publicKey"
           }
         ]
@@ -1700,6 +1700,24 @@
           },
           {
             "name": "Burn"
+          },
+          {
+            "name": "CreateTree"
+          },
+          {
+            "name": "VerifyCreator"
+          },
+          {
+            "name": "UnverifyCreator"
+          },
+          {
+            "name": "VerifyCollection"
+          },
+          {
+            "name": "UnverifyCollection"
+          },
+          {
+            "name": "SetAndVerifyCollection"
           }
         ]
       }
@@ -1835,88 +1853,108 @@
     },
     {
       "code": 6009,
+      "name": "CreatorHashMismatch",
+      "msg": "User-provided creator Vec must result in same user-provided creator hash"
+    },
+    {
+      "code": 6010,
+      "name": "DataHashMismatch",
+      "msg": "User-provided metadata must result in same user-provided data hash"
+    },
+    {
+      "code": 6011,
       "name": "CreatorsTooLong",
       "msg": "Creators list too long"
     },
     {
-      "code": 6010,
+      "code": 6012,
       "name": "MetadataNameTooLong",
       "msg": "Name in metadata is too long"
     },
     {
-      "code": 6011,
+      "code": 6013,
       "name": "MetadataSymbolTooLong",
       "msg": "Symbol in metadata is too long"
     },
     {
-      "code": 6012,
+      "code": 6014,
       "name": "MetadataUriTooLong",
       "msg": "Uri in metadata is too long"
     },
     {
-      "code": 6013,
+      "code": 6015,
       "name": "MetadataBasisPointsTooHigh",
       "msg": "Basis points in metadata cannot exceed 10000"
     },
     {
-      "code": 6014,
+      "code": 6016,
       "name": "InsufficientMintCapacity",
       "msg": "Not enough unapproved mints left"
     },
     {
-      "code": 6015,
+      "code": 6017,
       "name": "MintRequestNotApproved",
       "msg": "Mint request not approved"
     },
     {
-      "code": 6016,
+      "code": 6018,
       "name": "MintRequestKeyMismatch",
       "msg": "Mint authority key does not match request"
     },
     {
-      "code": 6017,
+      "code": 6019,
       "name": "MintRequestDiscriminatorMismatch",
       "msg": "Mint request data has incorrect disciminator"
     },
     {
-      "code": 6018,
+      "code": 6020,
       "name": "CloseMintRequestError",
       "msg": "Something went wrong closing mint request"
     },
     {
-      "code": 6019,
+      "code": 6021,
+      "name": "MintAuthorityMustSign",
+      "msg": "The mint authority must sign if it is not equal to the tree authority"
+    },
+    {
+      "code": 6022,
       "name": "NumericalOverflowError",
       "msg": "NumericalOverflowError"
     },
     {
-      "code": 6020,
+      "code": 6023,
       "name": "IncorrectOwner",
       "msg": "Incorrect account owner"
     },
     {
-      "code": 6021,
+      "code": 6024,
       "name": "CollectionCannotBeVerifiedInThisInstruction",
       "msg": "Cannot Verify Collection in this Instruction"
     },
     {
-      "code": 6022,
+      "code": 6025,
       "name": "CollectionNotFound",
       "msg": "Collection Not Found on Metadata"
     },
     {
-      "code": 6023,
+      "code": 6026,
       "name": "AlreadyVerified",
       "msg": "Collection item is already verified."
     },
     {
-      "code": 6024,
+      "code": 6027,
       "name": "AlreadyUnverified",
       "msg": "Collection item is already unverified."
     },
     {
-      "code": 6025,
+      "code": 6028,
       "name": "UpdateAuthorityIncorrect",
       "msg": "Incorrect leaf metadata update authority."
+    },
+    {
+      "code": 6029,
+      "name": "LeafAuthorityMustSign",
+      "msg": "This transaction must be signed by either the leaf owner or leaf delegate"
     }
   ],
   "metadata": {

--- a/bubblegum/js/src/generated/accounts/Voucher.ts
+++ b/bubblegum/js/src/generated/accounts/Voucher.ts
@@ -18,7 +18,7 @@ import { LeafSchema, leafSchemaBeet } from '../types/LeafSchema'
 export type VoucherArgs = {
   leafSchema: LeafSchema
   index: number
-  merkleSlab: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const voucherDiscriminator = [191, 204, 149, 234, 213, 165, 13, 65]
@@ -33,14 +33,14 @@ export class Voucher implements VoucherArgs {
   private constructor(
     readonly leafSchema: LeafSchema,
     readonly index: number,
-    readonly merkleSlab: web3.PublicKey
+    readonly merkleTree: web3.PublicKey
   ) {}
 
   /**
    * Creates a {@link Voucher} instance from the provided args.
    */
   static fromArgs(args: VoucherArgs) {
-    return new Voucher(args.leafSchema, args.index, args.merkleSlab)
+    return new Voucher(args.leafSchema, args.index, args.merkleTree)
   }
 
   /**
@@ -146,7 +146,7 @@ export class Voucher implements VoucherArgs {
     return {
       leafSchema: this.leafSchema.__kind,
       index: this.index,
-      merkleSlab: this.merkleSlab.toBase58(),
+      merkleTree: this.merkleTree.toBase58(),
     }
   }
 }
@@ -165,7 +165,7 @@ export const voucherBeet = new beet.FixableBeetStruct<
     ['accountDiscriminator', beet.uniformFixedSizeArray(beet.u8, 8)],
     ['leafSchema', leafSchemaBeet],
     ['index', beet.u32],
-    ['merkleSlab', beetSolana.publicKey],
+    ['merkleTree', beetSolana.publicKey],
   ],
   Voucher.fromArgs,
   'Voucher'

--- a/bubblegum/js/src/generated/errors/index.ts
+++ b/bubblegum/js/src/generated/errors/index.ts
@@ -222,13 +222,61 @@ createErrorFromNameLookup.set(
 )
 
 /**
+ * CreatorHashMismatch: 'User-provided creator Vec must result in same user-provided creator hash'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class CreatorHashMismatchError extends Error {
+  readonly code: number = 0x1779
+  readonly name: string = 'CreatorHashMismatch'
+  constructor() {
+    super(
+      'User-provided creator Vec must result in same user-provided creator hash'
+    )
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, CreatorHashMismatchError)
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x1779, () => new CreatorHashMismatchError())
+createErrorFromNameLookup.set(
+  'CreatorHashMismatch',
+  () => new CreatorHashMismatchError()
+)
+
+/**
+ * DataHashMismatch: 'User-provided metadata must result in same user-provided data hash'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class DataHashMismatchError extends Error {
+  readonly code: number = 0x177a
+  readonly name: string = 'DataHashMismatch'
+  constructor() {
+    super('User-provided metadata must result in same user-provided data hash')
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, DataHashMismatchError)
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x177a, () => new DataHashMismatchError())
+createErrorFromNameLookup.set(
+  'DataHashMismatch',
+  () => new DataHashMismatchError()
+)
+
+/**
  * CreatorsTooLong: 'Creators list too long'
  *
  * @category Errors
  * @category generated
  */
 export class CreatorsTooLongError extends Error {
-  readonly code: number = 0x1779
+  readonly code: number = 0x177b
   readonly name: string = 'CreatorsTooLong'
   constructor() {
     super('Creators list too long')
@@ -238,7 +286,7 @@ export class CreatorsTooLongError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1779, () => new CreatorsTooLongError())
+createErrorFromCodeLookup.set(0x177b, () => new CreatorsTooLongError())
 createErrorFromNameLookup.set(
   'CreatorsTooLong',
   () => new CreatorsTooLongError()
@@ -251,7 +299,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class MetadataNameTooLongError extends Error {
-  readonly code: number = 0x177a
+  readonly code: number = 0x177c
   readonly name: string = 'MetadataNameTooLong'
   constructor() {
     super('Name in metadata is too long')
@@ -261,7 +309,7 @@ export class MetadataNameTooLongError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x177a, () => new MetadataNameTooLongError())
+createErrorFromCodeLookup.set(0x177c, () => new MetadataNameTooLongError())
 createErrorFromNameLookup.set(
   'MetadataNameTooLong',
   () => new MetadataNameTooLongError()
@@ -274,7 +322,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class MetadataSymbolTooLongError extends Error {
-  readonly code: number = 0x177b
+  readonly code: number = 0x177d
   readonly name: string = 'MetadataSymbolTooLong'
   constructor() {
     super('Symbol in metadata is too long')
@@ -284,7 +332,7 @@ export class MetadataSymbolTooLongError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x177b, () => new MetadataSymbolTooLongError())
+createErrorFromCodeLookup.set(0x177d, () => new MetadataSymbolTooLongError())
 createErrorFromNameLookup.set(
   'MetadataSymbolTooLong',
   () => new MetadataSymbolTooLongError()
@@ -297,7 +345,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class MetadataUriTooLongError extends Error {
-  readonly code: number = 0x177c
+  readonly code: number = 0x177e
   readonly name: string = 'MetadataUriTooLong'
   constructor() {
     super('Uri in metadata is too long')
@@ -307,7 +355,7 @@ export class MetadataUriTooLongError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x177c, () => new MetadataUriTooLongError())
+createErrorFromCodeLookup.set(0x177e, () => new MetadataUriTooLongError())
 createErrorFromNameLookup.set(
   'MetadataUriTooLong',
   () => new MetadataUriTooLongError()
@@ -320,7 +368,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class MetadataBasisPointsTooHighError extends Error {
-  readonly code: number = 0x177d
+  readonly code: number = 0x177f
   readonly name: string = 'MetadataBasisPointsTooHigh'
   constructor() {
     super('Basis points in metadata cannot exceed 10000')
@@ -331,7 +379,7 @@ export class MetadataBasisPointsTooHighError extends Error {
 }
 
 createErrorFromCodeLookup.set(
-  0x177d,
+  0x177f,
   () => new MetadataBasisPointsTooHighError()
 )
 createErrorFromNameLookup.set(
@@ -346,7 +394,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class InsufficientMintCapacityError extends Error {
-  readonly code: number = 0x177e
+  readonly code: number = 0x1780
   readonly name: string = 'InsufficientMintCapacity'
   constructor() {
     super('Not enough unapproved mints left')
@@ -356,7 +404,7 @@ export class InsufficientMintCapacityError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x177e, () => new InsufficientMintCapacityError())
+createErrorFromCodeLookup.set(0x1780, () => new InsufficientMintCapacityError())
 createErrorFromNameLookup.set(
   'InsufficientMintCapacity',
   () => new InsufficientMintCapacityError()
@@ -369,7 +417,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class MintRequestNotApprovedError extends Error {
-  readonly code: number = 0x177f
+  readonly code: number = 0x1781
   readonly name: string = 'MintRequestNotApproved'
   constructor() {
     super('Mint request not approved')
@@ -379,7 +427,7 @@ export class MintRequestNotApprovedError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x177f, () => new MintRequestNotApprovedError())
+createErrorFromCodeLookup.set(0x1781, () => new MintRequestNotApprovedError())
 createErrorFromNameLookup.set(
   'MintRequestNotApproved',
   () => new MintRequestNotApprovedError()
@@ -392,7 +440,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class MintRequestKeyMismatchError extends Error {
-  readonly code: number = 0x1780
+  readonly code: number = 0x1782
   readonly name: string = 'MintRequestKeyMismatch'
   constructor() {
     super('Mint authority key does not match request')
@@ -402,7 +450,7 @@ export class MintRequestKeyMismatchError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1780, () => new MintRequestKeyMismatchError())
+createErrorFromCodeLookup.set(0x1782, () => new MintRequestKeyMismatchError())
 createErrorFromNameLookup.set(
   'MintRequestKeyMismatch',
   () => new MintRequestKeyMismatchError()
@@ -415,7 +463,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class MintRequestDiscriminatorMismatchError extends Error {
-  readonly code: number = 0x1781
+  readonly code: number = 0x1783
   readonly name: string = 'MintRequestDiscriminatorMismatch'
   constructor() {
     super('Mint request data has incorrect disciminator')
@@ -426,7 +474,7 @@ export class MintRequestDiscriminatorMismatchError extends Error {
 }
 
 createErrorFromCodeLookup.set(
-  0x1781,
+  0x1783,
   () => new MintRequestDiscriminatorMismatchError()
 )
 createErrorFromNameLookup.set(
@@ -441,7 +489,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class CloseMintRequestErrorError extends Error {
-  readonly code: number = 0x1782
+  readonly code: number = 0x1784
   readonly name: string = 'CloseMintRequestError'
   constructor() {
     super('Something went wrong closing mint request')
@@ -451,10 +499,35 @@ export class CloseMintRequestErrorError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1782, () => new CloseMintRequestErrorError())
+createErrorFromCodeLookup.set(0x1784, () => new CloseMintRequestErrorError())
 createErrorFromNameLookup.set(
   'CloseMintRequestError',
   () => new CloseMintRequestErrorError()
+)
+
+/**
+ * MintAuthorityMustSign: 'The mint authority must sign if it is not equal to the tree authority'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class MintAuthorityMustSignError extends Error {
+  readonly code: number = 0x1785
+  readonly name: string = 'MintAuthorityMustSign'
+  constructor() {
+    super(
+      'The mint authority must sign if it is not equal to the tree authority'
+    )
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, MintAuthorityMustSignError)
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x1785, () => new MintAuthorityMustSignError())
+createErrorFromNameLookup.set(
+  'MintAuthorityMustSign',
+  () => new MintAuthorityMustSignError()
 )
 
 /**
@@ -464,7 +537,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class NumericalOverflowErrorError extends Error {
-  readonly code: number = 0x1783
+  readonly code: number = 0x1786
   readonly name: string = 'NumericalOverflowError'
   constructor() {
     super('NumericalOverflowError')
@@ -474,7 +547,7 @@ export class NumericalOverflowErrorError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1783, () => new NumericalOverflowErrorError())
+createErrorFromCodeLookup.set(0x1786, () => new NumericalOverflowErrorError())
 createErrorFromNameLookup.set(
   'NumericalOverflowError',
   () => new NumericalOverflowErrorError()
@@ -487,7 +560,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class IncorrectOwnerError extends Error {
-  readonly code: number = 0x1784
+  readonly code: number = 0x1787
   readonly name: string = 'IncorrectOwner'
   constructor() {
     super('Incorrect account owner')
@@ -497,7 +570,7 @@ export class IncorrectOwnerError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1784, () => new IncorrectOwnerError())
+createErrorFromCodeLookup.set(0x1787, () => new IncorrectOwnerError())
 createErrorFromNameLookup.set('IncorrectOwner', () => new IncorrectOwnerError())
 
 /**
@@ -507,7 +580,7 @@ createErrorFromNameLookup.set('IncorrectOwner', () => new IncorrectOwnerError())
  * @category generated
  */
 export class CollectionCannotBeVerifiedInThisInstructionError extends Error {
-  readonly code: number = 0x1785
+  readonly code: number = 0x1788
   readonly name: string = 'CollectionCannotBeVerifiedInThisInstruction'
   constructor() {
     super('Cannot Verify Collection in this Instruction')
@@ -521,7 +594,7 @@ export class CollectionCannotBeVerifiedInThisInstructionError extends Error {
 }
 
 createErrorFromCodeLookup.set(
-  0x1785,
+  0x1788,
   () => new CollectionCannotBeVerifiedInThisInstructionError()
 )
 createErrorFromNameLookup.set(
@@ -536,7 +609,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class CollectionNotFoundError extends Error {
-  readonly code: number = 0x1786
+  readonly code: number = 0x1789
   readonly name: string = 'CollectionNotFound'
   constructor() {
     super('Collection Not Found on Metadata')
@@ -546,7 +619,7 @@ export class CollectionNotFoundError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1786, () => new CollectionNotFoundError())
+createErrorFromCodeLookup.set(0x1789, () => new CollectionNotFoundError())
 createErrorFromNameLookup.set(
   'CollectionNotFound',
   () => new CollectionNotFoundError()
@@ -559,7 +632,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class AlreadyVerifiedError extends Error {
-  readonly code: number = 0x1787
+  readonly code: number = 0x178a
   readonly name: string = 'AlreadyVerified'
   constructor() {
     super('Collection item is already verified.')
@@ -569,7 +642,7 @@ export class AlreadyVerifiedError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1787, () => new AlreadyVerifiedError())
+createErrorFromCodeLookup.set(0x178a, () => new AlreadyVerifiedError())
 createErrorFromNameLookup.set(
   'AlreadyVerified',
   () => new AlreadyVerifiedError()
@@ -582,7 +655,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class AlreadyUnverifiedError extends Error {
-  readonly code: number = 0x1788
+  readonly code: number = 0x178b
   readonly name: string = 'AlreadyUnverified'
   constructor() {
     super('Collection item is already unverified.')
@@ -592,7 +665,7 @@ export class AlreadyUnverifiedError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1788, () => new AlreadyUnverifiedError())
+createErrorFromCodeLookup.set(0x178b, () => new AlreadyUnverifiedError())
 createErrorFromNameLookup.set(
   'AlreadyUnverified',
   () => new AlreadyUnverifiedError()
@@ -605,7 +678,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class UpdateAuthorityIncorrectError extends Error {
-  readonly code: number = 0x1789
+  readonly code: number = 0x178c
   readonly name: string = 'UpdateAuthorityIncorrect'
   constructor() {
     super('Incorrect leaf metadata update authority.')
@@ -615,10 +688,35 @@ export class UpdateAuthorityIncorrectError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1789, () => new UpdateAuthorityIncorrectError())
+createErrorFromCodeLookup.set(0x178c, () => new UpdateAuthorityIncorrectError())
 createErrorFromNameLookup.set(
   'UpdateAuthorityIncorrect',
   () => new UpdateAuthorityIncorrectError()
+)
+
+/**
+ * LeafAuthorityMustSign: 'This transaction must be signed by either the leaf owner or leaf delegate'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class LeafAuthorityMustSignError extends Error {
+  readonly code: number = 0x178d
+  readonly name: string = 'LeafAuthorityMustSign'
+  constructor() {
+    super(
+      'This transaction must be signed by either the leaf owner or leaf delegate'
+    )
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, LeafAuthorityMustSignError)
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x178d, () => new LeafAuthorityMustSignError())
+createErrorFromNameLookup.set(
+  'LeafAuthorityMustSign',
+  () => new LeafAuthorityMustSignError()
 )
 
 /**

--- a/bubblegum/js/src/generated/instructions/approveMintAuthorityRequest.ts
+++ b/bubblegum/js/src/generated/instructions/approveMintAuthorityRequest.ts
@@ -38,7 +38,7 @@ export const approveMintAuthorityRequestStruct = new beet.BeetArgsStruct<
  * @property [_writable_] mintAuthorityRequest
  * @property [**signer**] treeDelegate
  * @property [_writable_] treeAuthority
- * @property [] merkleSlab
+ * @property [] merkleTree
  * @category Instructions
  * @category ApproveMintAuthorityRequest
  * @category generated
@@ -47,7 +47,7 @@ export type ApproveMintAuthorityRequestInstructionAccounts = {
   mintAuthorityRequest: web3.PublicKey
   treeDelegate: web3.PublicKey
   treeAuthority: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const approveMintAuthorityRequestInstructionDiscriminator = [
@@ -91,7 +91,7 @@ export function createApproveMintAuthorityRequestInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: false,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/burn.ts
+++ b/bubblegum/js/src/generated/instructions/burn.ts
@@ -45,10 +45,10 @@ export const burnStruct = new beet.BeetArgsStruct<
  *
  * @property [] authority
  * @property [] candyWrapper
- * @property [] gummyrollProgram
+ * @property [] compressionProgram
  * @property [] owner
  * @property [] delegate
- * @property [_writable_] merkleSlab
+ * @property [_writable_] merkleTree
  * @category Instructions
  * @category Burn
  * @category generated
@@ -56,10 +56,10 @@ export const burnStruct = new beet.BeetArgsStruct<
 export type BurnInstructionAccounts = {
   authority: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
+  compressionProgram: web3.PublicKey
   owner: web3.PublicKey
   delegate: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const burnInstructionDiscriminator = [116, 110, 29, 56, 107, 219, 42, 93]
@@ -95,7 +95,7 @@ export function createBurnInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
@@ -110,7 +110,7 @@ export function createBurnInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/cancelRedeem.ts
+++ b/bubblegum/js/src/generated/instructions/cancelRedeem.ts
@@ -37,8 +37,8 @@ export const cancelRedeemStruct = new beet.BeetArgsStruct<
  *
  * @property [] authority
  * @property [] candyWrapper
- * @property [] gummyrollProgram
- * @property [_writable_] merkleSlab
+ * @property [] compressionProgram
+ * @property [_writable_] merkleTree
  * @property [_writable_] voucher
  * @property [_writable_, **signer**] owner
  * @category Instructions
@@ -48,8 +48,8 @@ export const cancelRedeemStruct = new beet.BeetArgsStruct<
 export type CancelRedeemInstructionAccounts = {
   authority: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  compressionProgram: web3.PublicKey
+  merkleTree: web3.PublicKey
   voucher: web3.PublicKey
   owner: web3.PublicKey
 }
@@ -89,12 +89,12 @@ export function createCancelRedeemInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/closeMintRequest.ts
+++ b/bubblegum/js/src/generated/instructions/closeMintRequest.ts
@@ -25,7 +25,7 @@ export const closeMintRequestStruct = new beet.BeetArgsStruct<{
  * @property [_writable_] mintAuthorityRequest
  * @property [_writable_, **signer**] mintAuthority
  * @property [_writable_] treeAuthority
- * @property [] merkleSlab
+ * @property [] merkleTree
  * @category Instructions
  * @category CloseMintRequest
  * @category generated
@@ -34,7 +34,7 @@ export type CloseMintRequestInstructionAccounts = {
   mintAuthorityRequest: web3.PublicKey
   mintAuthority: web3.PublicKey
   treeAuthority: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const closeMintRequestInstructionDiscriminator = [
@@ -73,7 +73,7 @@ export function createCloseMintRequestInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: false,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/compress.ts
+++ b/bubblegum/js/src/generated/instructions/compress.ts
@@ -24,7 +24,7 @@ export const compressStruct = new beet.BeetArgsStruct<{
  * Accounts required by the _compress_ instruction
  *
  * @property [] authority
- * @property [] merkleSlab
+ * @property [] merkleTree
  * @property [**signer**] owner
  * @property [] delegate
  * @property [_writable_] tokenAccount
@@ -34,14 +34,14 @@ export const compressStruct = new beet.BeetArgsStruct<{
  * @property [_writable_, **signer**] payer
  * @property [] tokenMetadataProgram
  * @property [] candyWrapper
- * @property [] gummyrollProgram
+ * @property [] compressionProgram
  * @category Instructions
  * @category Compress
  * @category generated
  */
 export type CompressInstructionAccounts = {
   authority: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  merkleTree: web3.PublicKey
   owner: web3.PublicKey
   delegate: web3.PublicKey
   tokenAccount: web3.PublicKey
@@ -53,7 +53,7 @@ export type CompressInstructionAccounts = {
   tokenMetadataProgram: web3.PublicKey
   tokenProgram?: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
+  compressionProgram: web3.PublicKey
 }
 
 export const compressInstructionDiscriminator = [
@@ -82,7 +82,7 @@ export function createCompressInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: false,
       isSigner: false,
     },
@@ -142,7 +142,7 @@ export function createCompressInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/createDefaultMintRequest.ts
+++ b/bubblegum/js/src/generated/instructions/createDefaultMintRequest.ts
@@ -39,7 +39,7 @@ export const createDefaultMintRequestStruct = new beet.BeetArgsStruct<
  * @property [_writable_, **signer**] payer
  * @property [**signer**] creator
  * @property [_writable_] treeAuthority
- * @property [] merkleSlab
+ * @property [] merkleTree
  * @category Instructions
  * @category CreateDefaultMintRequest
  * @category generated
@@ -50,7 +50,7 @@ export type CreateDefaultMintRequestInstructionAccounts = {
   creator: web3.PublicKey
   treeAuthority: web3.PublicKey
   systemProgram?: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const createDefaultMintRequestInstructionDiscriminator = [
@@ -103,7 +103,7 @@ export function createCreateDefaultMintRequestInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: false,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/createTree.ts
+++ b/bubblegum/js/src/generated/instructions/createTree.ts
@@ -41,8 +41,8 @@ export const createTreeStruct = new beet.BeetArgsStruct<
  * @property [_writable_, **signer**] payer
  * @property [**signer**] treeCreator
  * @property [] candyWrapper
- * @property [] gummyrollProgram
- * @property [_writable_] merkleSlab
+ * @property [] compressionProgram
+ * @property [_writable_] merkleTree
  * @category Instructions
  * @category CreateTree
  * @category generated
@@ -53,8 +53,8 @@ export type CreateTreeInstructionAccounts = {
   treeCreator: web3.PublicKey
   candyWrapper: web3.PublicKey
   systemProgram?: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  compressionProgram: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const createTreeInstructionDiscriminator = [
@@ -107,12 +107,12 @@ export function createCreateTreeInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/delegate.ts
+++ b/bubblegum/js/src/generated/instructions/delegate.ts
@@ -48,8 +48,8 @@ export const delegateStruct = new beet.BeetArgsStruct<
  * @property [] previousDelegate
  * @property [] newDelegate
  * @property [] candyWrapper
- * @property [] gummyrollProgram
- * @property [_writable_] merkleSlab
+ * @property [] compressionProgram
+ * @property [_writable_] merkleTree
  * @category Instructions
  * @category Delegate
  * @category generated
@@ -60,8 +60,8 @@ export type DelegateInstructionAccounts = {
   previousDelegate: web3.PublicKey
   newDelegate: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  compressionProgram: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const delegateInstructionDiscriminator = [
@@ -114,12 +114,12 @@ export function createDelegateInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/mintV1.ts
+++ b/bubblegum/js/src/generated/instructions/mintV1.ts
@@ -39,11 +39,11 @@ export const mintV1Struct = new beet.FixableBeetArgsStruct<
  * @property [] mintAuthority
  * @property [_writable_] authority
  * @property [] candyWrapper
- * @property [] gummyrollProgram
+ * @property [] compressionProgram
  * @property [] owner
  * @property [] delegate
  * @property [_writable_] mintAuthorityRequest
- * @property [_writable_] merkleSlab
+ * @property [_writable_] merkleTree
  * @category Instructions
  * @category MintV1
  * @category generated
@@ -52,11 +52,11 @@ export type MintV1InstructionAccounts = {
   mintAuthority: web3.PublicKey
   authority: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
+  compressionProgram: web3.PublicKey
   owner: web3.PublicKey
   delegate: web3.PublicKey
   mintAuthorityRequest: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const mintV1InstructionDiscriminator = [
@@ -99,7 +99,7 @@ export function createMintV1Instruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
@@ -119,7 +119,7 @@ export function createMintV1Instruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/redeem.ts
+++ b/bubblegum/js/src/generated/instructions/redeem.ts
@@ -45,10 +45,10 @@ export const redeemStruct = new beet.BeetArgsStruct<
  *
  * @property [] authority
  * @property [] candyWrapper
- * @property [] gummyrollProgram
+ * @property [] compressionProgram
  * @property [_writable_, **signer**] owner
  * @property [] delegate
- * @property [_writable_] merkleSlab
+ * @property [_writable_] merkleTree
  * @property [_writable_] voucher
  * @category Instructions
  * @category Redeem
@@ -57,10 +57,10 @@ export const redeemStruct = new beet.BeetArgsStruct<
 export type RedeemInstructionAccounts = {
   authority: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
+  compressionProgram: web3.PublicKey
   owner: web3.PublicKey
   delegate: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  merkleTree: web3.PublicKey
   voucher: web3.PublicKey
   systemProgram?: web3.PublicKey
 }
@@ -100,7 +100,7 @@ export function createRedeemInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
@@ -115,7 +115,7 @@ export function createRedeemInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/requestMintAuthority.ts
+++ b/bubblegum/js/src/generated/instructions/requestMintAuthority.ts
@@ -39,7 +39,7 @@ export const requestMintAuthorityStruct = new beet.BeetArgsStruct<
  * @property [_writable_, **signer**] payer
  * @property [**signer**] mintAuthority
  * @property [_writable_] treeAuthority
- * @property [] merkleSlab
+ * @property [] merkleTree
  * @category Instructions
  * @category RequestMintAuthority
  * @category generated
@@ -50,7 +50,7 @@ export type RequestMintAuthorityInstructionAccounts = {
   mintAuthority: web3.PublicKey
   treeAuthority: web3.PublicKey
   systemProgram?: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const requestMintAuthorityInstructionDiscriminator = [
@@ -103,7 +103,7 @@ export function createRequestMintAuthorityInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: false,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/bubblegum/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -59,8 +59,8 @@ export const setAndVerifyCollectionStruct = new beet.FixableBeetArgsStruct<
  * @property [] editionAccount
  * @property [] bubblegumSigner
  * @property [] candyWrapper
- * @property [] gummyrollProgram
- * @property [_writable_] merkleSlab
+ * @property [] compressionProgram
+ * @property [_writable_] merkleTree
  * @property [] tokenMetadataProgram
  * @category Instructions
  * @category SetAndVerifyCollection
@@ -78,8 +78,8 @@ export type SetAndVerifyCollectionInstructionAccounts = {
   editionAccount: web3.PublicKey
   bubblegumSigner: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  compressionProgram: web3.PublicKey
+  merkleTree: web3.PublicKey
   tokenMetadataProgram: web3.PublicKey
 }
 
@@ -163,12 +163,12 @@ export function createSetAndVerifyCollectionInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/setTreeDelegate.ts
+++ b/bubblegum/js/src/generated/instructions/setTreeDelegate.ts
@@ -24,7 +24,7 @@ export const setTreeDelegateStruct = new beet.BeetArgsStruct<{
  *
  * @property [**signer**] creator
  * @property [] newDelegate
- * @property [] merkleSlab
+ * @property [] merkleTree
  * @property [_writable_] treeAuthority
  * @category Instructions
  * @category SetTreeDelegate
@@ -33,7 +33,7 @@ export const setTreeDelegateStruct = new beet.BeetArgsStruct<{
 export type SetTreeDelegateInstructionAccounts = {
   creator: web3.PublicKey
   newDelegate: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  merkleTree: web3.PublicKey
   treeAuthority: web3.PublicKey
 }
 
@@ -68,7 +68,7 @@ export function createSetTreeDelegateInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: false,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/transfer.ts
+++ b/bubblegum/js/src/generated/instructions/transfer.ts
@@ -48,8 +48,8 @@ export const transferStruct = new beet.BeetArgsStruct<
  * @property [] delegate
  * @property [] newOwner
  * @property [] candyWrapper
- * @property [] gummyrollProgram
- * @property [_writable_] merkleSlab
+ * @property [] compressionProgram
+ * @property [_writable_] merkleTree
  * @category Instructions
  * @category Transfer
  * @category generated
@@ -60,8 +60,8 @@ export type TransferInstructionAccounts = {
   delegate: web3.PublicKey
   newOwner: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  compressionProgram: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const transferInstructionDiscriminator = [
@@ -114,12 +114,12 @@ export function createTransferInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/unverifyCollection.ts
+++ b/bubblegum/js/src/generated/instructions/unverifyCollection.ts
@@ -57,8 +57,8 @@ export const unverifyCollectionStruct = new beet.FixableBeetArgsStruct<
  * @property [] editionAccount
  * @property [] bubblegumSigner
  * @property [] candyWrapper
- * @property [] gummyrollProgram
- * @property [_writable_] merkleSlab
+ * @property [] compressionProgram
+ * @property [_writable_] merkleTree
  * @property [] tokenMetadataProgram
  * @category Instructions
  * @category UnverifyCollection
@@ -76,8 +76,8 @@ export type UnverifyCollectionInstructionAccounts = {
   editionAccount: web3.PublicKey
   bubblegumSigner: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  compressionProgram: web3.PublicKey
+  merkleTree: web3.PublicKey
   tokenMetadataProgram: web3.PublicKey
 }
 
@@ -161,12 +161,12 @@ export function createUnverifyCollectionInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/unverifyCreator.ts
+++ b/bubblegum/js/src/generated/instructions/unverifyCreator.ts
@@ -52,8 +52,8 @@ export const unverifyCreatorStruct = new beet.FixableBeetArgsStruct<
  * @property [**signer**] payer
  * @property [**signer**] creator
  * @property [] candyWrapper
- * @property [] gummyrollProgram
- * @property [_writable_] merkleSlab
+ * @property [] compressionProgram
+ * @property [_writable_] merkleTree
  * @category Instructions
  * @category UnverifyCreator
  * @category generated
@@ -65,8 +65,8 @@ export type UnverifyCreatorInstructionAccounts = {
   payer: web3.PublicKey
   creator: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  compressionProgram: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const unverifyCreatorInstructionDiscriminator = [
@@ -124,12 +124,12 @@ export function createUnverifyCreatorInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/verifyCollection.ts
+++ b/bubblegum/js/src/generated/instructions/verifyCollection.ts
@@ -57,8 +57,8 @@ export const verifyCollectionStruct = new beet.FixableBeetArgsStruct<
  * @property [] editionAccount
  * @property [] bubblegumSigner
  * @property [] candyWrapper
- * @property [] gummyrollProgram
- * @property [_writable_] merkleSlab
+ * @property [] compressionProgram
+ * @property [_writable_] merkleTree
  * @property [] tokenMetadataProgram
  * @category Instructions
  * @category VerifyCollection
@@ -76,8 +76,8 @@ export type VerifyCollectionInstructionAccounts = {
   editionAccount: web3.PublicKey
   bubblegumSigner: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  compressionProgram: web3.PublicKey
+  merkleTree: web3.PublicKey
   tokenMetadataProgram: web3.PublicKey
 }
 
@@ -161,12 +161,12 @@ export function createVerifyCollectionInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/instructions/verifyCreator.ts
+++ b/bubblegum/js/src/generated/instructions/verifyCreator.ts
@@ -52,8 +52,8 @@ export const verifyCreatorStruct = new beet.FixableBeetArgsStruct<
  * @property [**signer**] payer
  * @property [**signer**] creator
  * @property [] candyWrapper
- * @property [] gummyrollProgram
- * @property [_writable_] merkleSlab
+ * @property [] compressionProgram
+ * @property [_writable_] merkleTree
  * @category Instructions
  * @category VerifyCreator
  * @category generated
@@ -65,8 +65,8 @@ export type VerifyCreatorInstructionAccounts = {
   payer: web3.PublicKey
   creator: web3.PublicKey
   candyWrapper: web3.PublicKey
-  gummyrollProgram: web3.PublicKey
-  merkleSlab: web3.PublicKey
+  compressionProgram: web3.PublicKey
+  merkleTree: web3.PublicKey
 }
 
 export const verifyCreatorInstructionDiscriminator = [
@@ -124,12 +124,12 @@ export function createVerifyCreatorInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.gummyrollProgram,
+      pubkey: accounts.compressionProgram,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: accounts.merkleSlab,
+      pubkey: accounts.merkleTree,
       isWritable: true,
       isSigner: false,
     },

--- a/bubblegum/js/src/generated/types/InstructionName.ts
+++ b/bubblegum/js/src/generated/types/InstructionName.ts
@@ -20,6 +20,12 @@ export enum InstructionName {
   DecompressV1,
   Compress,
   Burn,
+  CreateTree,
+  VerifyCreator,
+  UnverifyCreator,
+  VerifyCollection,
+  UnverifyCollection,
+  SetAndVerifyCollection,
 }
 
 /**

--- a/bubblegum/program/Cargo.toml
+++ b/bubblegum/program/Cargo.toml
@@ -19,7 +19,7 @@ anchor-lang = { version = "0.25.0", features = ["init-if-needed"] }
 anchor-spl = { version = "0.25.0" }
 spl-token = { version = "3.3.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "1.0.5", features = ["no-entrypoint"] }
-mpl-token-metadata = { version = "1.3.3", features = ["no-entrypoint"] }
+mpl-token-metadata = { version = "1.3.6", features = ["no-entrypoint"] }
 spl-compression = { git = "https://github.com/solana-labs/solana-program-library", rev = "7c7507f4ec1f320bbc33af459d4d8b5573a6a906", features = ["cpi"] }
 bytemuck = "1.8.0"
 solana-program = "1.10.29"

--- a/bubblegum/program/src/error.rs
+++ b/bubblegum/program/src/error.rs
@@ -20,6 +20,10 @@ pub enum BubblegumError {
     CreatorNotFound,
     #[msg("No creators in creator Vec")]
     NoCreatorsPresent,
+    #[msg("User-provided creator Vec must result in same user-provided creator hash")]
+    CreatorHashMismatch,
+    #[msg("User-provided metadata must result in same user-provided data hash")]
+    DataHashMismatch,
     #[msg("Creators list too long")]
     CreatorsTooLong,
     #[msg("Name in metadata is too long")]
@@ -40,6 +44,8 @@ pub enum BubblegumError {
     MintRequestDiscriminatorMismatch,
     #[msg("Something went wrong closing mint request")]
     CloseMintRequestError,
+    #[msg("The mint authority must sign if it is not equal to the tree authority")]
+    MintAuthorityMustSign,
     #[msg("NumericalOverflowError")]
     NumericalOverflowError,
     #[msg("Incorrect account owner")]
@@ -54,4 +60,6 @@ pub enum BubblegumError {
     AlreadyUnverified,
     #[msg("Incorrect leaf metadata update authority.")]
     UpdateAuthorityIncorrect,
+    #[msg("This transaction must be signed by either the leaf owner or leaf delegate")]
+    LeafAuthorityMustSign,
 }

--- a/bubblegum/program/src/state/metaplex_adapter.rs
+++ b/bubblegum/program/src/state/metaplex_adapter.rs
@@ -1,12 +1,12 @@
 use anchor_lang::prelude::*;
 
-#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Copy, Clone)]
+#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Eq, Copy, Clone)]
 pub enum TokenProgramVersion {
     Original,
     Token2022,
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Copy, Clone)]
+#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Eq, Copy, Clone)]
 pub struct Creator {
     pub address: Pubkey,
     pub verified: bool,
@@ -24,7 +24,7 @@ impl Creator {
     }
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Debug, Clone)]
+#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Eq, Debug, Clone)]
 pub enum TokenStandard {
     NonFungible,        // This is a master edition
     FungibleAsset,      // A token with metadata that can also have attrributes
@@ -32,14 +32,14 @@ pub enum TokenStandard {
     NonFungibleEdition, // This is a limited edition
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Debug, Clone)]
+#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Eq, Debug, Clone)]
 pub enum UseMethod {
     Burn,
     Multiple,
     Single,
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Debug, Clone)]
+#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Uses {
     // 17 bytes + Option byte
     pub use_method: UseMethod, //1
@@ -62,7 +62,7 @@ impl Uses {
 }
 
 #[repr(C)]
-#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Debug, Clone)]
+#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Collection {
     pub verified: bool,
     pub key: Pubkey,
@@ -77,7 +77,7 @@ impl Collection {
     }
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Clone)]
+#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Eq, Clone)]
 pub struct MetadataArgs {
     /// The name of the asset
     pub name: String,


### PR DESCRIPTION
- Also:
  - Adding new error variants.
  - Cargo fmt and clippy fixes.
  - Removing a collection TODO since we solved
a different way.
  - Adding `#[allow(unreachable_patterns)]` on one specific unsupported
schema error.
  - Updating token-metadata to be a crates.io version.
  - Regenerating API.