### PR TITLE
build: update path filters to include program/js subdirs

### DIFF
--- a/.github/workflows/program-auction-house.yml
+++ b/.github/workflows/program-auction-house.yml
@@ -64,9 +64,9 @@ jobs:
         with:
           filters: |
             core:
-              - 'core/**'
+              - 'core/rust/**'
             package:
-              - 'auction-house/**'
+              - 'auction-house/program/**'
 
   build-and-test-auction-house:
     needs: [changes, setup-versions, setup-tests]

--- a/.github/workflows/program-auction.yml
+++ b/.github/workflows/program-auction.yml
@@ -26,9 +26,10 @@ jobs:
         with:
           filters: |
             core:
-              - 'core/**'
+              - 'core/rust/**'
             package:
-              - 'auction/**'
+              - 'auction/program/**'
+
   build-and-test-auction:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}

--- a/.github/workflows/program-auctioneer.yml
+++ b/.github/workflows/program-auctioneer.yml
@@ -64,10 +64,10 @@ jobs:
         with:
           filters: |
             core:
-              - 'core/**'
+              - 'core/rust/**'
             package:
-              - 'auction-house/**'
-              - 'auctioneer/**'
+              - 'auction-house/program/**'
+              - 'auctioneer/program/**'
 
   build-and-test-auctioneer:
     needs: [changes, setup-versions, setup-tests]

