### PR TITLE
fix: yarn command

### DIFF
--- a/auction-house/js/README.md
+++ b/auction-house/js/README.md
@@ -7,7 +7,7 @@ This package contains the auction house contract SDK code.
 In order to update the generated SDK when the rust contract was updated please run:
 
 ```
-yarn gen:api
+yarn api:gen
 ```
 
 NOTE: at this point this only generates the IDL json file but later will generate TypeScript


### PR DESCRIPTION
ReadMe inside auction-house/js had a typo.

it should've been 

```yarn api:gen``` 

instead of 

```yarn gen:api```

Fixed that.