### PR TITLE
Add hidden settings validation

### DIFF
--- a/candy-machine-core/program/src/state/candy_machine_data.rs
+++ b/candy-machine-core/program/src/state/candy_machine_data.rs
@@ -98,6 +98,11 @@ impl CandyMachineData {
         // replacement of the variables
 
         if let Some(hidden) = &self.hidden_settings {
+            // config line settings should not be enabled at the same time as hidden settings
+            if &self.config_line_settings.is_some() {
+                return err!(CandyError::HiddenSettingsDoNotHaveConfigLines);
+            }
+
             let expected = replace_patterns(hidden.name.clone(), self.items_available as usize);
             if MAX_NAME_LENGTH < expected.len() {
                 return err!(CandyError::ExceededLengthError);


### PR DESCRIPTION
This PR adds an additional check when using hidden settings: if config line settings are present at the same time as hidden settings, the `initialize` and `update` instructions will report an error. Currently, hidden settings take precedence over config line settings, so the behviour of the candy machine does not change. The extra validation will make the on-chain configuration of the candy machine "cleaner".