### PR TITLE
refactor(token-metadata): move constants to separate file

### DIFF
--- a/token-metadata/program/src/assertions/collection.rs
+++ b/token-metadata/program/src/assertions/collection.rs
@@ -1,11 +1,12 @@
 use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
 
 use crate::{
+    constants::{EDITION, PREFIX},
     error::MetadataError,
     pda::find_collection_authority_account,
     state::{
         Collection, CollectionAuthorityRecord, MasterEditionV2, Metadata, TokenMetadataAccount,
-        TokenStandard, EDITION, PREFIX,
+        TokenStandard,
     },
     utils::assert_derivation,
 };

--- a/token-metadata/program/src/assertions/uses.rs
+++ b/token-metadata/program/src/assertions/uses.rs
@@ -1,9 +1,10 @@
 use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
 
 use crate::{
+    constants::{PREFIX, USER},
     error::MetadataError,
     pda,
-    state::{UseAuthorityRecord, UseMethod, Uses, PREFIX, USER},
+    state::{UseAuthorityRecord, UseMethod, Uses},
     utils::assert_derivation,
 };
 

--- a/token-metadata/program/src/constants.rs
+++ b/token-metadata/program/src/constants.rs
@@ -1,0 +1,69 @@
+/// prefix used for PDAs to avoid certain collision attacks (<https://en.wikipedia.org/wiki/Collision_attack#Chosen-prefix_collision_attack>)
+pub const PREFIX: &str = "metadata";
+
+/// Used in seeds to make Edition model pda address
+pub const EDITION: &str = "edition";
+
+pub const RESERVATION: &str = "reservation";
+
+pub const USER: &str = "user";
+
+pub const BURN: &str = "burn";
+
+pub const COLLECTION_AUTHORITY: &str = "collection_authority";
+
+pub const MAX_NAME_LENGTH: usize = 32;
+
+pub const MAX_SYMBOL_LENGTH: usize = 10;
+
+pub const MAX_URI_LENGTH: usize = 200;
+
+pub const MAX_METADATA_LEN: usize = 1 //key 
++ 32 // update auth pubkey
++ 32 // mint pubkey
++ MAX_DATA_SIZE
++ 1 // primary sale
++ 1 // mutable
++ 9 // nonce (pretty sure this only needs to be 2)
++ 2 // token standard
++ 34 // collection
++ 18 // uses
++ 118; // Padding
+
+pub const MAX_DATA_SIZE: usize = 4
+    + MAX_NAME_LENGTH
+    + 4
+    + MAX_SYMBOL_LENGTH
+    + 4
+    + MAX_URI_LENGTH
+    + 2
+    + 1
+    + 4
+    + MAX_CREATOR_LIMIT * MAX_CREATOR_LEN;
+
+pub const MAX_EDITION_LEN: usize = 1 + 32 + 8 + 200;
+
+// Large buffer because the older master editions have two pubkeys in them,
+// need to keep two versions same size because the conversion process actually changes the same account
+// by rewriting it.
+pub const MAX_MASTER_EDITION_LEN: usize = 1 + 9 + 8 + 264;
+
+pub const MAX_CREATOR_LIMIT: usize = 5;
+
+pub const MAX_CREATOR_LEN: usize = 32 + 1 + 1;
+
+pub const MAX_RESERVATIONS: usize = 200;
+
+// can hold up to 200 keys per reservation, note: the extra 8 is for number of elements in the vec
+pub const MAX_RESERVATION_LIST_V1_SIZE: usize = 1 + 32 + 8 + 8 + MAX_RESERVATIONS * 34 + 100;
+
+// can hold up to 200 keys per reservation, note: the extra 8 is for number of elements in the vec
+pub const MAX_RESERVATION_LIST_SIZE: usize = 1 + 32 + 8 + 8 + MAX_RESERVATIONS * 48 + 8 + 8 + 84;
+
+pub const MAX_EDITION_MARKER_SIZE: usize = 32;
+
+pub const EDITION_MARKER_BIT_SIZE: u64 = 248;
+
+pub const USE_AUTHORITY_RECORD_SIZE: usize = 18; //8 byte padding
+
+pub const COLLECTION_AUTHORITY_RECORD_SIZE: usize = 11; //10 byte padding

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -1,9 +1,7 @@
 use crate::{
+    constants::{EDITION, EDITION_MARKER_BIT_SIZE, PREFIX},
     deprecated_instruction::{MintPrintingTokensViaTokenArgs, SetReservationListArgs},
-    state::{
-        Collection, CollectionDetails, Creator, Data, DataV2, Uses, EDITION,
-        EDITION_MARKER_BIT_SIZE, PREFIX,
-    },
+    state::{Collection, CollectionDetails, Creator, Data, DataV2, Uses},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use shank::ShankInstruction;

--- a/token-metadata/program/src/lib.rs
+++ b/token-metadata/program/src/lib.rs
@@ -1,6 +1,7 @@
 //! A Token Metadata program for the Solana blockchain.
 
 pub mod assertions;
+pub mod constants;
 pub mod deprecated_instruction;
 pub mod deprecated_processor;
 mod deser;

--- a/token-metadata/program/src/pda.rs
+++ b/token-metadata/program/src/pda.rs
@@ -1,6 +1,6 @@
 use solana_program::pubkey::Pubkey;
 
-use crate::state::{BURN, COLLECTION_AUTHORITY, EDITION, PREFIX, USER};
+use crate::constants::{BURN, COLLECTION_AUTHORITY, EDITION, PREFIX, USER};
 
 pub fn find_edition_account(mint: &Pubkey, edition_number: String) -> (Pubkey, u8) {
     Pubkey::find_program_address(

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -6,6 +6,11 @@ use crate::{
         },
         uses::{assert_valid_use, process_use_authority_validation},
     },
+    constants::{
+        BURN, COLLECTION_AUTHORITY, COLLECTION_AUTHORITY_RECORD_SIZE, EDITION,
+        EDITION_MARKER_BIT_SIZE, MAX_MASTER_EDITION_LEN, MAX_METADATA_LEN, PREFIX, USER,
+        USE_AUTHORITY_RECORD_SIZE,
+    },
     deprecated_processor::{
         process_deprecated_create_metadata_accounts, process_deprecated_update_metadata_accounts,
     },
@@ -16,9 +21,7 @@ use crate::{
     state::{
         Collection, CollectionAuthorityRecord, CollectionDetails, DataV2, Edition, EditionMarker,
         Key, MasterEditionV1, MasterEditionV2, Metadata, TokenMetadataAccount, TokenStandard,
-        UseAuthorityRecord, UseMethod, Uses, BURN, COLLECTION_AUTHORITY,
-        COLLECTION_AUTHORITY_RECORD_SIZE, EDITION, EDITION_MARKER_BIT_SIZE, MAX_MASTER_EDITION_LEN,
-        MAX_METADATA_LEN, PREFIX, USER, USE_AUTHORITY_RECORD_SIZE,
+        UseAuthorityRecord, UseMethod, Uses,
     },
     utils::{
         assert_currently_holding, assert_data_valid, assert_delegated_tokens, assert_derivation,

--- a/token-metadata/program/src/state.rs
+++ b/token-metadata/program/src/state.rs
@@ -1,6 +1,7 @@
 use std::io::ErrorKind;
 
 use crate::{
+    constants::*,
     deser::meta_deser_unchecked,
     error::MetadataError,
     utils::{assert_owned_by, try_from_slice_checked},
@@ -20,76 +21,6 @@ use {
     serde::{Deserialize, Serialize},
     serde_with::{As, DisplayFromStr},
 };
-
-/// prefix used for PDAs to avoid certain collision attacks (<https://en.wikipedia.org/wiki/Collision_attack#Chosen-prefix_collision_attack>)
-pub const PREFIX: &str = "metadata";
-
-/// Used in seeds to make Edition model pda address
-pub const EDITION: &str = "edition";
-
-pub const RESERVATION: &str = "reservation";
-
-pub const USER: &str = "user";
-
-pub const BURN: &str = "burn";
-
-pub const COLLECTION_AUTHORITY: &str = "collection_authority";
-
-pub const MAX_NAME_LENGTH: usize = 32;
-
-pub const MAX_SYMBOL_LENGTH: usize = 10;
-
-pub const MAX_URI_LENGTH: usize = 200;
-
-pub const MAX_METADATA_LEN: usize = 1 //key 
-+ 32 // update auth pubkey
-+ 32 // mint pubkey
-+ MAX_DATA_SIZE
-+ 1 // primary sale
-+ 1 // mutable
-+ 9 // nonce (pretty sure this only needs to be 2)
-+ 2 // token standard
-+ 34 // collection
-+ 18 // uses
-+ 118; // Padding
-
-pub const MAX_DATA_SIZE: usize = 4
-    + MAX_NAME_LENGTH
-    + 4
-    + MAX_SYMBOL_LENGTH
-    + 4
-    + MAX_URI_LENGTH
-    + 2
-    + 1
-    + 4
-    + MAX_CREATOR_LIMIT * MAX_CREATOR_LEN;
-
-pub const MAX_EDITION_LEN: usize = 1 + 32 + 8 + 200;
-
-// Large buffer because the older master editions have two pubkeys in them,
-// need to keep two versions same size because the conversion process actually changes the same account
-// by rewriting it.
-pub const MAX_MASTER_EDITION_LEN: usize = 1 + 9 + 8 + 264;
-
-pub const MAX_CREATOR_LIMIT: usize = 5;
-
-pub const MAX_CREATOR_LEN: usize = 32 + 1 + 1;
-
-pub const MAX_RESERVATIONS: usize = 200;
-
-// can hold up to 200 keys per reservation, note: the extra 8 is for number of elements in the vec
-pub const MAX_RESERVATION_LIST_V1_SIZE: usize = 1 + 32 + 8 + 8 + MAX_RESERVATIONS * 34 + 100;
-
-// can hold up to 200 keys per reservation, note: the extra 8 is for number of elements in the vec
-pub const MAX_RESERVATION_LIST_SIZE: usize = 1 + 32 + 8 + 8 + MAX_RESERVATIONS * 48 + 8 + 8 + 84;
-
-pub const MAX_EDITION_MARKER_SIZE: usize = 32;
-
-pub const EDITION_MARKER_BIT_SIZE: u64 = 248;
-
-pub const USE_AUTHORITY_RECORD_SIZE: usize = 18; //8 byte padding
-
-pub const COLLECTION_AUTHORITY_RECORD_SIZE: usize = 11; //10 byte padding
 
 pub trait TokenMetadataAccount: BorshDeserialize {
     fn key() -> Key;

--- a/token-metadata/program/src/state_test.rs
+++ b/token-metadata/program/src/state_test.rs
@@ -4,11 +4,12 @@ use solana_program::account_info::AccountInfo;
 use solana_sdk::{signature::Keypair, signer::Signer};
 
 use crate::{
+    constants::MAX_METADATA_LEN,
     deser::tests::{expected_pesky_metadata, pesky_data},
     error::MetadataError,
     state::{
         CollectionAuthorityRecord, Edition, EditionMarker, Key, MasterEditionV2, Metadata,
-        UseAuthorityRecord, MAX_METADATA_LEN,
+        UseAuthorityRecord,
     },
     ID,
 };

--- a/token-metadata/program/src/utils.rs
+++ b/token-metadata/program/src/utils.rs
@@ -1,14 +1,16 @@
 use crate::{
     assertions::{collection::assert_collection_update_is_valid, uses::assert_valid_use},
+    constants::{
+        EDITION, EDITION_MARKER_BIT_SIZE, MAX_CREATOR_LIMIT, MAX_EDITION_LEN,
+        MAX_EDITION_MARKER_SIZE, MAX_MASTER_EDITION_LEN, MAX_METADATA_LEN, MAX_NAME_LENGTH,
+        MAX_SYMBOL_LENGTH, MAX_URI_LENGTH, PREFIX,
+    },
     deser::clean_write_metadata,
     error::MetadataError,
     pda::find_master_edition_account,
     state::{
         get_reservation_list, CollectionDetails, Creator, Data, DataV2, Edition, EditionMarker,
         Key, MasterEditionV1, MasterEditionV2, Metadata, TokenMetadataAccount, TokenStandard, Uses,
-        EDITION, EDITION_MARKER_BIT_SIZE, MAX_CREATOR_LIMIT, MAX_EDITION_LEN,
-        MAX_EDITION_MARKER_SIZE, MAX_MASTER_EDITION_LEN, MAX_METADATA_LEN, MAX_NAME_LENGTH,
-        MAX_SYMBOL_LENGTH, MAX_URI_LENGTH, PREFIX,
     },
 };
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};

--- a/token-metadata/program/src/utils_test.rs
+++ b/token-metadata/program/src/utils_test.rs
@@ -68,8 +68,9 @@ mod puff_out_test {
 
 mod try_from_slice_checked {
     use crate::{
+        constants::MAX_METADATA_LEN,
         deser::tests::{expected_pesky_metadata, pesky_data},
-        state::{Key, Metadata, MAX_METADATA_LEN},
+        state::{Key, Metadata},
         utils::try_from_slice_checked,
     };
 

--- a/token-metadata/program/tests/bump_seed_migration.rs
+++ b/token-metadata/program/tests/bump_seed_migration.rs
@@ -3,7 +3,7 @@ pub mod utils;
 
 use mpl_token_metadata::state::{UseMethod, Uses};
 use mpl_token_metadata::{
-    state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    constants::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
     utils::puffed_out_string,
 };
 

--- a/token-metadata/program/tests/create_metadata_account.rs
+++ b/token-metadata/program/tests/create_metadata_account.rs
@@ -2,9 +2,10 @@
 pub mod utils;
 
 use mpl_token_metadata::{
+    constants::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
     error::MetadataError,
     id, instruction,
-    state::{Creator, Key, UseMethod, Uses, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    state::{Creator, Key, UseMethod, Uses},
     utils::puffed_out_string,
 };
 use num_traits::FromPrimitive;

--- a/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
+++ b/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
@@ -3,9 +3,7 @@ pub mod utils;
 
 use borsh::BorshSerialize;
 use mpl_token_metadata::{
-    error::MetadataError,
-    id, instruction,
-    state::{Key, MAX_MASTER_EDITION_LEN},
+    constants::MAX_MASTER_EDITION_LEN, error::MetadataError, id, instruction, state::Key,
 };
 use num_traits::FromPrimitive;
 use solana_program_test::*;

--- a/token-metadata/program/tests/seralization.rs
+++ b/token-metadata/program/tests/seralization.rs
@@ -3,7 +3,7 @@ pub mod utils;
 
 use mpl_token_metadata::state::Key;
 use mpl_token_metadata::state::MasterEditionV2 as ProgramME;
-use mpl_token_metadata::{state::MAX_MASTER_EDITION_LEN, utils::try_from_slice_checked};
+use mpl_token_metadata::{constants::MAX_MASTER_EDITION_LEN, utils::try_from_slice_checked};
 
 use solana_program::borsh::try_from_slice_unchecked;
 use solana_program_test::*;

--- a/token-metadata/program/tests/update_metadata_account.rs
+++ b/token-metadata/program/tests/update_metadata_account.rs
@@ -2,9 +2,9 @@
 pub mod utils;
 
 use mpl_token_metadata::{
+    constants::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
     error::MetadataError,
     id, instruction,
-    state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
     utils::puffed_out_string,
 };
 use num_traits::FromPrimitive;

--- a/token-metadata/program/tests/update_metadata_account_v2.rs
+++ b/token-metadata/program/tests/update_metadata_account_v2.rs
@@ -2,12 +2,10 @@
 pub mod utils;
 
 use mpl_token_metadata::{
+    constants::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
     error::MetadataError,
     id, instruction,
-    state::{
-        Collection, Creator, DataV2, Key, UseMethod, Uses, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH,
-        MAX_URI_LENGTH,
-    },
+    state::{Collection, Creator, DataV2, Key, UseMethod, Uses},
     utils::puffed_out_string,
 };
 use num_traits::FromPrimitive;

--- a/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
+++ b/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
@@ -2,9 +2,10 @@
 pub mod utils;
 
 use mpl_token_metadata::{
+    constants::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
     error::MetadataError,
     id, instruction,
-    state::{Key, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    state::Key,
     utils::puffed_out_string,
 };
 use num_traits::FromPrimitive;

--- a/token-metadata/program/tests/utils/edition_marker.rs
+++ b/token-metadata/program/tests/utils/edition_marker.rs
@@ -1,9 +1,9 @@
 use crate::*;
 use borsh::BorshSerialize;
 use mpl_token_metadata::{
+    constants::{EDITION, EDITION_MARKER_BIT_SIZE, PREFIX},
     id,
     instruction::{self, MetadataInstruction, MintNewEditionFromMasterEditionViaTokenArgs},
-    state::{EDITION, EDITION_MARKER_BIT_SIZE, PREFIX},
 };
 use solana_program::{
     borsh::try_from_slice_unchecked,

--- a/token-metadata/program/tests/utils/master_edition_v2.rs
+++ b/token-metadata/program/tests/utils/master_edition_v2.rs
@@ -1,9 +1,10 @@
 use crate::*;
 use borsh::ser::BorshSerialize;
 use mpl_token_metadata::{
+    constants::{EDITION, PREFIX},
     id,
     instruction::{self, CreateMasterEditionArgs, MetadataInstruction},
-    state::{MasterEditionV2 as ProgramMasterEdition, TokenMetadataAccount, EDITION, PREFIX},
+    state::{MasterEditionV2 as ProgramMasterEdition, TokenMetadataAccount},
 };
 use solana_program::{
     borsh::try_from_slice_unchecked,

--- a/token-metadata/program/tests/utils/metadata.rs
+++ b/token-metadata/program/tests/utils/metadata.rs
@@ -1,7 +1,8 @@
 use crate::*;
 use mpl_token_metadata::{
+    constants::PREFIX,
     id, instruction,
-    state::{Collection, CollectionDetails, Creator, Data, DataV2, Uses, PREFIX},
+    state::{Collection, CollectionDetails, Creator, Data, DataV2, Uses},
 };
 use solana_program::borsh::try_from_slice_unchecked;
 

--- a/token-metadata/program/tests/verify_collection.rs
+++ b/token-metadata/program/tests/verify_collection.rs
@@ -4,11 +4,7 @@ pub mod utils;
 use mpl_token_metadata::pda::find_collection_authority_account;
 use mpl_token_metadata::state::Collection;
 use mpl_token_metadata::state::{UseMethod, Uses};
-use mpl_token_metadata::{
-    error::MetadataError,
-    state::{Key, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
-    utils::puffed_out_string,
-};
+use mpl_token_metadata::{error::MetadataError, state::Key, utils::puffed_out_string};
 use num_traits::FromPrimitive;
 use solana_program_test::*;
 use solana_sdk::{
@@ -19,7 +15,7 @@ use solana_sdk::{
 use utils::*;
 mod verify_collection {
 
-    use mpl_token_metadata::state::{CollectionAuthorityRecord, COLLECTION_AUTHORITY_RECORD_SIZE};
+    use mpl_token_metadata::{constants::*, state::CollectionAuthorityRecord};
     use solana_program::borsh::try_from_slice_unchecked;
     use solana_sdk::transaction::Transaction;
 

--- a/token-metadata/program/tests/verify_sized_collection_item.rs
+++ b/token-metadata/program/tests/verify_sized_collection_item.rs
@@ -6,8 +6,9 @@ use mpl_token_metadata::pda::find_collection_authority_account;
 use mpl_token_metadata::state::{Collection, CollectionDetails};
 use mpl_token_metadata::state::{UseMethod, Uses};
 use mpl_token_metadata::{
+    constants::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
     error::MetadataError,
-    state::{Key, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    state::Key,
     utils::puffed_out_string,
     ID as PROGRAM_ID,
 };
@@ -22,7 +23,9 @@ use solana_sdk::{
 use utils::*;
 mod verify_sized_collection_item {
 
-    use mpl_token_metadata::state::{CollectionAuthorityRecord, COLLECTION_AUTHORITY_RECORD_SIZE};
+    use mpl_token_metadata::{
+        constants::COLLECTION_AUTHORITY_RECORD_SIZE, state::CollectionAuthorityRecord,
+    };
     use solana_program::borsh::try_from_slice_unchecked;
     use solana_sdk::transaction::Transaction;
 


### PR DESCRIPTION
This is cleanup work preparing for some other changes I need to make to Token Metadata. It moves constants out of the `state.rs` file into `constants.rs` to limit the bloat of the state file. 

Closing this because needs and requirements have changed. Token Metadata still needs some refactoring but it will be done in a different PR.