### PR TITLE
[Hydra] move extra SOL in fanout account to native account to distribute

### DIFF
--- a/hydra/program/src/state.rs
+++ b/hydra/program/src/state.rs
@@ -16,6 +16,7 @@ impl Default for MembershipModel {
     }
 }
 
+pub const FANOUT_ACCOUNT_SIZE: usize = 300;
 #[account]
 #[derive(Default, Debug)]
 pub struct Fanout {


### PR DESCRIPTION
Purpose: Enable the ability to use Hydra fanout account address for creator royalties across SOL and SPL markets.

Background:
When we create a fanout wallet, it'll allow to distribute SOL and SPL funds to the members with the shares setup. But, the tests I've made, and then looking at the code, doesn't offer a uniform address to use so whether the wallet is receiving SOL or SPL tokens, we have only one address to send to. SOL is distributed from the Native account, and SPL tokens from the PDA for each mint out of the Fanout account.

My goal was to use the fanout account as the uniform for accepting both SOL and SPL, and then, when trying to distribute SOL, transferring the extra (besides rent) from the fanout account to the native account, to continue with the regular shares distribution.

This will also require that to compute the SOL balance for the wallet, we should consider both Native and Fanout accounts as available lamports.

Disclaimer:
I haven't been able to deploy this on localnet or devnet (I'm still a novice dealing with Solana programs and Rust), so I'm bringing this code to help someone else look at this and let me know if the approach is incorrect.