### PR TITLE
fix: candy machine tests for freeze auth change

### DIFF
--- a/candy-machine/program/tests/core/metadata_manager.rs
+++ b/candy-machine/program/tests/core/metadata_manager.rs
@@ -83,7 +83,6 @@ impl MetadataManager {
         creators: Option<Vec<Creator>>,
         seller_fee_basis_points: u16,
         is_mutable: bool,
-        freeze_authority: Option<&Pubkey>,
         collection: Option<Collection>,
         uses: Option<Uses>,
         sized: bool,
@@ -91,7 +90,7 @@ impl MetadataManager {
         create_mint(
             context,
             &self.authority.pubkey(),
-            freeze_authority,
+            Some(&self.authority.pubkey()),
             0,
             Some(clone_keypair(&self.mint)),
         )

--- a/candy-machine/program/tests/utils/candy_manager.rs
+++ b/candy-machine/program/tests/utils/candy_manager.rs
@@ -143,7 +143,6 @@ impl CollectionInfo {
                 true,
                 None,
                 None,
-                None,
                 sized,
             )
             .await

--- a/fixed-price-sale/program/Cargo.lock
+++ b/fixed-price-sale/program/Cargo.lock
@@ -2049,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "1.4.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e719d7e0b5a9d97c7fd4d6f52ebfc32f1e3942e068173e47355f8c275656488a"
+checksum = "d7bd6c4b74cfb4977653388285b1569ba055b3e131ba8f4ee8a4ed8435091965"
 dependencies = [
  "arrayref",
  "borsh",

--- a/fixed-price-sale/program/Cargo.toml
+++ b/fixed-price-sale/program/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 anchor-lang = {version="0.25.0", features=["init-if-needed"]}
 anchor-spl = {version="0.25.0"}
 spl-token = "3.2.0"
-mpl-token-metadata = { features = [ "no-entrypoint" ], version="1.4" }
+mpl-token-metadata = { features = [ "no-entrypoint" ], version="1.6" }
 
 [dev-dependencies]
 anchor-client = "0.25.0"

--- a/fixed-price-sale/program/tests/utils/helpers.rs
+++ b/fixed-price-sale/program/tests/utils/helpers.rs
@@ -109,7 +109,7 @@ pub async fn create_mint(
                 &spl_token::id(),
                 &mint.pubkey(),
                 authority,
-                None,
+                Some(&authority),
                 decimals,
             )
             .unwrap(),

--- a/nft-packs/program/tests/claim_card.rs
+++ b/nft-packs/program/tests/claim_card.rs
@@ -1235,9 +1235,14 @@ async fn fail_wrong_user_wallet() {
 
     let malicious_user = Keypair::new();
 
-    create_mint(&mut context, &new_mint, &malicious_user.pubkey(), None)
-        .await
-        .unwrap();
+    create_mint(
+        &mut context,
+        &new_mint,
+        &malicious_user.pubkey(),
+        Some(&malicious_user.pubkey()),
+    )
+    .await
+    .unwrap();
     create_token_account(
         &mut context,
         &new_mint_token_acc,

--- a/nft-packs/program/tests/utils/edition_marker.rs
+++ b/nft-packs/program/tests/utils/edition_marker.rs
@@ -155,7 +155,13 @@ impl TestEditionMarker {
         token_authority: &Keypair,
         master_token_acc: &Pubkey,
     ) -> transport::Result<()> {
-        create_mint(context, &self.mint, &authority.pubkey(), None).await?;
+        create_mint(
+            context,
+            &self.mint,
+            &authority.pubkey(),
+            Some(&authority.pubkey()),
+        )
+        .await?;
         create_token_account(
             context,
             &self.token,

--- a/nft-packs/program/tests/utils/metadata.rs
+++ b/nft-packs/program/tests/utils/metadata.rs
@@ -55,7 +55,13 @@ impl TestMetadata {
         token_account: &Keypair,
         token_owner: &Pubkey,
     ) -> transport::Result<()> {
-        create_mint(context, &self.mint, &context.payer.pubkey(), None).await?;
+        create_mint(
+            context,
+            &self.mint,
+            &context.payer.pubkey(),
+            Some(&context.payer.pubkey()),
+        )
+        .await?;
         create_token_account(context, token_account, &self.mint.pubkey(), token_owner).await?;
         mint_tokens(
             context,

--- a/nft-packs/program/tests/utils/pack_set.rs
+++ b/nft-packs/program/tests/utils/pack_set.rs
@@ -490,9 +490,14 @@ impl TestPackSet {
         master_mint: &Pubkey,
         index: u32,
     ) -> transport::Result<()> {
-        create_mint(context, new_mint, &new_mint_authority.pubkey(), None)
-            .await
-            .unwrap();
+        create_mint(
+            context,
+            new_mint,
+            &new_mint_authority.pubkey(),
+            Some(&new_mint_authority.pubkey()),
+        )
+        .await
+        .unwrap();
         create_token_account(
             context,
             new_mint_token_acc,


### PR DESCRIPTION
Updating tests to not pass in `None` for freeze authority to comply with Token Metadata v1.6 changes.