### PR TITLE
Fix readme link to use full path

### DIFF
--- a/bubblegum/js/README.md
+++ b/bubblegum/js/README.md
@@ -3,7 +3,7 @@
 This package contains the Metaplex Bubblegum program JS SDK code.
 
 ## HOW IT WORKS
-[Program Overview](../program/README.md)
+[Program Overview](https://github.com/metaplex-foundation/metaplex-program-library/blob/master/bubblegum/program/README.md)
 
 ## API Docs
 

--- a/bubblegum/js/package.json
+++ b/bubblegum/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaplex-foundation/mpl-bubblegum",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "programVersion": "0.1.4",
   "description": "SDK for MPL Bubblegum contract",
   "main": "dist/src/index.js",
@@ -50,7 +50,6 @@
     "@solana/spl-account-compression": "^0.1.1",
     "@metaplex-foundation/cusper": "^0.0.2",
     "@project-serum/anchor": "0.24.2",
-
     "@solana/spl-token": "^0.1.8",
     "@solana/web3.js": "^1.50.1",
     "js-sha3": "^0.8.0"

--- a/bubblegum/js/package.json
+++ b/bubblegum/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metaplex-foundation/mpl-bubblegum",
-  "version": "0.1.4",
-  "programVersion": "0.1.3",
+  "version": "0.1.5",
+  "programVersion": "0.1.4",
   "description": "SDK for MPL Bubblegum contract",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Current link works when you have the repo but doesn't work on npm