### PR TITLE
Enable integer overflow checks for any crates that were missing it

### DIFF
--- a/auctioneer/program/Cargo.toml
+++ b/auctioneer/program/Cargo.toml
@@ -38,3 +38,6 @@ env_logger="0.9.0"
 spl-associated-token-account = {version = "1.0.5", features = ["no-entrypoint"]}
 mpl-token-metadata = { version="1.4", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.2",  features = ["no-entrypoint"] }
+
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.

--- a/bubblegum/program/Cargo.toml
+++ b/bubblegum/program/Cargo.toml
@@ -35,4 +35,4 @@ spl-merkle-tree-reference = "0.1.0"
 spl-noop = { version = "0.1.2", features = ["no-entrypoint"] }
 
 [profile.release]
-overflow-checks = true
+overflow-checks = true     # Enable integer overflow checks.

--- a/candy-machine-core/program/Cargo.toml
+++ b/candy-machine-core/program/Cargo.toml
@@ -24,3 +24,6 @@ mpl-token-metadata = { version = "1.5.0", features = ["no-entrypoint"] }
 solana-program = "1.10.29"
 spl-associated-token-account = { version = "~1.0.5", features = ["no-entrypoint"] }
 spl-token = { version = "~3.3.1", features = ["no-entrypoint"] }
+
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.

--- a/candy-machine/program/Cargo.toml
+++ b/candy-machine/program/Cargo.toml
@@ -38,3 +38,6 @@ anchor-client = "0.25.0"
 borsh = "~0.9.2"
 tarpc = "0.29.0"
 console = "0.15.1"
+
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.

--- a/core/rust/testing-utils/Cargo.toml
+++ b/core/rust/testing-utils/Cargo.toml
@@ -30,3 +30,5 @@ num-derive = "0.3"
 num-traits = "0.2"
 borsh = "0.9.1"
 
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.

--- a/fixed-price-sale/program/Cargo.toml
+++ b/fixed-price-sale/program/Cargo.toml
@@ -31,3 +31,6 @@ solana-sdk = "1.10"
 spl-associated-token-account = "1.0.5"
 mpl-testing-utils= {path="../../core/rust/testing-utils" }
 mpl-metaplex = "0.1.0"
+
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.

--- a/gumdrop/program/Cargo.toml
+++ b/gumdrop/program/Cargo.toml
@@ -8,9 +8,6 @@ license-file = "../../LICENSE"
 edition = "2021"
 keywords = ["solana", "merkle", "distributor"]
 
-[profile.release]
-overflow-checks = true
-
 [lib]
 crate-type = ["cdylib", "lib"]
 name = "mpl_gumdrop"
@@ -28,3 +25,6 @@ solana-program = "1.9.18"
 spl-token = "3.2.0"
 spl-associated-token-account = { version = "=1.0.3", features = [ "no-entrypoint" ] }
 mpl-token-metadata = { version="=1.2.7", features = [ "no-entrypoint" ] }
+
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.

--- a/hydra/program/Cargo.toml
+++ b/hydra/program/Cargo.toml
@@ -23,3 +23,6 @@ anchor-lang = "0.24.2"
 anchor-spl = "0.24.2"
 spl-token = {version="3.2.0", features = [ "no-entrypoint" ]}
 mpl-token-metadata = {version="1.2.7", features = [ "no-entrypoint" ]}
+
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.

--- a/nft-packs/program/Cargo.toml
+++ b/nft-packs/program/Cargo.toml
@@ -30,3 +30,6 @@ rand = { version = "~0.8.4" }
 
 [lib]
 crate-type = ["cdylib", "lib"]
+
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.

--- a/token-entangler/program/Cargo.toml
+++ b/token-entangler/program/Cargo.toml
@@ -28,3 +28,6 @@ arrayref = "~0.3.6"
 [dev-dependencies]
 solana-program-test = "~1.9.28"
 solana-sdk = "~1.9.28"
+
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.

--- a/token-metadata/Cargo.toml
+++ b/token-metadata/Cargo.toml
@@ -5,4 +5,4 @@ members=[
 ]
 
 [profile.release]
-overflow-checks = true
+overflow-checks = true     # Enable integer overflow checks.

--- a/token-metadata/cli/Cargo.toml
+++ b/token-metadata/cli/Cargo.toml
@@ -19,3 +19,6 @@ solana-clap-utils = "1.9.5"
 solana-cli-config = "1.9.5"
 mpl-token-metadata = { path="../program", features = [ "no-entrypoint" ] }
 spl-token = { version="3.2.0", features = [ "no-entrypoint" ] }
+
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -33,3 +33,6 @@ solana-program-test = "1.11.5"
 
 [lib]
 crate-type = ["cdylib", "lib"]
+
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.


### PR DESCRIPTION
Added to everything even redundant in some cases, even testing utils crate (even though I doubt we would ever need it for that).