### PR TITLE
allow user to choose between Fungible and FungibleAsset types

### DIFF
--- a/token-metadata/program/src/error.rs
+++ b/token-metadata/program/src/error.rs
@@ -520,6 +520,10 @@ pub enum MetadataError {
     /// 131
     #[error("Invalid collection size change")]
     InvalidCollectionSizeChange,
+
+    /// 132
+    #[error("No token standard provided")]
+    NoTokenStandardProvided,
 }
 
 impl PrintProgramError for MetadataError {

--- a/token-metadata/program/src/escrow/close_escrow_account.rs
+++ b/token-metadata/program/src/escrow/close_escrow_account.rs
@@ -6,8 +6,8 @@ use crate::{
         ESCROW_POSTFIX, PREFIX,
     },
     utils::{
-        assert_derivation, assert_initialized, assert_owned_by, assert_signer,
-        check_token_standard, close_account_raw,
+        assert_derivation, assert_initialized, assert_owned_by, assert_signer, close_account_raw,
+        validate_token_standard,
     },
 };
 use borsh::BorshSerialize;
@@ -79,7 +79,7 @@ pub fn process_close_escrow_account(
         return Err(MetadataError::MintMismatch.into());
     }
 
-    if check_token_standard(mint_account_info, Some(edition_account_info))?
+    if validate_token_standard(mint_account_info, edition_account_info)?
         != TokenStandard::NonFungible
     {
         return Err(MetadataError::MustBeNonFungible.into());

--- a/token-metadata/program/src/escrow/create_escrow_account.rs
+++ b/token-metadata/program/src/escrow/create_escrow_account.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     utils::{
         assert_derivation, assert_initialized, assert_owned_by, assert_signer,
-        check_token_standard, create_or_allocate_account_raw,
+        create_or_allocate_account_raw, validate_token_standard,
     },
 };
 use borsh::BorshSerialize;
@@ -92,7 +92,7 @@ pub fn process_create_escrow_account(
     }
 
     // Only non-fungible tokens (i.e. unique) can have escrow accounts.
