### PR TITLE
chore: bump token-metadata deps

### DIFF
--- a/token-metadata/Cargo.lock
+++ b/token-metadata/Cargo.lock
@@ -2971,18 +2971,18 @@ dependencies = [
 
 [[package]]
 name = "shank"
-version = "0.0.5"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9986b297e6f42bcbe41f95ca2a881e7a75bd091549e95ecf495fa8178c0c1b"
+checksum = "b54c657cbe18aaff6d5042a4d48f643fdd2a826dfc7161de98ee28e5bd7e85e0"
 dependencies = [
  "shank_macro",
 ]
 
 [[package]]
 name = "shank_macro"
-version = "0.0.5"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd835154aa943dfc958f5a208f2e82b7d2a2c52b024229168c211ecc2d2bfd1"
+checksum = "1b43a02ae007b64b177f4dbb21d322f276458e4860f9fefbd8b9b791c21644ab"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -2992,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "shank_macro_impl"
-version = "0.0.5"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99ad9d5137704e86e2e4a54a121b9c443c37b60ce6638a7723ab700dbd2232a"
+checksum = "4d36cdf68202db080a13ef0300c369fc691695265e3d0ab0fa08d4734b0cfb66"
 dependencies = [
  "anyhow",
  "proc-macro2 1.0.43",

--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -3543,6 +3543,6 @@
     "origin": "shank",
     "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
     "binaryVersion": "0.0.9",
-    "libVersion": "~0.0.4"
+    "libVersion": "0.0.9"
   }
 }

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.10"
 mpl-token-vault = { version = "0.1.0", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.2.0", features = [ "no-entrypoint" ] }
-spl-associated-token-account = { version = "1.0.5", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "~1.0.5", features = ["no-entrypoint"] }
 thiserror = "1.0"
 borsh = "0.9.2"
 shank = { version = "0.0.9" }

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -17,18 +17,18 @@ serde-feature = ["serde", "serde_with"]
 num-derive = "0.3"
 arrayref = "0.3.6"
 num-traits = "0.2"
-solana-program = "1.9.13"
+solana-program = "1.10"
 mpl-token-vault = { version = "0.1.0", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.2.0", features = [ "no-entrypoint" ] }
-spl-associated-token-account = { version = "1.0.3", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "1.0.5", features = ["no-entrypoint"] }
 thiserror = "1.0"
 borsh = "0.9.2"
-shank = { version = "~0.0.4" }
+shank = { version = "0.0.9" }
 serde = { version = "1.0.136", optional = true }
 serde_with = { version = "1.12.0", optional = true }
 
 [dev-dependencies]
-solana-sdk = "1.9.13"
+solana-sdk = "1.10"
 solana-program-test = "1.11.5"
 
 [lib]


### PR DESCRIPTION
This may not be strictly necessary since I removed the tilde pinning allowing more flexibility with versions.