### PR TITLE
build: use shell syntax for user input to prevent injection attack

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -72,9 +72,11 @@ jobs:
       # GH doesn't process or format body fields, so we do some light processing so that multiline comments will break inputs
       - name: Process content body
         id: process-content-body
+        env:
+          REVIEW_BODY: ${{ github.event.review.body }}
         run: |
           REVIEW_CONTENT=$(cat << EOF
-          ${{ github.event.review.body }}
+          $REVIEW_BODY
           EOF
           )
           REVIEW_CONTENT="${REVIEW_CONTENT//\'/}"


### PR DESCRIPTION
Small update in workflow after a vulnerability from code scanning https://github.com/metaplex-foundation/metaplex-program-library/security/code-scanning/1

### Testing
* Tested in my personal fork
 * single line comment, no version: https://github.com/jshiohaha/metaplex-program-library/actions/runs/3053361588
 * multi-line comment, no version: https://github.com/jshiohaha/metaplex-program-library/actions/runs/3053374366
 * multi-line comment with version: https://github.com/jshiohaha/metaplex-program-library/actions/runs/3053376846