### PR TITLE
chore: stabilize auction-house tests in CI

### DIFF
--- a/auction-house/program/Cargo.lock
+++ b/auction-house/program/Cargo.lock
@@ -1637,36 +1637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metaplex-token-metadata"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcc939f0afdc6db054b9998a1292d0a016244b382462e61cfc7c570624982cb"
-dependencies = [
- "arrayref",
- "borsh",
- "metaplex-token-vault",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token",
- "thiserror",
-]
-
-[[package]]
-name = "metaplex-token-vault"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5211991ba3273df89cd5e0f6f558bc8d7453c87c0546f915b4a319e1541df33"
-dependencies = [
- "borsh",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token",
- "thiserror",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,7 +1692,6 @@ dependencies = [
  "anchor-spl",
  "arrayref",
  "env_logger",
- "metaplex-token-metadata",
  "mpl-testing-utils",
  "mpl-token-metadata",
  "serde_json",

--- a/auction-house/program/Cargo.toml
+++ b/auction-house/program/Cargo.toml
@@ -27,7 +27,6 @@ anchor-spl = "~0.24.2"
 spl-token = { version = "~3.2",  features = ["no-entrypoint"] }
 spl-associated-token-account = {version = "~1.0.3", features = ["no-entrypoint"]}
 mpl-token-metadata = { version="~1.2.7", features = [ "no-entrypoint" ] }
-metaplex-token-metadata = { version = "0.0.1", features = [ "no-entrypoint" ] }
 thiserror = "~1.0"
 arrayref = "~0.3.6"
 

--- a/auction-house/program/src/utils.rs
+++ b/auction-house/program/src/utils.rs
@@ -15,7 +15,7 @@ use anchor_lang::{
 };
 use anchor_spl::token::{Mint, Token, TokenAccount};
 use arrayref::array_ref;
-use metaplex_token_metadata::state::Metadata;
+use mpl_token_metadata::state::Metadata;
 use spl_associated_token_account::get_associated_token_address;
 use spl_token::{instruction::initialize_account2, state::Account as SplAccount};
 use std::{convert::TryInto, slice::Iter};

--- a/auction-house/program/tests/execute_sale.rs
+++ b/auction-house/program/tests/execute_sale.rs
@@ -4,7 +4,12 @@ pub mod common;
 pub mod utils;
 
 use common::*;
-use utils::{helpers::default_scopes, setup_functions::*};
+use utils::{
+    helpers::{
+        assert_error_ignoring_io_error_in_ci, default_scopes, unwrap_ignoring_io_error_in_ci,
+    },
+    setup_functions::*,
+};
 
 use anchor_lang::{AccountDeserialize, InstructionData, ToAccountMetas};
 use mpl_auction_house::pda::find_auctioneer_pda;
@@ -2223,7 +2228,7 @@ async fn execute_sale_partial_order_success() {
         .await
         .unwrap();
     assert!(!buyer_token_before.is_none());
-    context.banks_client.process_transaction(tx).await.unwrap();
+    unwrap_ignoring_io_error_in_ci(context.banks_client.process_transaction(tx).await);
 
     let seller_after = context
         .banks_client
@@ -2819,7 +2824,7 @@ async fn execute_sale_partial_order_order_exceeds_tokens() {
         .process_transaction(tx)
         .await
         .unwrap_err();
-    assert_error!(error, NOT_ENOUGH_TOKENS_AVAIL_FOR_PURCHASE);
+    assert_error_ignoring_io_error_in_ci(&error, NOT_ENOUGH_TOKENS_AVAIL_FOR_PURCHASE);
 }
 
 #[tokio::test]
@@ -3067,12 +3072,12 @@ async fn execute_sale_partial_order_fail_price_mismatch() {
         context.last_blockhash,
     );
 
-    let error = context
+    let error: TransportError = context
         .banks_client
         .process_transaction(tx)
         .await
         .unwrap_err();
-    assert_error!(error, PARTIAL_BUY_PRICE_MISMATCH);
+    assert_error_ignoring_io_error_in_ci(&error, PARTIAL_BUY_PRICE_MISMATCH);
 }
 
 #[tokio::test]

--- a/auction-house/program/tests/utils/helpers.rs
+++ b/auction-house/program/tests/utils/helpers.rs
@@ -92,8 +92,8 @@ pub fn assert_error_ignoring_io_error_in_ci(error: &TransportError, error_code: 
                     eprintln!("However since we are running in CI this is acceptable and we can ignore it");
                 }
                 _ => {
-                    eprintln!("Encountered {:#?} error ({})", err, err.to_string());
-                    assert!(false, "Encountered unknown IoError");
+                    eprintln!("Encountered {:#?} error ({})", err, err);
+                    panic!("Encountered unknown IoError");
                 }
             }
         }
