### PR TITLE
Add GitHub label automation

### DIFF
--- a/.github/configs/issue-label-automations.yml
+++ b/.github/configs/issue-label-automations.yml
@@ -1,0 +1,87 @@
+# Direct questions to StackOverflow.
+question:
+  close: true
+  comment: >
+    Hi @{issue-author},
+
+
+    Thank you for your question!
+
+
+    We'd like to make sure our GitHub issue tracker remains the best place to 
+    manage issues that affect the development of the Metaplex Program Library itself.
+
+
+    Your question deserves a purpose-built Q&A forum like StackOverflow so it is 
+    more searchable and encourages others to contribute to and benefit from the answer.
+
+
+    Unless there exists evidence that this is a bug with the Metaplex Program Library itself, would 
+    you **please post your question to the Solana Stack Exchange** using the following link:
+
+
+    **[https://solana.stackexchange.com/questions/ask?tags=metaplex](https://solana.stackexchange.com/questions/ask?tags=metaplex)**
+
+
+    If you could please share the link to the newly created question here afterwards, that would be very helpful for anyone following this thread.
+
+
+    ---
+
+    _This [automated message](https://github.com/metaplex-foundation/metaplex-program-library/tree/master/.github/configs/issue-label-automations.yml) is a result of having added the "question" label._
+
+# Direct feature requests to Canny.
+'feature request':
+  close: true
+  comment: >
+    Hi @{issue-author},
+
+
+    Thank you for raising this!
+
+    
+    We'd like to make sure our GitHub issue tracker remains the best place to 
+    manage issues that affect the development of the Metaplex Program Library itself. 
+    It looks like your issue is suggesting an improvement rather than raising a bug.
+
+
+    Unless there exists evidence that this is a bug with the Metaplex Program Library itself, 
+    **please use our Feature Request boards** to create new posts or upvote existing ones. 
+    You may use the following links to access the relevant Feature Request board:
+
+
+    - **[Token Metadata](https://metaplex.canny.io/developers?category=token-metadata)**
+    - **[Candy Machine](https://metaplex.canny.io/developers?category=candy-machine)**
+    - **[Auction House](https://metaplex.canny.io/developers?category=auction-house)**
+    - **[All Categories](https://metaplex.canny.io/developers)**
+
+
+    If you could please share the link to the relevant Feature Request here afterwards,
+    that would be very helpful for anyone following this thread.
+
+
+    ---
+
+    _This [automated message](https://github.com/metaplex-foundation/metaplex-program-library/tree/master/.github/configs/issue-label-automations.yml) is a result of having added the "feature request" label._
+
+# Ask for community contributions.
+'community contribution':
+  comment: >
+    Hi there,
+
+
+    We're kindly asking for community contributions on this issue. This is the perfect opportunity for anyone to contribute to the NFT ecosystem of Solana.
+
+
+    We've made sure to provide a detailed set of requirements that we believe would benefit the community. Feel free to ask any questions you might have before tackling this issue.
+
+
+    If you are currently working on this issue and are confident that you can fully implement it, please clearly state this on this thread to avoid having multiple people working on the same task.
+
+
+    Thank you in advance for your contribution to the Metaplex ecosystem!
+
+
+    ---
+
+    _This [automated message](https://github.com/metaplex-foundation/metaplex-program-library/tree/master/.github/configs/issue-label-automations.yml) is a result of having added the "community contribution" label._

--- a/.github/workflows/label-automations.yml
+++ b/.github/workflows/label-automations.yml
@@ -1,0 +1,24 @@
+name: Label Automations
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+  discussion:
+    types: [labeled, unlabeled]
+  # pull_request:
+    # types: [labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: write
+  discussions: write
+  # pull-requests: write
+
+jobs:
+  issue-label-automations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@v2
+        with:
+          config-path: '.github/configs/issue-label-automations.yml'
+          process-only: 'issues, discussions'


### PR DESCRIPTION
This PR aims to facilitate community management by triggering automation upon adding labels on GitHub issues.

It defines the following automation:

- **When the `question` label is added**:
  - ✍️ Adds a comment asking the author to open a new post on the Solana Stack Exchange using a link that automatically adds the `metaplex` tag to their post.
  - 🚫 Closes the issue.
- **When the `feature request` label is added**:
  - ✍️ Adds a comment asking the author to create a new Feature Request on Canny or upvote an existing one. It offers shortcuts to relevant Feature Request boards.
  - 🚫 Closes the issue.
- **When the `community contribution` label is added**:
  - ✍️ Adds a comment that explicitly states we are looking for community contributions on this issue with some rough guidelines that we can build upon in the future.

Any of the above labels that did not exist on the repo have been added using the same colour scheme as the JS SDK which already contains these label automation.