### PR TITLE
Add update authority to collection authority record

### DIFF
--- a/token-metadata/program/src/assertions/collection.rs
+++ b/token-metadata/program/src/assertions/collection.rs
@@ -63,9 +63,17 @@ pub fn assert_has_collection_authority(
         if data.len() == 0 {
             return Err(MetadataError::InvalidCollectionUpdateAuthority.into());
         }
-        let bump_match = CollectionAuthorityRecord::from_bytes(&data)?;
-        if bump_match.bump != bump {
+        let record = CollectionAuthorityRecord::from_bytes(&data)?;
+        if record.bump != bump {
             return Err(MetadataError::InvalidCollectionUpdateAuthority.into());
+        }
+        match record.update_authority {
+            Some(update_authority) => {
+                if update_authority != collection_data.update_authority {
+                    return Err(MetadataError::InvalidCollectionUpdateAuthority.into());
+                }
+            }
+            None => return Err(MetadataError::InvalidCollectionUpdateAuthority.into()),
         }
     } else if collection_data.update_authority != *collection_authority_info.key {
         return Err(MetadataError::InvalidCollectionUpdateAuthority.into());

--- a/token-metadata/program/src/processor.rs
+++ b/token-metadata/program/src/processor.rs
@@ -4,7 +4,7 @@ use crate::{
     assertions::{
         collection::{
             assert_collection_update_is_valid, assert_collection_verify_is_valid,
-            assert_has_collection_authority,
+            assert_has_collection_authority, assert_is_collection_delegated_authority,
         },
         uses::{assert_valid_use, process_use_authority_validation},
     },
@@ -1412,6 +1412,7 @@ pub fn process_approve_collection_authority(
     let mut record = CollectionAuthorityRecord::from_account_info(collection_authority_record)?;
     record.key = Key::CollectionAuthorityRecord;
     record.bump = collection_authority_bump_seed[0];
+    record.update_authority = Some(*update_authority.key);
     record.serialize(&mut *collection_authority_record.try_borrow_mut_data()?)?;
     Ok(())
 }
@@ -1442,12 +1443,13 @@ pub fn process_revoke_collection_authority(
     if collection_authority_info_empty {
         return Err(MetadataError::CollectionAuthorityDoesNotExist.into());
     }
-    assert_has_collection_authority(
-        delegate_authority,
-        &metadata,
+
+    assert_is_collection_delegated_authority(
+        collection_authority_record,
+        delegate_authority.key,
         mint_info.key,
-        Some(collection_authority_record),
     )?;
+
     let lamports = collection_authority_record.lamports();
     **collection_authority_record.try_borrow_mut_lamports()? = 0;
     **revoke_authority.try_borrow_mut_lamports()? = revoke_authority

--- a/token-metadata/program/src/state.rs
+++ b/token-metadata/program/src/state.rs
@@ -89,7 +89,7 @@ pub const EDITION_MARKER_BIT_SIZE: u64 = 248;
 
 pub const USE_AUTHORITY_RECORD_SIZE: usize = 18; //8 byte padding
 
-pub const COLLECTION_AUTHORITY_RECORD_SIZE: usize = 11; //10 byte padding
+pub const COLLECTION_AUTHORITY_RECORD_SIZE: usize = 35;
 
 pub trait TokenMetadataAccount: BorshDeserialize {
     fn key() -> Key;
@@ -286,8 +286,9 @@ impl UseAuthorityRecord {
 #[cfg_attr(feature = "serde-feature", derive(Serialize, Deserialize))]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone, ShankAccount)]
 pub struct CollectionAuthorityRecord {
-    pub key: Key, //1
-    pub bump: u8, //1
+    pub key: Key,                         //1
+    pub bump: u8,                         //1
+    pub update_authority: Option<Pubkey>, //33 (1 + 32)
 }
 
 impl Default for CollectionAuthorityRecord {
@@ -295,6 +296,7 @@ impl Default for CollectionAuthorityRecord {
         CollectionAuthorityRecord {
             key: Key::CollectionAuthorityRecord,
             bump: 255,
+            update_authority: None,
         }
     }
 }

--- a/token-metadata/program/src/state_test.rs
+++ b/token-metadata/program/src/state_test.rs
@@ -227,6 +227,7 @@ mod metadata {
         let collection_record = CollectionAuthorityRecord {
             key: Key::CollectionAuthorityRecord,
             bump: 255,
+            update_authority: None,
         };
 
         let mut buf = Vec::new();


### PR DESCRIPTION
This PR modifies the `CollectionAuthorityRecord` to add the `update_authority` field:
```
pub struct CollectionAuthorityRecord {
    pub key: Key,                         //1
    pub bump: u8,                         //1
    pub update_authority: Option<Pubkey>, //33 (1 + 32)
}
```

Thanks SolShield for identifying this exploit