### PR TITLE
chore: auction-house update SDK with latest solita

### DIFF
--- a/auction-house/js/package.json
+++ b/auction-house/js/package.json
@@ -39,14 +39,14 @@
   "author": "Metaplex Maintainers <contact@metaplex.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.1.0",
-    "@metaplex-foundation/beet-solana": "^0.1.1",
+    "@metaplex-foundation/beet": "^0.6.1",
+    "@metaplex-foundation/beet-solana": "^0.3.1",
     "@metaplex-foundation/cusper": "^0.0.2",
-    "@solana/web3.js": "^1.35.1",
+    "@solana/web3.js": "^1.56.2",
     "bn.js": "^5.2.0"
   },
   "devDependencies": {
-    "@metaplex-foundation/solita": "^0.5.0",
+    "@metaplex-foundation/solita": "^0.15.2",
     "@types/tape": "^4.13.2",
     "eslint": "^8.3.0",
     "prettier": "^2.5.1",

--- a/auction-house/js/src/generated/accounts/AuctionHouse.ts
+++ b/auction-house/js/src/generated/accounts/AuctionHouse.ts
@@ -34,7 +34,7 @@ export type AuctionHouseArgs = {
   scopes: boolean[] /* size: 7 */;
 };
 
-const auctionHouseDiscriminator = [40, 108, 215, 107, 213, 85, 245, 48];
+export const auctionHouseDiscriminator = [40, 108, 215, 107, 213, 85, 245, 48];
 /**
  * Holds the data for the {@link AuctionHouse} Account and provides de/serialization
  * functionality for that data
@@ -114,6 +114,18 @@ export class AuctionHouse implements AuctionHouseArgs {
       throw new Error(`Unable to find AuctionHouse account at ${address}`);
     }
     return AuctionHouse.fromAccountInfo(accountInfo, 0)[0];
+  }
+
+  /**
+   * Provides a {@link web3.Connection.getProgramAccounts} config builder,
+   * to fetch accounts matching filters that can be specified via that builder.
+   *
+   * @param programId - the program that owns the accounts we are filtering
+   */
+  static gpaBuilder(
+    programId: web3.PublicKey = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+  ) {
+    return beetSolana.GpaBuilder.fromStruct(programId, auctionHouseBeet);
   }
 
   /**

--- a/auction-house/js/src/generated/accounts/Auctioneer.ts
+++ b/auction-house/js/src/generated/accounts/Auctioneer.ts
@@ -20,7 +20,7 @@ export type AuctioneerArgs = {
   bump: number;
 };
 
-const auctioneerDiscriminator = [46, 101, 92, 150, 138, 30, 245, 120];
+export const auctioneerDiscriminator = [46, 101, 92, 150, 138, 30, 245, 120];
 /**
  * Holds the data for the {@link Auctioneer} Account and provides de/serialization
  * functionality for that data
@@ -65,6 +65,18 @@ export class Auctioneer implements AuctioneerArgs {
       throw new Error(`Unable to find Auctioneer account at ${address}`);
     }
     return Auctioneer.fromAccountInfo(accountInfo, 0)[0];
+  }
+
+  /**
+   * Provides a {@link web3.Connection.getProgramAccounts} config builder,
+   * to fetch accounts matching filters that can be specified via that builder.
+   *
+   * @param programId - the program that owns the accounts we are filtering
+   */
+  static gpaBuilder(
+    programId: web3.PublicKey = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+  ) {
+    return beetSolana.GpaBuilder.fromStruct(programId, auctioneerBeet);
   }
 
   /**

--- a/auction-house/js/src/generated/accounts/BidReceipt.ts
+++ b/auction-house/js/src/generated/accounts/BidReceipt.ts
@@ -30,7 +30,7 @@ export type BidReceiptArgs = {
   canceledAt: beet.COption<beet.bignum>;
 };
 
-const bidReceiptDiscriminator = [186, 150, 141, 135, 59, 122, 39, 99];
+export const bidReceiptDiscriminator = [186, 150, 141, 135, 59, 122, 39, 99];
 /**
  * Holds the data for the {@link BidReceipt} Account and provides de/serialization
  * functionality for that data
@@ -99,6 +99,18 @@ export class BidReceipt implements BidReceiptArgs {
       throw new Error(`Unable to find BidReceipt account at ${address}`);
     }
     return BidReceipt.fromAccountInfo(accountInfo, 0)[0];
+  }
+
+  /**
+   * Provides a {@link web3.Connection.getProgramAccounts} config builder,
+   * to fetch accounts matching filters that can be specified via that builder.
+   *
+   * @param programId - the program that owns the accounts we are filtering
+   */
+  static gpaBuilder(
+    programId: web3.PublicKey = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+  ) {
+    return beetSolana.GpaBuilder.fromStruct(programId, bidReceiptBeet);
   }
 
   /**

--- a/auction-house/js/src/generated/accounts/ListingReceipt.ts
+++ b/auction-house/js/src/generated/accounts/ListingReceipt.ts
@@ -29,7 +29,7 @@ export type ListingReceiptArgs = {
   canceledAt: beet.COption<beet.bignum>;
 };
 
-const listingReceiptDiscriminator = [240, 71, 225, 94, 200, 75, 84, 231];
+export const listingReceiptDiscriminator = [240, 71, 225, 94, 200, 75, 84, 231];
 /**
  * Holds the data for the {@link ListingReceipt} Account and provides de/serialization
  * functionality for that data
@@ -99,6 +99,18 @@ export class ListingReceipt implements ListingReceiptArgs {
       throw new Error(`Unable to find ListingReceipt account at ${address}`);
     }
     return ListingReceipt.fromAccountInfo(accountInfo, 0)[0];
+  }
+
+  /**
+   * Provides a {@link web3.Connection.getProgramAccounts} config builder,
+   * to fetch accounts matching filters that can be specified via that builder.
+   *
+   * @param programId - the program that owns the accounts we are filtering
+   */
+  static gpaBuilder(
+    programId: web3.PublicKey = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+  ) {
+    return beetSolana.GpaBuilder.fromStruct(programId, listingReceiptBeet);
   }
 
   /**

--- a/auction-house/js/src/generated/accounts/PurchaseReceipt.ts
+++ b/auction-house/js/src/generated/accounts/PurchaseReceipt.ts
@@ -26,7 +26,7 @@ export type PurchaseReceiptArgs = {
   createdAt: beet.bignum;
 };
 
-const purchaseReceiptDiscriminator = [79, 127, 222, 137, 154, 131, 150, 134];
+export const purchaseReceiptDiscriminator = [79, 127, 222, 137, 154, 131, 150, 134];
 /**
  * Holds the data for the {@link PurchaseReceipt} Account and provides de/serialization
  * functionality for that data
@@ -90,6 +90,18 @@ export class PurchaseReceipt implements PurchaseReceiptArgs {
       throw new Error(`Unable to find PurchaseReceipt account at ${address}`);
     }
     return PurchaseReceipt.fromAccountInfo(accountInfo, 0)[0];
+  }
+
+  /**
+   * Provides a {@link web3.Connection.getProgramAccounts} config builder,
+   * to fetch accounts matching filters that can be specified via that builder.
+   *
+   * @param programId - the program that owns the accounts we are filtering
+   */
+  static gpaBuilder(
+    programId: web3.PublicKey = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+  ) {
+    return beetSolana.GpaBuilder.fromStruct(programId, purchaseReceiptBeet);
   }
 
   /**

--- a/auction-house/js/src/generated/accounts/index.ts
+++ b/auction-house/js/src/generated/accounts/index.ts
@@ -3,3 +3,17 @@ export * from './Auctioneer';
 export * from './BidReceipt';
 export * from './ListingReceipt';
 export * from './PurchaseReceipt';
+
+import { BidReceipt } from './BidReceipt';
+import { ListingReceipt } from './ListingReceipt';
+import { PurchaseReceipt } from './PurchaseReceipt';
+import { AuctionHouse } from './AuctionHouse';
+import { Auctioneer } from './Auctioneer';
+
+export const accountProviders = {
+  BidReceipt,
+  ListingReceipt,
+  PurchaseReceipt,
+  AuctionHouse,
+  Auctioneer,
+};

--- a/auction-house/js/src/generated/instructions/auctioneerBuy.ts
+++ b/auction-house/js/src/generated/instructions/auctioneerBuy.ts
@@ -25,7 +25,7 @@ export type AuctioneerBuyInstructionArgs = {
  * @category AuctioneerBuy
  * @category generated
  */
-const auctioneerBuyStruct = new beet.BeetArgsStruct<
+export const auctioneerBuyStruct = new beet.BeetArgsStruct<
   AuctioneerBuyInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -73,9 +73,13 @@ export type AuctioneerBuyInstructionAccounts = {
   auctionHouseFeeAccount: web3.PublicKey;
   buyerTradeState: web3.PublicKey;
   ahAuctioneerPda: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const auctioneerBuyInstructionDiscriminator = [17, 106, 133, 46, 229, 48, 45, 208];
+export const auctioneerBuyInstructionDiscriminator = [17, 106, 133, 46, 229, 48, 45, 208];
 
 /**
  * Creates a _AuctioneerBuy_ instruction.
@@ -90,112 +94,103 @@ const auctioneerBuyInstructionDiscriminator = [17, 106, 133, 46, 229, 48, 45, 20
 export function createAuctioneerBuyInstruction(
   accounts: AuctioneerBuyInstructionAccounts,
   args: AuctioneerBuyInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    wallet,
-    paymentAccount,
-    transferAuthority,
-    treasuryMint,
-    tokenAccount,
-    metadata,
-    escrowPaymentAccount,
-    authority,
-    auctioneerAuthority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    buyerTradeState,
-    ahAuctioneerPda,
-  } = accounts;
-
   const [data] = auctioneerBuyStruct.serialize({
     instructionDiscriminator: auctioneerBuyInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: paymentAccount,
+      pubkey: accounts.paymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: transferAuthority,
+      pubkey: accounts.transferAuthority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctioneerAuthority,
+      pubkey: accounts.auctioneerAuthority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerTradeState,
+      pubkey: accounts.buyerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: ahAuctioneerPda,
+      pubkey: accounts.ahAuctioneerPda,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/auctioneerCancel.ts
+++ b/auction-house/js/src/generated/instructions/auctioneerCancel.ts
@@ -23,7 +23,7 @@ export type AuctioneerCancelInstructionArgs = {
  * @category AuctioneerCancel
  * @category generated
  */
-const auctioneerCancelStruct = new beet.BeetArgsStruct<
+export const auctioneerCancelStruct = new beet.BeetArgsStruct<
   AuctioneerCancelInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -61,9 +61,11 @@ export type AuctioneerCancelInstructionAccounts = {
   auctionHouseFeeAccount: web3.PublicKey;
   tradeState: web3.PublicKey;
   ahAuctioneerPda: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const auctioneerCancelInstructionDiscriminator = [197, 97, 152, 196, 115, 204, 64, 215];
+export const auctioneerCancelInstructionDiscriminator = [197, 97, 152, 196, 115, 204, 64, 215];
 
 /**
  * Creates a _AuctioneerCancel_ instruction.
@@ -78,78 +80,73 @@ const auctioneerCancelInstructionDiscriminator = [197, 97, 152, 196, 115, 204, 6
 export function createAuctioneerCancelInstruction(
   accounts: AuctioneerCancelInstructionAccounts,
   args: AuctioneerCancelInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    wallet,
-    tokenAccount,
-    tokenMint,
-    authority,
-    auctioneerAuthority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    tradeState,
-    ahAuctioneerPda,
-  } = accounts;
-
   const [data] = auctioneerCancelStruct.serialize({
     instructionDiscriminator: auctioneerCancelInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenMint,
+      pubkey: accounts.tokenMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctioneerAuthority,
+      pubkey: accounts.auctioneerAuthority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tradeState,
+      pubkey: accounts.tradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: ahAuctioneerPda,
+      pubkey: accounts.ahAuctioneerPda,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/auctioneerDeposit.ts
+++ b/auction-house/js/src/generated/instructions/auctioneerDeposit.ts
@@ -23,7 +23,7 @@ export type AuctioneerDepositInstructionArgs = {
  * @category AuctioneerDeposit
  * @category generated
  */
-const auctioneerDepositStruct = new beet.BeetArgsStruct<
+export const auctioneerDepositStruct = new beet.BeetArgsStruct<
   AuctioneerDepositInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -63,9 +63,13 @@ export type AuctioneerDepositInstructionAccounts = {
   auctionHouse: web3.PublicKey;
   auctionHouseFeeAccount: web3.PublicKey;
   ahAuctioneerPda: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const auctioneerDepositInstructionDiscriminator = [79, 122, 37, 162, 120, 173, 57, 127];
+export const auctioneerDepositInstructionDiscriminator = [79, 122, 37, 162, 120, 173, 57, 127];
 
 /**
  * Creates a _AuctioneerDeposit_ instruction.
@@ -80,94 +84,88 @@ const auctioneerDepositInstructionDiscriminator = [79, 122, 37, 162, 120, 173, 5
 export function createAuctioneerDepositInstruction(
   accounts: AuctioneerDepositInstructionAccounts,
   args: AuctioneerDepositInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    wallet,
-    paymentAccount,
-    transferAuthority,
-    escrowPaymentAccount,
-    treasuryMint,
-    authority,
-    auctioneerAuthority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    ahAuctioneerPda,
-  } = accounts;
-
   const [data] = auctioneerDepositStruct.serialize({
     instructionDiscriminator: auctioneerDepositInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: paymentAccount,
+      pubkey: accounts.paymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: transferAuthority,
+      pubkey: accounts.transferAuthority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctioneerAuthority,
+      pubkey: accounts.auctioneerAuthority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: ahAuctioneerPda,
+      pubkey: accounts.ahAuctioneerPda,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/auctioneerExecutePartialSale.ts
+++ b/auction-house/js/src/generated/instructions/auctioneerExecutePartialSale.ts
@@ -28,7 +28,7 @@ export type AuctioneerExecutePartialSaleInstructionArgs = {
  * @category AuctioneerExecutePartialSale
  * @category generated
  */
-const auctioneerExecutePartialSaleStruct = new beet.FixableBeetArgsStruct<
+export const auctioneerExecutePartialSaleStruct = new beet.FixableBeetArgsStruct<
   AuctioneerExecutePartialSaleInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -90,10 +90,17 @@ export type AuctioneerExecutePartialSaleInstructionAccounts = {
   sellerTradeState: web3.PublicKey;
   freeTradeState: web3.PublicKey;
   ahAuctioneerPda: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  ataProgram?: web3.PublicKey;
   programAsSigner: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const auctioneerExecutePartialSaleInstructionDiscriminator = [9, 44, 46, 15, 161, 143, 21, 54];
+export const auctioneerExecutePartialSaleInstructionDiscriminator = [
+  9, 44, 46, 15, 161, 143, 21, 54,
+];
 
 /**
  * Creates a _AuctioneerExecutePartialSale_ instruction.
@@ -108,153 +115,138 @@ const auctioneerExecutePartialSaleInstructionDiscriminator = [9, 44, 46, 15, 161
 export function createAuctioneerExecutePartialSaleInstruction(
   accounts: AuctioneerExecutePartialSaleInstructionAccounts,
   args: AuctioneerExecutePartialSaleInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    buyer,
-    seller,
-    tokenAccount,
-    tokenMint,
-    metadata,
-    treasuryMint,
-    escrowPaymentAccount,
-    sellerPaymentReceiptAccount,
-    buyerReceiptTokenAccount,
-    authority,
-    auctioneerAuthority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    auctionHouseTreasury,
-    buyerTradeState,
-    sellerTradeState,
-    freeTradeState,
-    ahAuctioneerPda,
-    programAsSigner,
-  } = accounts;
-
   const [data] = auctioneerExecutePartialSaleStruct.serialize({
     instructionDiscriminator: auctioneerExecutePartialSaleInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: buyer,
+      pubkey: accounts.buyer,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: seller,
+      pubkey: accounts.seller,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenMint,
+      pubkey: accounts.tokenMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: sellerPaymentReceiptAccount,
+      pubkey: accounts.sellerPaymentReceiptAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerReceiptTokenAccount,
+      pubkey: accounts.buyerReceiptTokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctioneerAuthority,
+      pubkey: accounts.auctioneerAuthority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseTreasury,
+      pubkey: accounts.auctionHouseTreasury,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerTradeState,
+      pubkey: accounts.buyerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: sellerTradeState,
+      pubkey: accounts.sellerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: freeTradeState,
+      pubkey: accounts.freeTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: ahAuctioneerPda,
+      pubkey: accounts.ahAuctioneerPda,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
+      pubkey: accounts.ataProgram ?? splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: programAsSigner,
+      pubkey: accounts.programAsSigner,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/auctioneerExecuteSale.ts
+++ b/auction-house/js/src/generated/instructions/auctioneerExecuteSale.ts
@@ -26,7 +26,7 @@ export type AuctioneerExecuteSaleInstructionArgs = {
  * @category AuctioneerExecuteSale
  * @category generated
  */
-const auctioneerExecuteSaleStruct = new beet.BeetArgsStruct<
+export const auctioneerExecuteSaleStruct = new beet.BeetArgsStruct<
   AuctioneerExecuteSaleInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -86,10 +86,15 @@ export type AuctioneerExecuteSaleInstructionAccounts = {
   sellerTradeState: web3.PublicKey;
   freeTradeState: web3.PublicKey;
   ahAuctioneerPda: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  ataProgram?: web3.PublicKey;
   programAsSigner: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const auctioneerExecuteSaleInstructionDiscriminator = [68, 125, 32, 65, 251, 43, 35, 53];
+export const auctioneerExecuteSaleInstructionDiscriminator = [68, 125, 32, 65, 251, 43, 35, 53];
 
 /**
  * Creates a _AuctioneerExecuteSale_ instruction.
@@ -104,153 +109,138 @@ const auctioneerExecuteSaleInstructionDiscriminator = [68, 125, 32, 65, 251, 43,
 export function createAuctioneerExecuteSaleInstruction(
   accounts: AuctioneerExecuteSaleInstructionAccounts,
   args: AuctioneerExecuteSaleInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    buyer,
-    seller,
-    tokenAccount,
-    tokenMint,
-    metadata,
-    treasuryMint,
-    escrowPaymentAccount,
-    sellerPaymentReceiptAccount,
-    buyerReceiptTokenAccount,
-    authority,
-    auctioneerAuthority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    auctionHouseTreasury,
-    buyerTradeState,
-    sellerTradeState,
-    freeTradeState,
-    ahAuctioneerPda,
-    programAsSigner,
-  } = accounts;
-
   const [data] = auctioneerExecuteSaleStruct.serialize({
     instructionDiscriminator: auctioneerExecuteSaleInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: buyer,
+      pubkey: accounts.buyer,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: seller,
+      pubkey: accounts.seller,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenMint,
+      pubkey: accounts.tokenMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: sellerPaymentReceiptAccount,
+      pubkey: accounts.sellerPaymentReceiptAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerReceiptTokenAccount,
+      pubkey: accounts.buyerReceiptTokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctioneerAuthority,
+      pubkey: accounts.auctioneerAuthority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseTreasury,
+      pubkey: accounts.auctionHouseTreasury,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerTradeState,
+      pubkey: accounts.buyerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: sellerTradeState,
+      pubkey: accounts.sellerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: freeTradeState,
+      pubkey: accounts.freeTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: ahAuctioneerPda,
+      pubkey: accounts.ahAuctioneerPda,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
+      pubkey: accounts.ataProgram ?? splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: programAsSigner,
+      pubkey: accounts.programAsSigner,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/auctioneerPublicBuy.ts
+++ b/auction-house/js/src/generated/instructions/auctioneerPublicBuy.ts
@@ -25,7 +25,7 @@ export type AuctioneerPublicBuyInstructionArgs = {
  * @category AuctioneerPublicBuy
  * @category generated
  */
-const auctioneerPublicBuyStruct = new beet.BeetArgsStruct<
+export const auctioneerPublicBuyStruct = new beet.BeetArgsStruct<
   AuctioneerPublicBuyInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -73,9 +73,13 @@ export type AuctioneerPublicBuyInstructionAccounts = {
   auctionHouseFeeAccount: web3.PublicKey;
   buyerTradeState: web3.PublicKey;
   ahAuctioneerPda: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const auctioneerPublicBuyInstructionDiscriminator = [221, 239, 99, 240, 86, 46, 213, 126];
+export const auctioneerPublicBuyInstructionDiscriminator = [221, 239, 99, 240, 86, 46, 213, 126];
 
 /**
  * Creates a _AuctioneerPublicBuy_ instruction.
@@ -90,112 +94,103 @@ const auctioneerPublicBuyInstructionDiscriminator = [221, 239, 99, 240, 86, 46, 
 export function createAuctioneerPublicBuyInstruction(
   accounts: AuctioneerPublicBuyInstructionAccounts,
   args: AuctioneerPublicBuyInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    wallet,
-    paymentAccount,
-    transferAuthority,
-    treasuryMint,
-    tokenAccount,
-    metadata,
-    escrowPaymentAccount,
-    authority,
-    auctioneerAuthority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    buyerTradeState,
-    ahAuctioneerPda,
-  } = accounts;
-
   const [data] = auctioneerPublicBuyStruct.serialize({
     instructionDiscriminator: auctioneerPublicBuyInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: paymentAccount,
+      pubkey: accounts.paymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: transferAuthority,
+      pubkey: accounts.transferAuthority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctioneerAuthority,
+      pubkey: accounts.auctioneerAuthority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerTradeState,
+      pubkey: accounts.buyerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: ahAuctioneerPda,
+      pubkey: accounts.ahAuctioneerPda,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/auctioneerSell.ts
+++ b/auction-house/js/src/generated/instructions/auctioneerSell.ts
@@ -25,7 +25,7 @@ export type AuctioneerSellInstructionArgs = {
  * @category AuctioneerSell
  * @category generated
  */
-const auctioneerSellStruct = new beet.BeetArgsStruct<
+export const auctioneerSellStruct = new beet.BeetArgsStruct<
   AuctioneerSellInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -69,9 +69,13 @@ export type AuctioneerSellInstructionAccounts = {
   freeSellerTradeState: web3.PublicKey;
   ahAuctioneerPda: web3.PublicKey;
   programAsSigner: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const auctioneerSellInstructionDiscriminator = [251, 60, 142, 195, 121, 203, 26, 183];
+export const auctioneerSellInstructionDiscriminator = [251, 60, 142, 195, 121, 203, 26, 183];
 
 /**
  * Creates a _AuctioneerSell_ instruction.
@@ -86,100 +90,93 @@ const auctioneerSellInstructionDiscriminator = [251, 60, 142, 195, 121, 203, 26,
 export function createAuctioneerSellInstruction(
   accounts: AuctioneerSellInstructionAccounts,
   args: AuctioneerSellInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    wallet,
-    tokenAccount,
-    metadata,
-    authority,
-    auctioneerAuthority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    sellerTradeState,
-    freeSellerTradeState,
-    ahAuctioneerPda,
-    programAsSigner,
-  } = accounts;
-
   const [data] = auctioneerSellStruct.serialize({
     instructionDiscriminator: auctioneerSellInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctioneerAuthority,
+      pubkey: accounts.auctioneerAuthority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: sellerTradeState,
+      pubkey: accounts.sellerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: freeSellerTradeState,
+      pubkey: accounts.freeSellerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: ahAuctioneerPda,
+      pubkey: accounts.ahAuctioneerPda,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: programAsSigner,
+      pubkey: accounts.programAsSigner,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/auctioneerWithdraw.ts
+++ b/auction-house/js/src/generated/instructions/auctioneerWithdraw.ts
@@ -23,7 +23,7 @@ export type AuctioneerWithdrawInstructionArgs = {
  * @category AuctioneerWithdraw
  * @category generated
  */
-const auctioneerWithdrawStruct = new beet.BeetArgsStruct<
+export const auctioneerWithdrawStruct = new beet.BeetArgsStruct<
   AuctioneerWithdrawInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -61,9 +61,14 @@ export type AuctioneerWithdrawInstructionAccounts = {
   auctionHouse: web3.PublicKey;
   auctionHouseFeeAccount: web3.PublicKey;
   ahAuctioneerPda: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  ataProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const auctioneerWithdrawInstructionDiscriminator = [85, 166, 219, 110, 168, 143, 180, 236];
+export const auctioneerWithdrawInstructionDiscriminator = [85, 166, 219, 110, 168, 143, 180, 236];
 
 /**
  * Creates a _AuctioneerWithdraw_ instruction.
@@ -78,93 +83,88 @@ const auctioneerWithdrawInstructionDiscriminator = [85, 166, 219, 110, 168, 143,
 export function createAuctioneerWithdrawInstruction(
   accounts: AuctioneerWithdrawInstructionAccounts,
   args: AuctioneerWithdrawInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    wallet,
-    receiptAccount,
-    escrowPaymentAccount,
-    treasuryMint,
-    authority,
-    auctioneerAuthority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    ahAuctioneerPda,
-  } = accounts;
-
   const [data] = auctioneerWithdrawStruct.serialize({
     instructionDiscriminator: auctioneerWithdrawInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: receiptAccount,
+      pubkey: accounts.receiptAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctioneerAuthority,
+      pubkey: accounts.auctioneerAuthority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: ahAuctioneerPda,
+      pubkey: accounts.ahAuctioneerPda,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
+      pubkey: accounts.ataProgram ?? splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/buy.ts
+++ b/auction-house/js/src/generated/instructions/buy.ts
@@ -25,7 +25,7 @@ export type BuyInstructionArgs = {
  * @category Buy
  * @category generated
  */
-const buyStruct = new beet.BeetArgsStruct<
+export const buyStruct = new beet.BeetArgsStruct<
   BuyInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -69,9 +69,13 @@ export type BuyInstructionAccounts = {
   auctionHouse: web3.PublicKey;
   auctionHouseFeeAccount: web3.PublicKey;
   buyerTradeState: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const buyInstructionDiscriminator = [102, 6, 61, 18, 1, 218, 235, 234];
+export const buyInstructionDiscriminator = [102, 6, 61, 18, 1, 218, 235, 234];
 
 /**
  * Creates a _Buy_ instruction.
@@ -83,100 +87,96 @@ const buyInstructionDiscriminator = [102, 6, 61, 18, 1, 218, 235, 234];
  * @category Buy
  * @category generated
  */
-export function createBuyInstruction(accounts: BuyInstructionAccounts, args: BuyInstructionArgs) {
-  const {
-    wallet,
-    paymentAccount,
-    transferAuthority,
-    treasuryMint,
-    tokenAccount,
-    metadata,
-    escrowPaymentAccount,
-    authority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    buyerTradeState,
-  } = accounts;
-
+export function createBuyInstruction(
+  accounts: BuyInstructionAccounts,
+  args: BuyInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+) {
   const [data] = buyStruct.serialize({
     instructionDiscriminator: buyInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: paymentAccount,
+      pubkey: accounts.paymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: transferAuthority,
+      pubkey: accounts.transferAuthority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerTradeState,
+      pubkey: accounts.buyerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/cancel.ts
+++ b/auction-house/js/src/generated/instructions/cancel.ts
@@ -23,7 +23,7 @@ export type CancelInstructionArgs = {
  * @category Cancel
  * @category generated
  */
-const cancelStruct = new beet.BeetArgsStruct<
+export const cancelStruct = new beet.BeetArgsStruct<
   CancelInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -57,9 +57,11 @@ export type CancelInstructionAccounts = {
   auctionHouse: web3.PublicKey;
   auctionHouseFeeAccount: web3.PublicKey;
   tradeState: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const cancelInstructionDiscriminator = [232, 219, 223, 41, 219, 236, 220, 190];
+export const cancelInstructionDiscriminator = [232, 219, 223, 41, 219, 236, 220, 190];
 
 /**
  * Creates a _Cancel_ instruction.
@@ -74,66 +76,63 @@ const cancelInstructionDiscriminator = [232, 219, 223, 41, 219, 236, 220, 190];
 export function createCancelInstruction(
   accounts: CancelInstructionAccounts,
   args: CancelInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    wallet,
-    tokenAccount,
-    tokenMint,
-    authority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    tradeState,
-  } = accounts;
-
   const [data] = cancelStruct.serialize({
     instructionDiscriminator: cancelInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenMint,
+      pubkey: accounts.tokenMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tradeState,
+      pubkey: accounts.tradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/cancelBidReceipt.ts
+++ b/auction-house/js/src/generated/instructions/cancelBidReceipt.ts
@@ -13,7 +13,7 @@ import * as web3 from '@solana/web3.js';
  * @category CancelBidReceipt
  * @category generated
  */
-const cancelBidReceiptStruct = new beet.BeetArgsStruct<{
+export const cancelBidReceiptStruct = new beet.BeetArgsStruct<{
   instructionDiscriminator: number[] /* size: 8 */;
 }>(
   [['instructionDiscriminator', beet.uniformFixedSizeArray(beet.u8, 8)]],
@@ -30,10 +30,12 @@ const cancelBidReceiptStruct = new beet.BeetArgsStruct<{
  */
 export type CancelBidReceiptInstructionAccounts = {
   receipt: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
   instruction: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const cancelBidReceiptInstructionDiscriminator = [246, 108, 27, 229, 220, 42, 176, 43];
+export const cancelBidReceiptInstructionDiscriminator = [246, 108, 27, 229, 220, 42, 176, 43];
 
 /**
  * Creates a _CancelBidReceipt_ instruction.
@@ -43,32 +45,39 @@ const cancelBidReceiptInstructionDiscriminator = [246, 108, 27, 229, 220, 42, 17
  * @category CancelBidReceipt
  * @category generated
  */
-export function createCancelBidReceiptInstruction(accounts: CancelBidReceiptInstructionAccounts) {
-  const { receipt, instruction } = accounts;
-
+export function createCancelBidReceiptInstruction(
+  accounts: CancelBidReceiptInstructionAccounts,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+) {
   const [data] = cancelBidReceiptStruct.serialize({
     instructionDiscriminator: cancelBidReceiptInstructionDiscriminator,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: receipt,
+      pubkey: accounts.receipt,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: instruction,
+      pubkey: accounts.instruction,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/cancelListingReceipt.ts
+++ b/auction-house/js/src/generated/instructions/cancelListingReceipt.ts
@@ -13,7 +13,7 @@ import * as web3 from '@solana/web3.js';
  * @category CancelListingReceipt
  * @category generated
  */
-const cancelListingReceiptStruct = new beet.BeetArgsStruct<{
+export const cancelListingReceiptStruct = new beet.BeetArgsStruct<{
   instructionDiscriminator: number[] /* size: 8 */;
 }>(
   [['instructionDiscriminator', beet.uniformFixedSizeArray(beet.u8, 8)]],
@@ -30,10 +30,12 @@ const cancelListingReceiptStruct = new beet.BeetArgsStruct<{
  */
 export type CancelListingReceiptInstructionAccounts = {
   receipt: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
   instruction: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const cancelListingReceiptInstructionDiscriminator = [171, 59, 138, 126, 246, 189, 91, 11];
+export const cancelListingReceiptInstructionDiscriminator = [171, 59, 138, 126, 246, 189, 91, 11];
 
 /**
  * Creates a _CancelListingReceipt_ instruction.
@@ -45,32 +47,37 @@ const cancelListingReceiptInstructionDiscriminator = [171, 59, 138, 126, 246, 18
  */
 export function createCancelListingReceiptInstruction(
   accounts: CancelListingReceiptInstructionAccounts,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const { receipt, instruction } = accounts;
-
   const [data] = cancelListingReceiptStruct.serialize({
     instructionDiscriminator: cancelListingReceiptInstructionDiscriminator,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: receipt,
+      pubkey: accounts.receipt,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: instruction,
+      pubkey: accounts.instruction,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/closeEscrowAccount.ts
+++ b/auction-house/js/src/generated/instructions/closeEscrowAccount.ts
@@ -21,7 +21,7 @@ export type CloseEscrowAccountInstructionArgs = {
  * @category CloseEscrowAccount
  * @category generated
  */
-const closeEscrowAccountStruct = new beet.BeetArgsStruct<
+export const closeEscrowAccountStruct = new beet.BeetArgsStruct<
   CloseEscrowAccountInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -46,9 +46,11 @@ export type CloseEscrowAccountInstructionAccounts = {
   wallet: web3.PublicKey;
   escrowPaymentAccount: web3.PublicKey;
   auctionHouse: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const closeEscrowAccountInstructionDiscriminator = [209, 42, 208, 179, 140, 78, 18, 43];
+export const closeEscrowAccountInstructionDiscriminator = [209, 42, 208, 179, 140, 78, 18, 43];
 
 /**
  * Creates a _CloseEscrowAccount_ instruction.
@@ -63,38 +65,43 @@ const closeEscrowAccountInstructionDiscriminator = [209, 42, 208, 179, 140, 78, 
 export function createCloseEscrowAccountInstruction(
   accounts: CloseEscrowAccountInstructionAccounts,
   args: CloseEscrowAccountInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const { wallet, escrowPaymentAccount, auctionHouse } = accounts;
-
   const [data] = closeEscrowAccountStruct.serialize({
     instructionDiscriminator: closeEscrowAccountInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/createAuctionHouse.ts
+++ b/auction-house/js/src/generated/instructions/createAuctionHouse.ts
@@ -27,7 +27,7 @@ export type CreateAuctionHouseInstructionArgs = {
  * @category CreateAuctionHouse
  * @category generated
  */
-const createAuctionHouseStruct = new beet.BeetArgsStruct<
+export const createAuctionHouseStruct = new beet.BeetArgsStruct<
   CreateAuctionHouseInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -69,9 +69,14 @@ export type CreateAuctionHouseInstructionAccounts = {
   auctionHouse: web3.PublicKey;
   auctionHouseFeeAccount: web3.PublicKey;
   auctionHouseTreasury: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  ataProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const createAuctionHouseInstructionDiscriminator = [221, 66, 242, 159, 249, 206, 134, 241];
+export const createAuctionHouseInstructionDiscriminator = [221, 66, 242, 159, 249, 206, 134, 241];
 
 /**
  * Creates a _CreateAuctionHouse_ instruction.
@@ -86,93 +91,88 @@ const createAuctionHouseInstructionDiscriminator = [221, 66, 242, 159, 249, 206,
 export function createCreateAuctionHouseInstruction(
   accounts: CreateAuctionHouseInstructionAccounts,
   args: CreateAuctionHouseInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    treasuryMint,
-    payer,
-    authority,
-    feeWithdrawalDestination,
-    treasuryWithdrawalDestination,
-    treasuryWithdrawalDestinationOwner,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    auctionHouseTreasury,
-  } = accounts;
-
   const [data] = createAuctionHouseStruct.serialize({
     instructionDiscriminator: createAuctionHouseInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: payer,
+      pubkey: accounts.payer,
       isWritable: true,
       isSigner: true,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: feeWithdrawalDestination,
+      pubkey: accounts.feeWithdrawalDestination,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: treasuryWithdrawalDestination,
+      pubkey: accounts.treasuryWithdrawalDestination,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: treasuryWithdrawalDestinationOwner,
+      pubkey: accounts.treasuryWithdrawalDestinationOwner,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseTreasury,
+      pubkey: accounts.auctionHouseTreasury,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
+      pubkey: accounts.ataProgram ?? splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/delegateAuctioneer.ts
+++ b/auction-house/js/src/generated/instructions/delegateAuctioneer.ts
@@ -22,7 +22,7 @@ export type DelegateAuctioneerInstructionArgs = {
  * @category DelegateAuctioneer
  * @category generated
  */
-const delegateAuctioneerStruct = new beet.FixableBeetArgsStruct<
+export const delegateAuctioneerStruct = new beet.FixableBeetArgsStruct<
   DelegateAuctioneerInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -49,9 +49,11 @@ export type DelegateAuctioneerInstructionAccounts = {
   authority: web3.PublicKey;
   auctioneerAuthority: web3.PublicKey;
   ahAuctioneerPda: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const delegateAuctioneerInstructionDiscriminator = [106, 178, 12, 122, 74, 173, 251, 222];
+export const delegateAuctioneerInstructionDiscriminator = [106, 178, 12, 122, 74, 173, 251, 222];
 
 /**
  * Creates a _DelegateAuctioneer_ instruction.
@@ -66,43 +68,48 @@ const delegateAuctioneerInstructionDiscriminator = [106, 178, 12, 122, 74, 173, 
 export function createDelegateAuctioneerInstruction(
   accounts: DelegateAuctioneerInstructionAccounts,
   args: DelegateAuctioneerInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const { auctionHouse, authority, auctioneerAuthority, ahAuctioneerPda } = accounts;
-
   const [data] = delegateAuctioneerStruct.serialize({
     instructionDiscriminator: delegateAuctioneerInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: true,
       isSigner: true,
     },
     {
-      pubkey: auctioneerAuthority,
+      pubkey: accounts.auctioneerAuthority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: ahAuctioneerPda,
+      pubkey: accounts.ahAuctioneerPda,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/deposit.ts
+++ b/auction-house/js/src/generated/instructions/deposit.ts
@@ -23,7 +23,7 @@ export type DepositInstructionArgs = {
  * @category Deposit
  * @category generated
  */
-const depositStruct = new beet.BeetArgsStruct<
+export const depositStruct = new beet.BeetArgsStruct<
   DepositInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -59,9 +59,13 @@ export type DepositInstructionAccounts = {
   authority: web3.PublicKey;
   auctionHouse: web3.PublicKey;
   auctionHouseFeeAccount: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const depositInstructionDiscriminator = [242, 35, 198, 137, 82, 225, 242, 182];
+export const depositInstructionDiscriminator = [242, 35, 198, 137, 82, 225, 242, 182];
 
 /**
  * Creates a _Deposit_ instruction.
@@ -76,82 +80,78 @@ const depositInstructionDiscriminator = [242, 35, 198, 137, 82, 225, 242, 182];
 export function createDepositInstruction(
   accounts: DepositInstructionAccounts,
   args: DepositInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    wallet,
-    paymentAccount,
-    transferAuthority,
-    escrowPaymentAccount,
-    treasuryMint,
-    authority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-  } = accounts;
-
   const [data] = depositStruct.serialize({
     instructionDiscriminator: depositInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: paymentAccount,
+      pubkey: accounts.paymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: transferAuthority,
+      pubkey: accounts.transferAuthority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/executePartialSale.ts
+++ b/auction-house/js/src/generated/instructions/executePartialSale.ts
@@ -28,7 +28,7 @@ export type ExecutePartialSaleInstructionArgs = {
  * @category ExecutePartialSale
  * @category generated
  */
-const executePartialSaleStruct = new beet.FixableBeetArgsStruct<
+export const executePartialSaleStruct = new beet.FixableBeetArgsStruct<
   ExecutePartialSaleInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -86,10 +86,15 @@ export type ExecutePartialSaleInstructionAccounts = {
   buyerTradeState: web3.PublicKey;
   sellerTradeState: web3.PublicKey;
   freeTradeState: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  ataProgram?: web3.PublicKey;
   programAsSigner: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const executePartialSaleInstructionDiscriminator = [163, 18, 35, 157, 49, 164, 203, 133];
+export const executePartialSaleInstructionDiscriminator = [163, 18, 35, 157, 49, 164, 203, 133];
 
 /**
  * Creates a _ExecutePartialSale_ instruction.
@@ -104,141 +109,128 @@ const executePartialSaleInstructionDiscriminator = [163, 18, 35, 157, 49, 164, 2
 export function createExecutePartialSaleInstruction(
   accounts: ExecutePartialSaleInstructionAccounts,
   args: ExecutePartialSaleInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    buyer,
-    seller,
-    tokenAccount,
-    tokenMint,
-    metadata,
-    treasuryMint,
-    escrowPaymentAccount,
-    sellerPaymentReceiptAccount,
-    buyerReceiptTokenAccount,
-    authority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    auctionHouseTreasury,
-    buyerTradeState,
-    sellerTradeState,
-    freeTradeState,
-    programAsSigner,
-  } = accounts;
-
   const [data] = executePartialSaleStruct.serialize({
     instructionDiscriminator: executePartialSaleInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: buyer,
+      pubkey: accounts.buyer,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: seller,
+      pubkey: accounts.seller,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenMint,
+      pubkey: accounts.tokenMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: sellerPaymentReceiptAccount,
+      pubkey: accounts.sellerPaymentReceiptAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerReceiptTokenAccount,
+      pubkey: accounts.buyerReceiptTokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseTreasury,
+      pubkey: accounts.auctionHouseTreasury,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerTradeState,
+      pubkey: accounts.buyerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: sellerTradeState,
+      pubkey: accounts.sellerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: freeTradeState,
+      pubkey: accounts.freeTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
+      pubkey: accounts.ataProgram ?? splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: programAsSigner,
+      pubkey: accounts.programAsSigner,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/executeSale.ts
+++ b/auction-house/js/src/generated/instructions/executeSale.ts
@@ -26,7 +26,7 @@ export type ExecuteSaleInstructionArgs = {
  * @category ExecuteSale
  * @category generated
  */
-const executeSaleStruct = new beet.BeetArgsStruct<
+export const executeSaleStruct = new beet.BeetArgsStruct<
   ExecuteSaleInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -82,10 +82,15 @@ export type ExecuteSaleInstructionAccounts = {
   buyerTradeState: web3.PublicKey;
   sellerTradeState: web3.PublicKey;
   freeTradeState: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  ataProgram?: web3.PublicKey;
   programAsSigner: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const executeSaleInstructionDiscriminator = [37, 74, 217, 157, 79, 49, 35, 6];
+export const executeSaleInstructionDiscriminator = [37, 74, 217, 157, 79, 49, 35, 6];
 
 /**
  * Creates a _ExecuteSale_ instruction.
@@ -100,141 +105,128 @@ const executeSaleInstructionDiscriminator = [37, 74, 217, 157, 79, 49, 35, 6];
 export function createExecuteSaleInstruction(
   accounts: ExecuteSaleInstructionAccounts,
   args: ExecuteSaleInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    buyer,
-    seller,
-    tokenAccount,
-    tokenMint,
-    metadata,
-    treasuryMint,
-    escrowPaymentAccount,
-    sellerPaymentReceiptAccount,
-    buyerReceiptTokenAccount,
-    authority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    auctionHouseTreasury,
-    buyerTradeState,
-    sellerTradeState,
-    freeTradeState,
-    programAsSigner,
-  } = accounts;
-
   const [data] = executeSaleStruct.serialize({
     instructionDiscriminator: executeSaleInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: buyer,
+      pubkey: accounts.buyer,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: seller,
+      pubkey: accounts.seller,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: tokenMint,
+      pubkey: accounts.tokenMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: sellerPaymentReceiptAccount,
+      pubkey: accounts.sellerPaymentReceiptAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerReceiptTokenAccount,
+      pubkey: accounts.buyerReceiptTokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseTreasury,
+      pubkey: accounts.auctionHouseTreasury,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerTradeState,
+      pubkey: accounts.buyerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: sellerTradeState,
+      pubkey: accounts.sellerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: freeTradeState,
+      pubkey: accounts.freeTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
+      pubkey: accounts.ataProgram ?? splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: programAsSigner,
+      pubkey: accounts.programAsSigner,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/printBidReceipt.ts
+++ b/auction-house/js/src/generated/instructions/printBidReceipt.ts
@@ -21,7 +21,7 @@ export type PrintBidReceiptInstructionArgs = {
  * @category PrintBidReceipt
  * @category generated
  */
-const printBidReceiptStruct = new beet.BeetArgsStruct<
+export const printBidReceiptStruct = new beet.BeetArgsStruct<
   PrintBidReceiptInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -45,10 +45,13 @@ const printBidReceiptStruct = new beet.BeetArgsStruct<
 export type PrintBidReceiptInstructionAccounts = {
   receipt: web3.PublicKey;
   bookkeeper: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
   instruction: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const printBidReceiptInstructionDiscriminator = [94, 249, 90, 230, 239, 64, 68, 218];
+export const printBidReceiptInstructionDiscriminator = [94, 249, 90, 230, 239, 64, 68, 218];
 
 /**
  * Creates a _PrintBidReceipt_ instruction.
@@ -63,43 +66,48 @@ const printBidReceiptInstructionDiscriminator = [94, 249, 90, 230, 239, 64, 68, 
 export function createPrintBidReceiptInstruction(
   accounts: PrintBidReceiptInstructionAccounts,
   args: PrintBidReceiptInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const { receipt, bookkeeper, instruction } = accounts;
-
   const [data] = printBidReceiptStruct.serialize({
     instructionDiscriminator: printBidReceiptInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: receipt,
+      pubkey: accounts.receipt,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: bookkeeper,
+      pubkey: accounts.bookkeeper,
       isWritable: true,
       isSigner: true,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: instruction,
+      pubkey: accounts.instruction,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/printListingReceipt.ts
+++ b/auction-house/js/src/generated/instructions/printListingReceipt.ts
@@ -21,7 +21,7 @@ export type PrintListingReceiptInstructionArgs = {
  * @category PrintListingReceipt
  * @category generated
  */
-const printListingReceiptStruct = new beet.BeetArgsStruct<
+export const printListingReceiptStruct = new beet.BeetArgsStruct<
   PrintListingReceiptInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -45,10 +45,13 @@ const printListingReceiptStruct = new beet.BeetArgsStruct<
 export type PrintListingReceiptInstructionAccounts = {
   receipt: web3.PublicKey;
   bookkeeper: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
   instruction: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const printListingReceiptInstructionDiscriminator = [207, 107, 44, 160, 75, 222, 195, 27];
+export const printListingReceiptInstructionDiscriminator = [207, 107, 44, 160, 75, 222, 195, 27];
 
 /**
  * Creates a _PrintListingReceipt_ instruction.
@@ -63,43 +66,48 @@ const printListingReceiptInstructionDiscriminator = [207, 107, 44, 160, 75, 222,
 export function createPrintListingReceiptInstruction(
   accounts: PrintListingReceiptInstructionAccounts,
   args: PrintListingReceiptInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const { receipt, bookkeeper, instruction } = accounts;
-
   const [data] = printListingReceiptStruct.serialize({
     instructionDiscriminator: printListingReceiptInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: receipt,
+      pubkey: accounts.receipt,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: bookkeeper,
+      pubkey: accounts.bookkeeper,
       isWritable: true,
       isSigner: true,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: instruction,
+      pubkey: accounts.instruction,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/printPurchaseReceipt.ts
+++ b/auction-house/js/src/generated/instructions/printPurchaseReceipt.ts
@@ -21,7 +21,7 @@ export type PrintPurchaseReceiptInstructionArgs = {
  * @category PrintPurchaseReceipt
  * @category generated
  */
-const printPurchaseReceiptStruct = new beet.BeetArgsStruct<
+export const printPurchaseReceiptStruct = new beet.BeetArgsStruct<
   PrintPurchaseReceiptInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -49,10 +49,13 @@ export type PrintPurchaseReceiptInstructionAccounts = {
   listingReceipt: web3.PublicKey;
   bidReceipt: web3.PublicKey;
   bookkeeper: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
   instruction: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const printPurchaseReceiptInstructionDiscriminator = [227, 154, 251, 7, 180, 56, 100, 143];
+export const printPurchaseReceiptInstructionDiscriminator = [227, 154, 251, 7, 180, 56, 100, 143];
 
 /**
  * Creates a _PrintPurchaseReceipt_ instruction.
@@ -67,53 +70,58 @@ const printPurchaseReceiptInstructionDiscriminator = [227, 154, 251, 7, 180, 56,
 export function createPrintPurchaseReceiptInstruction(
   accounts: PrintPurchaseReceiptInstructionAccounts,
   args: PrintPurchaseReceiptInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const { purchaseReceipt, listingReceipt, bidReceipt, bookkeeper, instruction } = accounts;
-
   const [data] = printPurchaseReceiptStruct.serialize({
     instructionDiscriminator: printPurchaseReceiptInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: purchaseReceipt,
+      pubkey: accounts.purchaseReceipt,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: listingReceipt,
+      pubkey: accounts.listingReceipt,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: bidReceipt,
+      pubkey: accounts.bidReceipt,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: bookkeeper,
+      pubkey: accounts.bookkeeper,
       isWritable: true,
       isSigner: true,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: instruction,
+      pubkey: accounts.instruction,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/publicBuy.ts
+++ b/auction-house/js/src/generated/instructions/publicBuy.ts
@@ -25,7 +25,7 @@ export type PublicBuyInstructionArgs = {
  * @category PublicBuy
  * @category generated
  */
-const publicBuyStruct = new beet.BeetArgsStruct<
+export const publicBuyStruct = new beet.BeetArgsStruct<
   PublicBuyInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -69,9 +69,13 @@ export type PublicBuyInstructionAccounts = {
   auctionHouse: web3.PublicKey;
   auctionHouseFeeAccount: web3.PublicKey;
   buyerTradeState: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const publicBuyInstructionDiscriminator = [169, 84, 218, 35, 42, 206, 16, 171];
+export const publicBuyInstructionDiscriminator = [169, 84, 218, 35, 42, 206, 16, 171];
 
 /**
  * Creates a _PublicBuy_ instruction.
@@ -86,100 +90,93 @@ const publicBuyInstructionDiscriminator = [169, 84, 218, 35, 42, 206, 16, 171];
 export function createPublicBuyInstruction(
   accounts: PublicBuyInstructionAccounts,
   args: PublicBuyInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    wallet,
-    paymentAccount,
-    transferAuthority,
-    treasuryMint,
-    tokenAccount,
-    metadata,
-    escrowPaymentAccount,
-    authority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    buyerTradeState,
-  } = accounts;
-
   const [data] = publicBuyStruct.serialize({
     instructionDiscriminator: publicBuyInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: paymentAccount,
+      pubkey: accounts.paymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: transferAuthority,
+      pubkey: accounts.transferAuthority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: buyerTradeState,
+      pubkey: accounts.buyerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/sell.ts
+++ b/auction-house/js/src/generated/instructions/sell.ts
@@ -26,7 +26,7 @@ export type SellInstructionArgs = {
  * @category Sell
  * @category generated
  */
-const sellStruct = new beet.BeetArgsStruct<
+export const sellStruct = new beet.BeetArgsStruct<
   SellInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -66,10 +66,14 @@ export type SellInstructionAccounts = {
   auctionHouseFeeAccount: web3.PublicKey;
   sellerTradeState: web3.PublicKey;
   freeSellerTradeState: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
   programAsSigner: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const sellInstructionDiscriminator = [51, 230, 133, 164, 1, 127, 131, 173];
+export const sellInstructionDiscriminator = [51, 230, 133, 164, 1, 127, 131, 173];
 
 /**
  * Creates a _Sell_ instruction.
@@ -84,88 +88,83 @@ const sellInstructionDiscriminator = [51, 230, 133, 164, 1, 127, 131, 173];
 export function createSellInstruction(
   accounts: SellInstructionAccounts,
   args: SellInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    wallet,
-    tokenAccount,
-    metadata,
-    authority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-    sellerTradeState,
-    freeSellerTradeState,
-    programAsSigner,
-  } = accounts;
-
   const [data] = sellStruct.serialize({
     instructionDiscriminator: sellInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: tokenAccount,
+      pubkey: accounts.tokenAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: metadata,
+      pubkey: accounts.metadata,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: sellerTradeState,
+      pubkey: accounts.sellerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: freeSellerTradeState,
+      pubkey: accounts.freeSellerTradeState,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: programAsSigner,
+      pubkey: accounts.programAsSigner,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/updateAuctionHouse.ts
+++ b/auction-house/js/src/generated/instructions/updateAuctionHouse.ts
@@ -24,7 +24,7 @@ export type UpdateAuctionHouseInstructionArgs = {
  * @category UpdateAuctionHouse
  * @category generated
  */
-const updateAuctionHouseStruct = new beet.FixableBeetArgsStruct<
+export const updateAuctionHouseStruct = new beet.FixableBeetArgsStruct<
   UpdateAuctionHouseInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -61,9 +61,14 @@ export type UpdateAuctionHouseInstructionAccounts = {
   treasuryWithdrawalDestination: web3.PublicKey;
   treasuryWithdrawalDestinationOwner: web3.PublicKey;
   auctionHouse: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  ataProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const updateAuctionHouseInstructionDiscriminator = [84, 215, 2, 172, 241, 0, 245, 219];
+export const updateAuctionHouseInstructionDiscriminator = [84, 215, 2, 172, 241, 0, 245, 219];
 
 /**
  * Creates a _UpdateAuctionHouse_ instruction.
@@ -78,87 +83,83 @@ const updateAuctionHouseInstructionDiscriminator = [84, 215, 2, 172, 241, 0, 245
 export function createUpdateAuctionHouseInstruction(
   accounts: UpdateAuctionHouseInstructionAccounts,
   args: UpdateAuctionHouseInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    treasuryMint,
-    payer,
-    authority,
-    newAuthority,
-    feeWithdrawalDestination,
-    treasuryWithdrawalDestination,
-    treasuryWithdrawalDestinationOwner,
-    auctionHouse,
-  } = accounts;
-
   const [data] = updateAuctionHouseStruct.serialize({
     instructionDiscriminator: updateAuctionHouseInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: payer,
-      isWritable: false,
-      isSigner: true,
-    },
-    {
-      pubkey: authority,
+      pubkey: accounts.payer,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: newAuthority,
+      pubkey: accounts.authority,
+      isWritable: false,
+      isSigner: true,
+    },
+    {
+      pubkey: accounts.newAuthority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: feeWithdrawalDestination,
+      pubkey: accounts.feeWithdrawalDestination,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: treasuryWithdrawalDestination,
+      pubkey: accounts.treasuryWithdrawalDestination,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: treasuryWithdrawalDestinationOwner,
+      pubkey: accounts.treasuryWithdrawalDestinationOwner,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
+      pubkey: accounts.ataProgram ?? splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/updateAuctioneer.ts
+++ b/auction-house/js/src/generated/instructions/updateAuctioneer.ts
@@ -22,7 +22,7 @@ export type UpdateAuctioneerInstructionArgs = {
  * @category UpdateAuctioneer
  * @category generated
  */
-const updateAuctioneerStruct = new beet.FixableBeetArgsStruct<
+export const updateAuctioneerStruct = new beet.FixableBeetArgsStruct<
   UpdateAuctioneerInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -49,9 +49,11 @@ export type UpdateAuctioneerInstructionAccounts = {
   authority: web3.PublicKey;
   auctioneerAuthority: web3.PublicKey;
   ahAuctioneerPda: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const updateAuctioneerInstructionDiscriminator = [103, 255, 80, 234, 94, 56, 168, 208];
+export const updateAuctioneerInstructionDiscriminator = [103, 255, 80, 234, 94, 56, 168, 208];
 
 /**
  * Creates a _UpdateAuctioneer_ instruction.
@@ -66,43 +68,48 @@ const updateAuctioneerInstructionDiscriminator = [103, 255, 80, 234, 94, 56, 168
 export function createUpdateAuctioneerInstruction(
   accounts: UpdateAuctioneerInstructionAccounts,
   args: UpdateAuctioneerInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const { auctionHouse, authority, auctioneerAuthority, ahAuctioneerPda } = accounts;
-
   const [data] = updateAuctioneerStruct.serialize({
     instructionDiscriminator: updateAuctioneerInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: true,
       isSigner: true,
     },
     {
-      pubkey: auctioneerAuthority,
+      pubkey: accounts.auctioneerAuthority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: ahAuctioneerPda,
+      pubkey: accounts.ahAuctioneerPda,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/withdraw.ts
+++ b/auction-house/js/src/generated/instructions/withdraw.ts
@@ -23,7 +23,7 @@ export type WithdrawInstructionArgs = {
  * @category Withdraw
  * @category generated
  */
-const withdrawStruct = new beet.BeetArgsStruct<
+export const withdrawStruct = new beet.BeetArgsStruct<
   WithdrawInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -57,9 +57,14 @@ export type WithdrawInstructionAccounts = {
   authority: web3.PublicKey;
   auctionHouse: web3.PublicKey;
   auctionHouseFeeAccount: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  ataProgram?: web3.PublicKey;
+  rent?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const withdrawInstructionDiscriminator = [183, 18, 70, 156, 148, 109, 161, 34];
+export const withdrawInstructionDiscriminator = [183, 18, 70, 156, 148, 109, 161, 34];
 
 /**
  * Creates a _Withdraw_ instruction.
@@ -74,81 +79,78 @@ const withdrawInstructionDiscriminator = [183, 18, 70, 156, 148, 109, 161, 34];
 export function createWithdrawInstruction(
   accounts: WithdrawInstructionAccounts,
   args: WithdrawInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    wallet,
-    receiptAccount,
-    escrowPaymentAccount,
-    treasuryMint,
-    authority,
-    auctionHouse,
-    auctionHouseFeeAccount,
-  } = accounts;
-
   const [data] = withdrawStruct.serialize({
     instructionDiscriminator: withdrawInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: wallet,
+      pubkey: accounts.wallet,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: receiptAccount,
+      pubkey: accounts.receiptAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: escrowPaymentAccount,
+      pubkey: accounts.escrowPaymentAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
+      pubkey: accounts.ataProgram ?? splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SYSVAR_RENT_PUBKEY,
+      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/withdrawFromFee.ts
+++ b/auction-house/js/src/generated/instructions/withdrawFromFee.ts
@@ -21,7 +21,7 @@ export type WithdrawFromFeeInstructionArgs = {
  * @category WithdrawFromFee
  * @category generated
  */
-const withdrawFromFeeStruct = new beet.BeetArgsStruct<
+export const withdrawFromFeeStruct = new beet.BeetArgsStruct<
   WithdrawFromFeeInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -48,9 +48,11 @@ export type WithdrawFromFeeInstructionAccounts = {
   feeWithdrawalDestination: web3.PublicKey;
   auctionHouseFeeAccount: web3.PublicKey;
   auctionHouse: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const withdrawFromFeeInstructionDiscriminator = [179, 208, 190, 154, 32, 179, 19, 59];
+export const withdrawFromFeeInstructionDiscriminator = [179, 208, 190, 154, 32, 179, 19, 59];
 
 /**
  * Creates a _WithdrawFromFee_ instruction.
@@ -65,43 +67,48 @@ const withdrawFromFeeInstructionDiscriminator = [179, 208, 190, 154, 32, 179, 19
 export function createWithdrawFromFeeInstruction(
   accounts: WithdrawFromFeeInstructionAccounts,
   args: WithdrawFromFeeInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const { authority, feeWithdrawalDestination, auctionHouseFeeAccount, auctionHouse } = accounts;
-
   const [data] = withdrawFromFeeStruct.serialize({
     instructionDiscriminator: withdrawFromFeeInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: feeWithdrawalDestination,
+      pubkey: accounts.feeWithdrawalDestination,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseFeeAccount,
+      pubkey: accounts.auctionHouseFeeAccount,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/auction-house/js/src/generated/instructions/withdrawFromTreasury.ts
+++ b/auction-house/js/src/generated/instructions/withdrawFromTreasury.ts
@@ -22,7 +22,7 @@ export type WithdrawFromTreasuryInstructionArgs = {
  * @category WithdrawFromTreasury
  * @category generated
  */
-const withdrawFromTreasuryStruct = new beet.BeetArgsStruct<
+export const withdrawFromTreasuryStruct = new beet.BeetArgsStruct<
   WithdrawFromTreasuryInstructionArgs & {
     instructionDiscriminator: number[] /* size: 8 */;
   }
@@ -51,9 +51,12 @@ export type WithdrawFromTreasuryInstructionAccounts = {
   treasuryWithdrawalDestination: web3.PublicKey;
   auctionHouseTreasury: web3.PublicKey;
   auctionHouse: web3.PublicKey;
+  tokenProgram?: web3.PublicKey;
+  systemProgram?: web3.PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
 };
 
-const withdrawFromTreasuryInstructionDiscriminator = [0, 164, 86, 76, 56, 72, 12, 170];
+export const withdrawFromTreasuryInstructionDiscriminator = [0, 164, 86, 76, 56, 72, 12, 170];
 
 /**
  * Creates a _WithdrawFromTreasury_ instruction.
@@ -68,59 +71,58 @@ const withdrawFromTreasuryInstructionDiscriminator = [0, 164, 86, 76, 56, 72, 12
 export function createWithdrawFromTreasuryInstruction(
   accounts: WithdrawFromTreasuryInstructionAccounts,
   args: WithdrawFromTreasuryInstructionArgs,
+  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
 ) {
-  const {
-    treasuryMint,
-    authority,
-    treasuryWithdrawalDestination,
-    auctionHouseTreasury,
-    auctionHouse,
-  } = accounts;
-
   const [data] = withdrawFromTreasuryStruct.serialize({
     instructionDiscriminator: withdrawFromTreasuryInstructionDiscriminator,
     ...args,
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: treasuryMint,
+      pubkey: accounts.treasuryMint,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: authority,
+      pubkey: accounts.authority,
       isWritable: false,
       isSigner: true,
     },
     {
-      pubkey: treasuryWithdrawalDestination,
+      pubkey: accounts.treasuryWithdrawalDestination,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: auctionHouseTreasury,
+      pubkey: accounts.auctionHouseTreasury,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: auctionHouse,
+      pubkey: accounts.auctionHouse,
       isWritable: true,
       isSigner: false,
     },
     {
-      pubkey: splToken.TOKEN_PROGRAM_ID,
+      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
       isWritable: false,
       isSigner: false,
     },
     {
-      pubkey: web3.SystemProgram.programId,
+      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
       isWritable: false,
       isSigner: false,
     },
   ];
 
+  if (accounts.anchorRemainingAccounts != null) {
+    for (const acc of accounts.anchorRemainingAccounts) {
+      keys.push(acc);
+    }
+  }
+
   const ix = new web3.TransactionInstruction({
-    programId: new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'),
+    programId,
     keys,
     data,
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,6 +1000,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metaplex-foundation/beet-solana@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@metaplex-foundation/beet-solana@npm:0.3.1"
+  dependencies:
+    "@metaplex-foundation/beet": ">=0.1.0"
+    "@solana/web3.js": ^1.56.2
+    bs58: ^5.0.0
+    debug: ^4.3.4
+  checksum: 5405ec57c8cdb2dce016bf96f1cbd96ae185d6c764b8bdd1aaa68028e1970ad4815e7eb026a61703f57c33ddac261e47874e013bb03d84fa74ad78fce4b6e7cd
+  languageName: node
+  linkType: hard
+
 "@metaplex-foundation/beet@npm:0.3.0":
   version: 0.3.0
   resolution: "@metaplex-foundation/beet@npm:0.3.0"
@@ -1055,6 +1067,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metaplex-foundation/beet@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@metaplex-foundation/beet@npm:0.6.1"
+  dependencies:
+    ansicolors: ^0.3.2
+    bn.js: ^5.2.0
+    debug: ^4.3.3
+  checksum: 8ee340feb08dce44657f1ebe55c17d6c617ae8b44ea086a8d43aadeded7ee919b3d541b0c3e74a8cd3dbc16e749f6228333ca2ea50e2b52194f14e5d59587aaa
+  languageName: node
+  linkType: hard
+
 "@metaplex-foundation/cusper@npm:^0.0.2":
   version: 0.0.2
   resolution: "@metaplex-foundation/cusper@npm:0.0.2"
@@ -1082,11 +1105,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metaplex-foundation/mpl-auction-house@workspace:auction-house/js"
   dependencies:
-    "@metaplex-foundation/beet": ^0.1.0
-    "@metaplex-foundation/beet-solana": ^0.1.1
+    "@metaplex-foundation/beet": ^0.6.1
+    "@metaplex-foundation/beet-solana": ^0.3.1
     "@metaplex-foundation/cusper": ^0.0.2
-    "@metaplex-foundation/solita": ^0.5.0
-    "@solana/web3.js": ^1.35.1
+    "@metaplex-foundation/solita": ^0.15.2
+    "@solana/web3.js": ^1.56.2
     "@types/tape": ^4.13.2
     bn.js: ^5.2.0
     eslint: ^8.3.0
@@ -1449,6 +1472,26 @@ __metadata:
   bin:
     solita: dist/src/cli/solita.js
   checksum: 438614f3e42781f585bed7d92e79f0da1cfb41cf2c43be762ff0ff1b1d3f2d90a407f6a2063240ef1b62f1561a621c7d8fb09995f4e9649bf7d3c059ef2eb29e
+  languageName: node
+  linkType: hard
+
+"@metaplex-foundation/solita@npm:^0.15.2":
+  version: 0.15.2
+  resolution: "@metaplex-foundation/solita@npm:0.15.2"
+  dependencies:
+    "@metaplex-foundation/beet": ^0.6.1
+    "@metaplex-foundation/beet-solana": ^0.3.1
+    "@metaplex-foundation/rustbin": ^0.3.0
+    "@solana/web3.js": ^1.56.2
+    camelcase: ^6.2.1
+    debug: ^4.3.3
+    js-sha256: ^0.9.0
+    prettier: ^2.5.1
+    snake-case: ^3.0.4
+    spok: ^1.4.3
+  bin:
+    solita: dist/src/cli/solita.js
+  checksum: d38eb725b874cac09685b484d603cd0c215bb74c2e8c5a7481f06dd464686a078a0bd74954675fa5265352fbe92deaa6f397f6b99fd178930a3b813ea392c325
   languageName: node
   linkType: hard
 
@@ -1961,6 +2004,30 @@ __metadata:
     rpc-websockets: ^7.5.0
     superstruct: ^0.14.2
   checksum: 775bfb797c70625434cbb92a1919add1d422eaa696ce91d7b0f80dbb0ff2d6c7839dc0a9d1f6c58680c187e1d7176c54b76480c65bc70eafa905fa753e80d765
+  languageName: node
+  linkType: hard
+
+"@solana/web3.js@npm:^1.56.2":
+  version: 1.56.2
+  resolution: "@solana/web3.js@npm:1.56.2"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    "@noble/ed25519": ^1.7.0
+    "@noble/hashes": ^1.1.2
+    "@noble/secp256k1": ^1.6.3
+    "@solana/buffer-layout": ^4.0.0
+    bigint-buffer: ^1.1.5
+    bn.js: ^5.0.0
+    borsh: ^0.7.0
+    bs58: ^4.0.1
+    buffer: 6.0.1
+    fast-stable-stringify: ^1.0.0
+    jayson: ^3.4.4
+    js-sha3: ^0.8.0
+    node-fetch: 2
+    rpc-websockets: ^7.5.0
+    superstruct: ^0.14.2
+  checksum: 9c87e82782e5b43299aa2401c14fef66f146749390a43801ef66f2b07b6fb7b965acbac1aec1f61c2fe02d9a81b9a4463a1b959e94d8be5c8d1dec0d5123523f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

In order to fix the issue that there is no way to provide anchor remaining accounts I updated
solita to support this and then regenerated the SDK here. As a result the SDK is improved in
the following ways.

## Accounts

- include gpa builders
- expose `accountProviders` to be used by diagnostics/testing tools like amman
- account discriminators are exported for each account

## Instructions

- allow overriding program id
- allow overriding _builtin_ accounts
- allow providing `anchorRemaingAccounts` which when set will be pushed to the end of the
  array of accounts sent to the program
- instruction discriminators are exported for each instruction

## Deps Upgrades

Solita itself and related packages like beet and beet-solana where upgraded as well as web3.js.

FIXES: #678