--- a/.github/workflows/program-candy-machine.yml
+++ b/.github/workflows/program-candy-machine.yml
@@ -26,9 +26,10 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/rust/**'
           package:
-            - 'candy-machine/**'
+            - 'candy-machine/program/**'
+
   build-and-test-candy-machine:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}

--- a/.github/workflows/program-fixed-price-sale.yml
+++ b/.github/workflows/program-fixed-price-sale.yml
@@ -26,9 +26,9 @@ jobs:
         with:
           filters: |
             core:
-              - 'core/**'
+              - 'core/rust/**'
             package:
-              - 'fixed-price-sale/**'
+              - 'fixed-price-sale/program/**'
             workflow:
               - '.github/workflows/program-fixed-price-sale.yml'
   build-and-test-fixed-price-sale:

--- a/.github/workflows/program-gumdrop.yml
+++ b/.github/workflows/program-gumdrop.yml
@@ -26,9 +26,10 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/rust/**'
           package:
-            - 'gumdrop/**'
+            - 'gumdrop/program/**'
+
   build-and-test-gumdrop:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}

--- a/.github/workflows/program-metaplex.yml
+++ b/.github/workflows/program-metaplex.yml
@@ -20,16 +20,15 @@ jobs:
       package: ${{ steps.filter.outputs.package }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/checkout@v2
     # For pull requests it's not necessary to checkout the code
     - uses: dorny/paths-filter@v2
       id: filter
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/rust/**'
           package:
-            - 'metaplex/**'
+            - 'metaplex/program/**'
 
   build-and-test-metaplex:
     needs: changes

--- a/.github/workflows/program-nft-packs.yml
+++ b/.github/workflows/program-nft-packs.yml
@@ -26,9 +26,9 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/rust/**'
           package:
-            - 'nft-packs/**'
+            - 'nft-packs/program/**'
 
   build-and-test-nft-packs:
     needs: changes

--- a/.github/workflows/program-token-entangler.yml
+++ b/.github/workflows/program-token-entangler.yml
@@ -26,9 +26,9 @@ jobs:
         with:
           filters: |
             core:
-              - 'core/**'
+              - 'core/rust/**'
             package:
-              - 'token-entangler/**'
+              - 'token-entangler/program/**'
 
   build-and-test-token-entangler:
     needs: changes

--- a/.github/workflows/program-token-metadata.yml
+++ b/.github/workflows/program-token-metadata.yml
@@ -26,9 +26,9 @@ jobs:
         with:
           filters: |
             core:
-              - 'core/**'
+              - 'core/rust/**'
             package:
-              - 'token-metadata/**'
+              - 'token-metadata/program/**'
 
   build-and-test-token-metadata:
     needs: changes

--- a/.github/workflows/program-token-vault.yml
+++ b/.github/workflows/program-token-vault.yml
@@ -26,9 +26,10 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/rust/**'
           package:
-            - 'token-vault/**'
+            - 'token-vault/program/**'
+
   build-and-test-token-vault:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}

--- a/.github/workflows/sdk-auction-house.yml
+++ b/.github/workflows/sdk-auction-house.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/js/**'
           package:
-            - 'auction-house/**'
+            - 'auction-house/js/**'
 
   build-lint-and-test-auction-house:
     needs: changes

--- a/.github/workflows/sdk-auction.yml
+++ b/.github/workflows/sdk-auction.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/js/**'
           package:
-            - 'auction/**'
+            - 'auction/js/**'
 
   build-lint-and-test-auction:
     needs: changes

--- a/.github/workflows/sdk-candy-machine.yml
+++ b/.github/workflows/sdk-candy-machine.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/js/**'
           package:
-            - 'candy-machine/**'
+            - 'candy-machine/js/**'
 
   build-lint-and-test-candy-machine:
     needs: changes

--- a/.github/workflows/sdk-core.yml
+++ b/.github/workflows/sdk-core.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/js/**'
 
   build-lint-and-test-core:
     needs: changes

--- a/.github/workflows/sdk-fixed-price-sale.yml
+++ b/.github/workflows/sdk-fixed-price-sale.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           filters: |
             core:
-              - 'core/**'
+              - 'core/js/**'
             package:
-              - 'fixed-price-sale/**'
+              - 'fixed-price-sale/js/**'
 
   build-lint-and-test-fixed-price-sale:
     needs: changes

--- a/.github/workflows/sdk-gumdrop.yml
+++ b/.github/workflows/sdk-gumdrop.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/js/**'
           package:
-            - 'gumdrop/**'
+            - 'gumdrop/js/**'
 
   build-lint-and-test-gumdrop:
     needs: changes

--- a/.github/workflows/sdk-metaplex.yml
+++ b/.github/workflows/sdk-metaplex.yml
@@ -21,9 +21,10 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/js/**'
           package:
-            - 'metaplex/**'
+            - 'metaplex/js/**'
+
   build-lint-and-test-metaplex:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}

--- a/.github/workflows/sdk-nft-packs.yml
+++ b/.github/workflows/sdk-nft-packs.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         filters: |
           package:
-            - 'nft-packs/**'
+            - 'nft-packs/js/**'
 
   build-lint-and-test-token-metadata:
     needs: changes

--- a/.github/workflows/sdk-token-entangler.yml
+++ b/.github/workflows/sdk-token-entangler.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/js/**'
           package:
-            - 'token-entangler/**'
+            - 'token-entangler/js/**'
 
   build-lint-and-test-token-entangler:
     needs: changes

--- a/.github/workflows/sdk-token-metadata.yml
+++ b/.github/workflows/sdk-token-metadata.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/js/**'
           package:
-            - 'token-metadata/**'
+            - 'token-metadata/js/**'
 
   build-lint-and-test-token-metadata:
     needs: changes

--- a/.github/workflows/sdk-token-vault.yml
+++ b/.github/workflows/sdk-token-vault.yml
@@ -13,7 +13,6 @@ jobs:
     outputs:
       core: ${{ steps.filter.outputs.core }}
       package: ${{ steps.filter.outputs.package }}
-      workflow: ${{ steps.filter.outputs.workflow }}
     steps:
     - uses: actions/checkout@v2
     # For pull requests it's not necessary to checkout the code
@@ -22,14 +21,13 @@ jobs:
       with:
         filters: |
           core:
-            - 'core/**'
+            - 'core/js/**'
           package:
-            - 'token-vault/**'
-          workflow:
-            - '.github/workflows/sdk-token-vault.yml'
+            - 'token-vault/js/**'
+
   build-lint-and-test-token-vault:
     needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.workflow == 'true' }}
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.package == 'true' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Update paths filters to only include rust subdirs for program workflows and js subdirs for sdk workflows. This should prevent program tests from running when only js changes are made, and vice versa.