-    if check_token_standard(mint_account_info, Some(edition_account_info))?
+    if validate_token_standard(mint_account_info, edition_account_info)?
         != TokenStandard::NonFungible
     {
         return Err(MetadataError::MustBeNonFungible.into());

--- a/token-metadata/program/src/instruction.rs
+++ b/token-metadata/program/src/instruction.rs
@@ -2,7 +2,7 @@ use crate::{
     deprecated_instruction::{MintPrintingTokensViaTokenArgs, SetReservationListArgs},
     escrow::TransferOutOfEscrowArgs,
     state::{
-        Collection, CollectionDetails, Creator, Data, DataV2, Uses, EDITION,
+        Collection, CollectionDetails, Creator, Data, DataV2, TokenStandard, Uses, EDITION,
         EDITION_MARKER_BIT_SIZE, PREFIX,
     },
 };
@@ -117,6 +117,13 @@ pub struct UtilizeArgs {
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 pub struct SetCollectionSizeArgs {
     pub size: u64,
+}
+
+#[repr(C)]
+#[cfg_attr(feature = "serde-feature", derive(Serialize, Deserialize))]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+pub struct SetTokenStandardArgs {
+    pub token_standard: Option<TokenStandard>,
 }
 
 /// Instructions supported by the Metadata program.
@@ -518,7 +525,7 @@ pub enum MetadataInstruction {
     #[account(1, signer, writable, name="update_authority", desc="Metadata update authority")]
     #[account(2, name="mint", desc="Mint account")]
     #[account(3, optional, name="edition", desc="Edition account")]
-    SetTokenStandard,
+    SetTokenStandard(SetTokenStandardArgs),
 
     /// Set size of an existing collection using CPI from the Bubblegum program.  This is how
     /// collection size is incremented and decremented for compressed NFTs.
@@ -1801,13 +1808,16 @@ pub fn set_token_standard(
     update_authority: Pubkey,
     mint_account: Pubkey,
     edition_account: Option<Pubkey>,
+    token_standard: Option<TokenStandard>,
 ) -> Instruction {
     let mut accounts = vec![
         AccountMeta::new(metadata_account, false),
         AccountMeta::new(update_authority, true),
         AccountMeta::new_readonly(mint_account, false),
     ];
-    let data = MetadataInstruction::SetTokenStandard.try_to_vec().unwrap();
+    let data = MetadataInstruction::SetTokenStandard(SetTokenStandardArgs { token_standard })
+        .try_to_vec()
+        .unwrap();
 
     if let Some(edition_account) = edition_account {
         accounts.push(AccountMeta::new_readonly(edition_account, false));

--- a/token-metadata/program/src/utils.rs
+++ b/token-metadata/program/src/utils.rs
@@ -1422,32 +1422,22 @@ pub fn assert_verified_member_of_collection(
     Ok(())
 }
 
-pub fn check_token_standard(
+pub fn validate_token_standard(
     mint_info: &AccountInfo,
-    edition_account_info: Option<&AccountInfo>,
+    edition_account_info: &AccountInfo,
 ) -> Result<TokenStandard, ProgramError> {
     let mint_decimals = get_mint_decimals(mint_info)?;
     let mint_supply = get_mint_supply(mint_info)?;
 
-    match edition_account_info {
-        Some(edition) => {
-            if is_master_edition(edition, mint_decimals, mint_supply) {
-                Ok(TokenStandard::NonFungible)
-            } else if is_print_edition(edition, mint_decimals, mint_supply) {
-                Ok(TokenStandard::NonFungibleEdition)
-            } else {
-                Err(MetadataError::CouldNotDetermineTokenStandard.into())
-            }
-        }
-        None => {
-            assert_edition_is_not_mint_authority(mint_info)?;
-            if mint_decimals == 0 {
-                Ok(TokenStandard::FungibleAsset)
-            } else {
-                Ok(TokenStandard::Fungible)
-            }
-        }
-    }
+    let standard = if is_master_edition(edition_account_info, mint_decimals, mint_supply) {
+        TokenStandard::NonFungible
+    } else if is_print_edition(edition_account_info, mint_decimals, mint_supply) {
+        TokenStandard::NonFungibleEdition
+    } else {
+        return Err(MetadataError::CouldNotDetermineTokenStandard.into());
+    };
+
+    Ok(standard)
 }
 
 pub fn is_master_edition(

--- a/token-metadata/program/tests/set_token_standard.rs
+++ b/token-metadata/program/tests/set_token_standard.rs
@@ -54,6 +54,7 @@ async fn successfully_update_nonfungible() {
         context.payer.pubkey(),
         test_nft.mint.pubkey(),
         Some(master_edition.pubkey),
+        None,
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -127,6 +128,7 @@ async fn successfully_update_nonfungible_edition() {
         context.payer.pubkey(),
         edition.mint.pubkey(),
         Some(edition.new_edition_pubkey),
+        None,
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -177,6 +179,7 @@ async fn successfully_update_fungible_asset() {
         context.payer.pubkey(),
         test_nft.mint.pubkey(),
         None,
+        Some(TokenStandard::FungibleAsset),
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -224,6 +227,7 @@ async fn successfully_update_fungible() {
         context.payer.pubkey(),
         test_nft.mint.pubkey(),
         None,
+        Some(TokenStandard::Fungible),
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -277,6 +281,7 @@ async fn updating_without_authority_fails() {
         fake_authority.pubkey(),
         test_nft.mint.pubkey(),
         Some(master_edition.pubkey),
+        None,
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -341,6 +346,7 @@ async fn mint_matches_metadata() {
         context.payer.pubkey(),
         test_nft.mint.pubkey(),
         Some(master_edition.pubkey),
+        None,
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -412,6 +418,7 @@ async fn incorrect_edition_fails() {
         context.payer.pubkey(),
         test_nft.mint.pubkey(),
         Some(wrong_master_edition.pubkey),
+        None,
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -462,6 +469,7 @@ async fn invalid_edition_fails() {
         context.payer.pubkey(),
         test_nft.mint.pubkey(),
         Some(invalid_edition),
+        None,
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -513,6 +521,7 @@ async fn updating_nonfungible_without_edition_fails() {
         context.payer.pubkey(),
         test_nft.mint.pubkey(),
         None,
+        Some(TokenStandard::Fungible),
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],


### PR DESCRIPTION
This PR modifies `set_token_standard` to allow the user to choose between `Fungible` and `FungibleAsset` token standard types as long as the token is actually a fungible (no edition account). This adds an arg to the instruction handler, so is a breaking change. 