### PR TITLE
Downgrades SPL ASSOC

### DIFF
--- a/bubblegum/program/Cargo.toml
+++ b/bubblegum/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpl-bubblegum"
-version = "0.1.0"
+version = "0.1.1"
 description = "NFT Compression"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/metaplex-program-library"
@@ -25,7 +25,7 @@ bytemuck = "1.8.0"
 mpl-token-metadata = { version = "1.3.6", features = ["no-entrypoint"] }
 solana-program = "1.10.29"
 spl-account-compression = { version="0.1.0", features = ["cpi"] }
-spl-associated-token-account = { version = "1.0.5", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "1.0.3", features = ["no-entrypoint"] }
 spl-token = { version = "3.3.0", features = ["no-entrypoint"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This change supports blockbuster, by downgrading spl associated token account to be more compatible with anchor