### PR TITLE
Bump version and regen IDL

### DIFF
--- a/auction-house/js/idl/auction_house.json
+++ b/auction-house/js/idl/auction_house.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.1",
+  "version": "1.3.4",
   "name": "auction_house",
   "instructions": [
     {

--- a/auction-house/js/package.json
+++ b/auction-house/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metaplex-foundation/mpl-auction-house",
-  "version": "2.3.0",
-  "contractVersion": "1.3.1",
+  "version": "2.3.1",
+  "contractVersion": "1.3.4",
   "description": "MPL Auction House JavaScript API.",
   "main": "dist/src/mpl-auction-house.js",
   "types": "dist/src/mpl-auction-house.d.ts",

--- a/auction-house/program/Cargo.lock
+++ b/auction-house/program/Cargo.lock
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-auction-house"
-version = "1.3.2"
+version = "1.3.4"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/auction-house/program/Cargo.toml
+++ b/auction-house/program/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 name = "mpl-auction-house"
-version = "1.3.2"
+version = "1.3.4"
 edition = "2021"
 description = "Decentralized Sales Protocol for Solana Tokens"
 authors = ["Metaplex Developers <dev@metaplex.com>"]


### PR DESCRIPTION
This is a bump for Auction House 1.3.4
- 1.3.4 removes a specific ata check that was overly restrictive