### PR TITLE
fix: Allow the seller to cancel its bids from its own listing

### DIFF
--- a/auctioneer/program/src/cancel/mod.rs
+++ b/auctioneer/program/src/cancel/mod.rs
@@ -156,7 +156,7 @@ pub fn auctioneer_cancel<'info>(
 
     // Close the Listing Config account if the seller is canceling their listing.
     if ctx.accounts.token_account.owner == ctx.accounts.wallet.key()
-        && ctx.accounts.wallet.is_signer
+        && ctx.accounts.wallet.is_signer && buyer_price == AUCTIONEER_BUYER_PRICE
     {
         let listing_config = &ctx.accounts.listing_config.to_account_info();
         let seller = &ctx.accounts.seller.to_account_info();


### PR DESCRIPTION
I added the condition buyer_price == AUCTIONEER_BUYER_PRICE in the last "if" statement of cancel instruction.

Indeed, when a seller wants to cancel its bids from a listing they created, the listing config account is getting closed because of the last commit in auctioneer.

Adding this condition make sure the seller wants to cancel its listing not its bids.