### PR TITLE
Add shank install and wrapper action for program dependencies

### DIFF
--- a/.github/actions/install-anchor/action.yml
+++ b/.github/actions/install-anchor/action.yml
@@ -1,3 +1,4 @@
+# if referencing from a workflow, ANCHOR_VERSION environment variable must be defined
 name: Setup Anchor CLI
 description: 'Setup Anchor CLI'
 

--- a/.github/actions/install-common-build-deps/action.yml
+++ b/.github/actions/install-common-build-deps/action.yml
@@ -1,0 +1,49 @@
+name: Install common build deps
+
+inputs:
+  linux:
+    description: Install or restore Linux dependencies from cache
+    required: false
+    default: true
+  rust:
+    description: Install or restore Rust from cache
+    required: false
+    default: true
+  rust-version:
+    description: Version for Rust, default to stable
+    required: false
+    default: 'stable'
+  solana:
+    description: Install or restore Solana from cache
+    required: false
+    default: true
+  anchor:
+    description: Install or restore Anchor CLI from cache
+    required: false
+    default: true
+  shank:
+    description: Install or restore Shank CLI from cache
+    required: false
+    default: true
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/install-linux-build-deps
+      if: inputs.linux == 'true'
+
+    - uses: ./.github/actions/install-rust
+      if: inputs.rust == 'true'
+      with:
+        toolchain: ${{ inputs.rust-version }}
+
+    - uses: ./.github/actions/install-solana
+      if: inputs.solana == 'true'
+      with:
+        solana_version: ${{ env.SOLANA_VERSION }}
+
+    - uses: ./.github/actions/install-anchor
+      if: inputs.anchor == 'true'
+
+    - uses: ./.github/actions/install-shank
+      if: inputs.shank == 'true'

--- a/.github/actions/install-shank/action.yml
+++ b/.github/actions/install-shank/action.yml
@@ -1,0 +1,17 @@
+# if referencing from a workflow, SHANK_VERSION environment variable must be defined
+name: Setup Shank CLI
+description: 'Setup Shank CLI'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/cache@v2
+      name: Cache Shank CLI
+      id: cache-shank-cli
+      with:
+        path: /home/runner/.cargo/bin/shank
+        key: shank-cli-${{ runner.os }}-v${{ env.SHANK_VERSION }}
+
+    - run: cargo install --git https://github.com/metaplex-foundation/shank --tag "shank-cli@v$SHANK_VERSION" shank-cli --locked
+      shell: bash
+      if: steps.cache-shank-cli.outputs.cache-hit != 'true'


### PR DESCRIPTION
* We now have a cache-able action to install `shank-cli` like linux deps, rust, and solana, anchor, etc.
* We now also have a wrapper around all common program build dependencies. We can now install with something as simple as (1) instead of (2). However, we still have flexibility to exclude certain dependencies we don't want. In the future, we can also extend to specify versions, or fallback to a default.

**(1) possibly new way of installing dependencies**

```
- uses: ./.github/actions/install-common-build-deps
```

**(2) old way of installing dependencies**
```
- uses: ./.github/actions/install-linux-build-deps
- uses: ./.github/actions/install-rust
  with:
    toolchain: ${{ env.RUST_TOOLCHAIN }}
- uses: ./.github/actions/install-solana
- uses: ./.github/actions/install-anchor 
```