### PR TITLE
Change Structure of `EscrowConstraintType::Tokens`

### DIFF
--- a/token-metadata/program/src/escrow/create_constraint_model.rs
+++ b/token-metadata/program/src/escrow/create_constraint_model.rs
@@ -52,7 +52,7 @@ pub fn create_escrow_constraint_model(
     }
 }
 
-pub fn process_create_escrow_constraints_model_account(
+pub fn process_create_escrow_constraint_model_account(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     args: CreateEscrowConstraintModelAccountArgs,

--- a/token-metadata/program/src/escrow/mod.rs
+++ b/token-metadata/program/src/escrow/mod.rs
@@ -1,6 +1,6 @@
 pub mod add_constraint;
 pub mod close_escrow_account;
-pub mod create_constraints_model;
+pub mod create_constraint_model;
 pub mod create_escrow_account;
 pub mod pda;
 pub mod state;
@@ -9,7 +9,7 @@ pub mod transfer_out;
 
 pub use add_constraint::*;
 pub use close_escrow_account::*;
-pub use create_constraints_model::*;
+pub use create_constraint_model::*;
 pub use create_escrow_account::*;
 pub use pda::*;
 pub use state::*;

--- a/token-metadata/program/src/escrow/state.rs
+++ b/token-metadata/program/src/escrow/state.rs
@@ -126,7 +126,7 @@ impl EscrowConstraint {
 pub enum EscrowConstraintType {
     None,
     Collection(Pubkey),
-    Tokens(HashMap<Pubkey, ()>),
+    Tokens(HashMap<Pubkey, bool>),
 }
 
 impl EscrowConstraintType {
@@ -135,7 +135,7 @@ impl EscrowConstraintType {
             EscrowConstraintType::None => Ok(1),
             EscrowConstraintType::Collection(_) => Ok(1 + mem::size_of::<Pubkey>()),
             EscrowConstraintType::Tokens(hm) => {
-                if let Some(len) = hm.len().checked_mul(mem::size_of::<Pubkey>()) {
+                if let Some(len) = hm.len().checked_mul(mem::size_of::<Pubkey>() + 1) {
                     len.checked_add(1) // enum overhead
                         .ok_or(MetadataError::NumericalOverflowError)?
                         .checked_add(4) // map overhead
@@ -150,7 +150,7 @@ impl EscrowConstraintType {
     pub fn tokens_from_slice(tokens: &[Pubkey]) -> EscrowConstraintType {
         let mut hm = HashMap::new();
         for token in tokens {
-            hm.insert(*token, ());
+            hm.insert(*token, false);
         }
         EscrowConstraintType::Tokens(hm)
     }

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -539,7 +539,7 @@ pub enum MetadataInstruction {
     #[account(3, name="edition", desc="Edition account")]
     #[account(4, writable, signer, name="payer", desc="Wallet paying for the transaction and new account")]
     #[account(5, name="system_program", desc="System program")]
-    #[account(6, writable, name="escrow_constraints_model", desc="Optional Escrow Constraints Model")]
+    #[account(6, optional, writable, name="escrow_constraint_model", desc="Optional Escrow Constraints Model")]
     CreateEscrowAccount,
 
     /// Close the escrow account.

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -13,7 +13,7 @@ use crate::{
     error::MetadataError,
     escrow::{
         process_add_constraint_to_escrow_constraint_model, process_close_escrow_account,
-        process_create_escrow_account, process_create_escrow_constraints_model_account,
+        process_create_escrow_account, process_create_escrow_constraint_model_account,
         process_transfer_into_escrow, process_transfer_out_of_escrow,
     },
     instruction::{MetadataInstruction, SetCollectionSizeArgs},
@@ -264,7 +264,7 @@ pub fn process_instruction<'a>(
         }
         MetadataInstruction::CreateEscrowConstraintModelAccount(args) => {
             msg!("Instruction: Create Escrow Constraint Model Account");
-            process_create_escrow_constraints_model_account(program_id, accounts, args)
+            process_create_escrow_constraint_model_account(program_id, accounts, args)
         }
         MetadataInstruction::AddConstraintToEscrowConstraintModel(args) => {
             msg!("Instruction: Add Constraint To Escrow Constraint Model");

--- a/token-metadata/program/src/state_test.rs
+++ b/token-metadata/program/src/state_test.rs
@@ -597,7 +597,7 @@ mod collection_authority_record {
     }
 
     #[test]
-    fn test_escrow_constraints_model_len() {
+    fn test_escrow_constraint_model_len() {
         let ect_none = EscrowConstraintType::None;
         let ect_collection = EscrowConstraintType::Collection(Keypair::new().pubkey());
         let ect_tokens = EscrowConstraintType::tokens_from_slice(&[
@@ -685,7 +685,7 @@ mod collection_authority_record {
             "EscrowConstraint::tokens length is not equal to serialized length"
         );
 
-        let escrow_constraints_model = EscrowConstraintModel {
+        let escrow_constraint_model = EscrowConstraintModel {
             key: Key::EscrowConstraintModel,
             name: "test".to_string(),
             count: 0,
@@ -698,15 +698,15 @@ mod collection_authority_record {
             ],
         };
 
-        let mut buf_escrow_constraints_model = Vec::new();
+        let mut buf_escrow_constraint_model = Vec::new();
 
-        escrow_constraints_model
-            .serialize(&mut buf_escrow_constraints_model)
+        escrow_constraint_model
+            .serialize(&mut buf_escrow_constraint_model)
             .unwrap();
 
         assert_eq!(
-            escrow_constraints_model.try_len().unwrap(),
-            buf_escrow_constraints_model.len(),
+            escrow_constraint_model.try_len().unwrap(),
+            buf_escrow_constraint_model.len(),
             "EscrowConstraintModel length is not equal to serialized length"
         );
     }
@@ -738,7 +738,7 @@ mod collection_authority_record {
 
             token_limit: 1,
         };
-        let escrow_constraints_model = EscrowConstraintModel {
+        let escrow_constraint_model = EscrowConstraintModel {
             key: Key::EscrowConstraintModel,
             name: "test".to_string(),
             count: 0,
@@ -747,23 +747,23 @@ mod collection_authority_record {
             constraints: vec![ec_none, ec_collection, ec_tokens],
         };
 
-        escrow_constraints_model
+        escrow_constraint_model
             .validate_at(&keypair_1.pubkey(), 0)
             .expect("None constraint failed");
 
-        escrow_constraints_model
+        escrow_constraint_model
             .validate_at(&keypair_1.pubkey(), 1)
             .expect("Collection constraint failed");
 
-        escrow_constraints_model
+        escrow_constraint_model
             .validate_at(&keypair_2.pubkey(), 1)
             .expect_err("Collection constraint failed");
 
-        escrow_constraints_model
+        escrow_constraint_model
             .validate_at(&keypair_2.pubkey(), 2)
             .expect("Tokens constraint failed");
 
-        escrow_constraints_model
+        escrow_constraint_model
             .validate_at(&keypair_1.pubkey(), 2)
             .expect_err("Tokens constraint failed");
     }


### PR DESCRIPTION
This PR makes `EscrowConstraintType::Tokens` hold `HashMap<Pubkey, bool>`. I snuck in a rename from `escrow_constraints_model` to `escrow_constraint_model` and adjusted one of the shank attributes on `CreateEscrowAccount`.