### PR TITLE
fix: set freeze auth in DecompressV1

### DIFF
--- a/bubblegum/program/src/lib.rs
+++ b/bubblegum/program/src/lib.rs
@@ -812,7 +812,7 @@ pub mod bubblegum {
         ctx: Context<CreateTree>,
         max_depth: u32,
         max_buffer_size: u32,
-        public: Option<bool>
+        public: Option<bool>,
     ) -> Result<()> {
         let merkle_tree = ctx.accounts.merkle_tree.to_account_info();
         let seed = merkle_tree.key();
@@ -1294,7 +1294,7 @@ pub mod bubblegum {
                             &spl_token::id(),
                             &ctx.accounts.mint.key(),
                             &ctx.accounts.mint_authority.key(),
-                            None,
+                            Some(&ctx.accounts.mint_authority.key()),
                             0,
                         )?,
                         &[

--- a/bubblegum/program/tests/utils/tree.rs
+++ b/bubblegum/program/tests/utils/tree.rs
@@ -216,7 +216,11 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> Tree<MAX_DEPTH, MAX_B
     // different signer, payer, accounts, data, etc.) before execution.
     // Moreover executions don't consume the builder, which can be modified
     // some more and executed again etc.
-    pub fn create_tree_tx(&self, payer: &Keypair, public: bool) -> CreateBuilder<MAX_DEPTH, MAX_BUFFER_SIZE> {
+    pub fn create_tree_tx(
+        &self,
+        payer: &Keypair,
+        public: bool,
+    ) -> CreateBuilder<MAX_DEPTH, MAX_BUFFER_SIZE> {
         let accounts = mpl_bubblegum::accounts::CreateTree {
             tree_authority: self.authority(),
             payer: payer.pubkey(),
@@ -247,9 +251,10 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> Tree<MAX_DEPTH, MAX_B
         self.create_tree_tx(payer, true).execute().await
     }
 
-    pub fn mint_v1_non_owner_tx<'a>(&'a self,
-                                 tree_delegate: &Keypair,
-                                 args: &'a mut LeafArgs,
+    pub fn mint_v1_non_owner_tx<'a>(
+        &'a self,
+        tree_delegate: &Keypair,
+        args: &'a mut LeafArgs,
     ) -> MintV1Builder<MAX_DEPTH, MAX_BUFFER_SIZE> {
         let accounts = mpl_bubblegum::accounts::MintV1 {
             tree_authority: self.authority(),
@@ -318,8 +323,14 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> Tree<MAX_DEPTH, MAX_B
         self.mint_v1_tx(tree_delegate, args).execute().await
     }
 
-    pub async fn mint_v1_non_owner(&self, tree_delegate: &Keypair, args: &mut LeafArgs) -> Result<()> {
-        self.mint_v1_non_owner_tx(tree_delegate, args).execute().await
+    pub async fn mint_v1_non_owner(
+        &self,
+        tree_delegate: &Keypair,
+        args: &mut LeafArgs,
+    ) -> Result<()> {
+        self.mint_v1_non_owner_tx(tree_delegate, args)
+            .execute()
+            .await
     }
 
     pub async fn decode_root(&self) -> Result<[u8; 32]> {


### PR DESCRIPTION
Token Metadata v1.6 disallows setting a freeze authority to `None`. This fixes the DecompressV1 instruction to use the mint authority as the freeze authority. (This is overridden with the edition when create_master_edition is called.)

There are also some `cargo fmt` lints.