### PR TITLE
Fix: sum of account balances before and after instruction do not match #822

### DIFF
--- a/auction-house/program/src/execute_sale/mod.rs
+++ b/auction-house/program/src/execute_sale/mod.rs
@@ -1341,15 +1341,6 @@ fn auctioneer_execute_sale_logic<'c, 'info>(
         &[&program_as_signer_seeds],
     )?;
 
-    // Close the buyer trade state account if the rest of execute sale was successful.
-    let curr_buyer_lamp = buyer_trade_state.lamports();
-    **buyer_trade_state.lamports.borrow_mut() = 0;
-    sol_memset(&mut *buyer_ts_data, 0, TRADE_STATE_SIZE);
-    **fee_payer.lamports.borrow_mut() = fee_payer
-        .lamports()
-        .checked_add(curr_buyer_lamp)
-        .ok_or(AuctionHouseError::NumericalOverflow)?;
-
     let token_account_data = SplAccount::unpack(&token_account.data.borrow())?;
     if token_account_data.delegated_amount == 0 {
         if seller.to_account_info().is_signer {
@@ -1392,6 +1383,15 @@ fn auctioneer_execute_sale_logic<'c, 'info>(
                 TRADE_STATE_SIZE,
             );
         }
+        // Close the buyer trade state account if the rest of execute sale was successful.
+        let curr_buyer_lamp = buyer_trade_state.lamports();
+        **buyer_trade_state.lamports.borrow_mut() = 0;
+        sol_memset(&mut *buyer_ts_data, 0, TRADE_STATE_SIZE);
+        **fee_payer.lamports.borrow_mut() = fee_payer
+            .lamports()
+            .checked_add(curr_buyer_lamp)
+            .ok_or(AuctionHouseError::NumericalOverflow)?;
+
     }
     Ok(())
 }
@@ -1749,15 +1749,6 @@ fn execute_sale_logic<'c, 'info>(
         &[&program_as_signer_seeds],
     )?;
 
-    // Close the buyer trade state account if the rest of execute sale was successful.
-    let curr_buyer_lamp = buyer_trade_state.lamports();
-    **buyer_trade_state.lamports.borrow_mut() = 0;
-    sol_memset(&mut *buyer_ts_data, 0, TRADE_STATE_SIZE);
-    **fee_payer.lamports.borrow_mut() = fee_payer
-        .lamports()
-        .checked_add(curr_buyer_lamp)
-        .ok_or(AuctionHouseError::NumericalOverflow)?;
-
     let token_account_data = SplAccount::unpack(&token_account.data.borrow())?;
     if token_account_data.delegated_amount == 0 {
         if seller.to_account_info().is_signer {
@@ -1799,6 +1790,14 @@ fn execute_sale_logic<'c, 'info>(
                 TRADE_STATE_SIZE,
             );
         }
+        // Close the buyer trade state account if the rest of execute sale was successful.
+        let curr_buyer_lamp = buyer_trade_state.lamports();
+        **buyer_trade_state.lamports.borrow_mut() = 0;
+        sol_memset(&mut *buyer_ts_data, 0, TRADE_STATE_SIZE);
+        **fee_payer.lamports.borrow_mut() = fee_payer
+            .lamports()
+            .checked_add(curr_buyer_lamp)
+            .ok_or(AuctionHouseError::NumericalOverflow)?;
     };
 
     Ok(())

--- a/auction-house/program/src/execute_sale/mod.rs
+++ b/auction-house/program/src/execute_sale/mod.rs
@@ -1391,7 +1391,6 @@ fn auctioneer_execute_sale_logic<'c, 'info>(
             .lamports()
             .checked_add(curr_buyer_lamp)
             .ok_or(AuctionHouseError::NumericalOverflow)?;
-
     }
     Ok(())
 }


### PR DESCRIPTION
Deployed the contract on devnet after these changes, and tested again with the flow mentioned in the issue #822. Execute sale is working fine now.
ProgramID on devnet: 3D9cn2367JxcHyKPQpySFoZgf2ZDekh9ZVfEreVWT4WA
Auction House Keys (on which I tested)
{
    "authority": "rHETQthTcwEVwHCxj3YDGQcJCyFxCAn5QQmbgnMjYzq",
    "payer": "rHETQthTcwEVwHCxj3YDGQcJCyFxCAn5QQmbgnMjYzq",
    "treasuryMint": "So11111111111111111111111111111111111111112",
    "feeWithdrawalDestination": "rHETQthTcwEVwHCxj3YDGQcJCyFxCAn5QQmbgnMjYzq",
    "treasuryWithdrawalDestination": "rHETQthTcwEVwHCxj3YDGQcJCyFxCAn5QQmbgnMjYzq",
    "treasuryWithdrawalDestinationOwner": "rHETQthTcwEVwHCxj3YDGQcJCyFxCAn5QQmbgnMjYzq",
    "auctionHouse": "21aSox4W7C72XVdeyfnecgJ4xS8TmUXbU3P1UxEQL4uS",
    "auctionHouseFeeAccount": "5GZRUuX6sds78ntTyBmf4mrQAqNQANsgmGruGbHwWBvu",
    "auctionHouseTreasury": "3dtumsMMWHDWzuVdzbuQnFcQ5PFFLMw9HHZ1Z1LUugrH"
}