@@ -116,12 +116,12 @@ pub fn unwrap_ignoring_io_error_in_ci(result: Result<(), TransportError>) {
                     eprintln!("However since we are running in CI this is acceptable and we can ignore it");
                 }
                 _ => {
-                    eprintln!("Encountered {:#?} error ({})", err, err.to_string());
-                    assert!(false, "Encountered unknown IoError");
+                    eprintln!("Encountered {:#?} error ({})", err, err);
+                    panic!("Encountered unknown IoError");
                 }
             },
             _ => {
-                assert!(false, "Encountered: {:#?}", error);
+                panic!("Encountered: {:#?}", error);
             }
         },
     }

--- a/auction-house/program/tests/utils/helpers.rs
+++ b/auction-house/program/tests/utils/helpers.rs
@@ -1,8 +1,13 @@
+use std::env;
+
 use anchor_lang::prelude::Pubkey;
 use mpl_auction_house::{
     constants::{FEE_PAYER, MAX_NUM_SCOPES, PREFIX, TREASURY},
     AuthorityScope,
 };
+use mpl_testing_utils::assert_error;
+use solana_program::instruction::InstructionError;
+use solana_sdk::{transaction::TransactionError, transport::TransportError};
 
 pub fn default_scopes() -> Vec<AuthorityScope> {
     vec![
@@ -67,4 +72,57 @@ pub fn find_noncanonical_auction_house_treasury_address(
         TREASURY.as_bytes(),
     ];
     find_noncanonical_program_address(auction_house_treasury_seeds, &mpl_auction_house::id())
+}
+
+/// In CI we're running into IoError(the request exceeded its deadline) which is most likely a
+/// timing issue that happens due to decreased performance.
+/// Increasing compute limits seems to have made this happen less often, but for a few tests we
+/// still observe this behavior which makes tests fail in CI for the wrong reason.
+/// The below is a workaround to make it even less likely.
+/// Tests are still brittle, but fail much less often which is the best we can do for now aside
+/// from disabling the problematic tests in CI entirely.
+pub fn assert_error_ignoring_io_error_in_ci(error: &TransportError, error_code: u32) {
+    match error {
+        TransportError::IoError(err) if env::var("CI").is_ok() => {
+            match err.kind() {
+                std::io::ErrorKind::Other
+                    if &err.to_string() == "the request exceeded its deadline" =>
+                {
+                    eprintln!("Encountered {:#?} error", err);
+                    eprintln!("However since we are running in CI this is acceptable and we can ignore it");
+                }
+                _ => {
+                    eprintln!("Encountered {:#?} error ({})", err, err.to_string());
+                    assert!(false, "Encountered unknown IoError");
+                }
+            }
+        }
+        _ => {
+            assert_error!(error, &error_code)
+        }
+    }
+}
+
+/// See `assert_error_ignoring_io_error_in_ci` for more details regarding this workaround
+pub fn unwrap_ignoring_io_error_in_ci(result: Result<(), TransportError>) {
+    match result {
+        Ok(()) => (),
+        Err(error) => match error {
+            TransportError::IoError(err) if env::var("CI").is_ok() => match err.kind() {
+                std::io::ErrorKind::Other
+                    if &err.to_string() == "the request exceeded its deadline" =>
+                {
+                    eprintln!("Encountered {:#?} error", err);
+                    eprintln!("However since we are running in CI this is acceptable and we can ignore it");
+                }
+                _ => {
+                    eprintln!("Encountered {:#?} error ({})", err, err.to_string());
+                    assert!(false, "Encountered unknown IoError");
+                }
+            },
+            _ => {
+                assert!(false, "Encountered: {:#?}", error);
+            }
+        },
+    }
 }

--- a/auction-house/program/tests/utils/setup_functions.rs
+++ b/auction-house/program/tests/utils/setup_functions.rs
@@ -29,6 +29,7 @@ use spl_associated_token_account::get_associated_token_address;
 pub fn auction_house_program_test() -> ProgramTest {
     let mut program = ProgramTest::new("mpl_auction_house", mpl_auction_house::id(), None);
     program.add_program("mpl_token_metadata", mpl_token_metadata::id(), None);
+    program.set_compute_max_units(u64::MAX);
     program
 }
 


### PR DESCRIPTION
## Summary

Some Auction House execute sale tests are encountering time issues in CI resulting in IOErrors.
This was mitigated by the below

- test: increase compute units to max in hopes to fix tests
- ci: fix test flakiness by allowing IoErrors in CI for known cases

### Unrelated

Auction House was still using the now obsolete token metadata dependency to access the
`Metadata` type. 
This was fixed by making it use `mpl-token-metadata` instead.
