### PR TITLE
TM: add `JsonSchema` field to `Metadata` struct

### DIFF
--- a/token-metadata/program/src/state.rs
+++ b/token-metadata/program/src/state.rs
@@ -327,6 +327,19 @@ pub struct Collection {
     pub key: Pubkey,
 }
 
+#[repr(u8)]
+#[cfg_attr(feature = "serde-feature", derive(Serialize, Deserialize))]
+#[derive(BorshSerialize, BorshDeserialize, Copy, Clone, Debug, Eq, PartialEq)]
+pub enum JsonSchema {
+    Core = 1,
+    MultiMedia = 2,
+    SimpleImage = 3,
+    SimpleAudio = 4,
+    Simple3D = 5,
+    SimpleText = 6,
+    MusicRecording = 7,
+}
+
 #[repr(C)]
 #[cfg_attr(feature = "serde-feature", derive(Serialize, Deserialize))]
 #[derive(Clone, BorshSerialize, Debug, PartialEq, Eq, ShankAccount)]
@@ -349,6 +362,8 @@ pub struct Metadata {
     pub uses: Option<Uses>,
     /// Item Details
     pub collection_details: Option<CollectionDetails>,
+    /// JSON schema.
+    pub json_schema: Option<JsonSchema>,
 }
 
 impl Default for Metadata {
@@ -365,6 +380,7 @@ impl Default for Metadata {
             collection: None,
             uses: None,
             collection_details: None,
+            json_schema: None,
         }
     }
 }

--- a/token-metadata/program/src/utils_test.rs
+++ b/token-metadata/program/src/utils_test.rs
@@ -4,7 +4,7 @@ mod puff_out_test {
     pub use solana_program::pubkey::Pubkey;
 
     pub use crate::{
-        state::{Data, Key, Metadata},
+        state::{Data, JsonSchema, Key, Metadata},
         utils::{puff_out_data_fields, puffed_out_string},
     };
 
@@ -46,6 +46,7 @@ mod puff_out_test {
             uses: None,
             token_standard: None,
             collection_details: None,
+            json_schema: None,
         };
 
         puff_out_data_fields(&mut metadata);


### PR DESCRIPTION
This is a draft PR to check whether this is the right direction in terms of augmenting `struct Metadata` with a field which specifies (on-chain) the kind of schema used to interpret the JSON file associated with an NFT. Tests don't work, but will get fixed as soon as everything else is well. The particular list of variants for `enum JsonSchema` has been initially borrowed from a similar enum in `digital-asset-protocol`.