### PR TITLE
Bump Token Metadata to 1.6.3

### DIFF
--- a/token-metadata/Cargo.lock
+++ b/token-metadata/Cargo.lock
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "arrayref",
  "borsh",

--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.2",
+  "version": "1.6.3",
   "name": "mpl_token_metadata",
   "instructions": [
     {

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metaplex-foundation/mpl-token-metadata",
-  "version": "2.5.2",
-  "contractVersion": "1.6.2",
+  "version": "2.5.3",
+  "contractVersion": "1.6.3",
   "description": "MPL Token Metadata JavaScript API.",
   "main": "dist/src/mpl-token-metadata.js",
   "types": "dist/src/mpl-token-metadata.d.ts",

--- a/token-metadata/js/src/generated/accounts/CollectionAuthorityRecord.ts
+++ b/token-metadata/js/src/generated/accounts/CollectionAuthorityRecord.ts
@@ -61,9 +61,8 @@ export class CollectionAuthorityRecord implements CollectionAuthorityRecordArgs 
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
-    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<CollectionAuthorityRecord> {
-    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
+    const accountInfo = await connection.getAccountInfo(address);
     if (accountInfo == null) {
       throw new Error(`Unable to find CollectionAuthorityRecord account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/Edition.ts
+++ b/token-metadata/js/src/generated/accounts/Edition.ts
@@ -58,9 +58,8 @@ export class Edition implements EditionArgs {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
-    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<Edition> {
-    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
+    const accountInfo = await connection.getAccountInfo(address);
     if (accountInfo == null) {
       throw new Error(`Unable to find Edition account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/EditionMarker.ts
+++ b/token-metadata/js/src/generated/accounts/EditionMarker.ts
@@ -56,9 +56,8 @@ export class EditionMarker implements EditionMarkerArgs {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
-    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<EditionMarker> {
-    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
+    const accountInfo = await connection.getAccountInfo(address);
     if (accountInfo == null) {
       throw new Error(`Unable to find EditionMarker account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/MasterEditionV1.ts
+++ b/token-metadata/js/src/generated/accounts/MasterEditionV1.ts
@@ -71,9 +71,8 @@ export class MasterEditionV1 implements MasterEditionV1Args {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
-    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<MasterEditionV1> {
-    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
+    const accountInfo = await connection.getAccountInfo(address);
     if (accountInfo == null) {
       throw new Error(`Unable to find MasterEditionV1 account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/MasterEditionV2.ts
+++ b/token-metadata/js/src/generated/accounts/MasterEditionV2.ts
@@ -61,9 +61,8 @@ export class MasterEditionV2 implements MasterEditionV2Args {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
-    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<MasterEditionV2> {
-    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
+    const accountInfo = await connection.getAccountInfo(address);
     if (accountInfo == null) {
       throw new Error(`Unable to find MasterEditionV2 account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/Metadata.ts
+++ b/token-metadata/js/src/generated/accounts/Metadata.ts
@@ -92,9 +92,8 @@ export class Metadata implements MetadataArgs {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
-    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<Metadata> {
-    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
+    const accountInfo = await connection.getAccountInfo(address);
     if (accountInfo == null) {
       throw new Error(`Unable to find Metadata account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/ReservationListV1.ts
+++ b/token-metadata/js/src/generated/accounts/ReservationListV1.ts
@@ -69,9 +69,8 @@ export class ReservationListV1 implements ReservationListV1Args {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
-    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<ReservationListV1> {
-    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
+    const accountInfo = await connection.getAccountInfo(address);
     if (accountInfo == null) {
       throw new Error(`Unable to find ReservationListV1 account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/ReservationListV2.ts
+++ b/token-metadata/js/src/generated/accounts/ReservationListV2.ts
@@ -75,9 +75,8 @@ export class ReservationListV2 implements ReservationListV2Args {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
-    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<ReservationListV2> {
-    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
+    const accountInfo = await connection.getAccountInfo(address);
     if (accountInfo == null) {
       throw new Error(`Unable to find ReservationListV2 account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/TokenOwnedEscrow.ts
+++ b/token-metadata/js/src/generated/accounts/TokenOwnedEscrow.ts
@@ -64,9 +64,8 @@ export class TokenOwnedEscrow implements TokenOwnedEscrowArgs {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
-    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<TokenOwnedEscrow> {
-    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
+    const accountInfo = await connection.getAccountInfo(address);
     if (accountInfo == null) {
       throw new Error(`Unable to find TokenOwnedEscrow account at ${address}`);
     }
@@ -103,33 +102,31 @@ export class TokenOwnedEscrow implements TokenOwnedEscrowArgs {
 
   /**
    * Returns the byteSize of a {@link Buffer} holding the serialized data of
-   * {@link TokenOwnedEscrow} for the provided args.
-   *
-   * @param args need to be provided since the byte size for this account
-   * depends on them
+   * {@link TokenOwnedEscrow}
    */
-  static byteSize(args: TokenOwnedEscrowArgs) {
-    const instance = TokenOwnedEscrow.fromArgs(args);
-    return tokenOwnedEscrowBeet.toFixedFromValue(instance).byteSize;
+  static get byteSize() {
+    return tokenOwnedEscrowBeet.byteSize;
   }
 
   /**
    * Fetches the minimum balance needed to exempt an account holding
    * {@link TokenOwnedEscrow} data from rent
    *
-   * @param args need to be provided since the byte size for this account
-   * depends on them
    * @param connection used to retrieve the rent exemption information
    */
   static async getMinimumBalanceForRentExemption(
-    args: TokenOwnedEscrowArgs,
     connection: web3.Connection,
     commitment?: web3.Commitment,
   ): Promise<number> {
-    return connection.getMinimumBalanceForRentExemption(
-      TokenOwnedEscrow.byteSize(args),
-      commitment,
-    );
+    return connection.getMinimumBalanceForRentExemption(TokenOwnedEscrow.byteSize, commitment);
+  }
+
+  /**
+   * Determines if the provided {@link Buffer} has the correct byte size to
+   * hold {@link TokenOwnedEscrow} data.
+   */
+  static hasCorrectByteSize(buf: Buffer, offset = 0) {
+    return buf.byteLength - offset === TokenOwnedEscrow.byteSize;
   }
 
   /**
@@ -140,7 +137,7 @@ export class TokenOwnedEscrow implements TokenOwnedEscrowArgs {
     return {
       key: 'Key.' + Key[this.key],
       baseToken: this.baseToken.toBase58(),
-      authority: this.authority.__kind,
+      authority: 'EscrowAuthority.' + EscrowAuthority[this.authority],
       bump: this.bump,
     };
   }
@@ -150,10 +147,7 @@ export class TokenOwnedEscrow implements TokenOwnedEscrowArgs {
  * @category Accounts
  * @category generated
  */
-export const tokenOwnedEscrowBeet = new beet.FixableBeetStruct<
-  TokenOwnedEscrow,
-  TokenOwnedEscrowArgs
->(
+export const tokenOwnedEscrowBeet = new beet.BeetStruct<TokenOwnedEscrow, TokenOwnedEscrowArgs>(
   [
     ['key', keyBeet],
     ['baseToken', beetSolana.publicKey],

--- a/token-metadata/js/src/generated/accounts/UseAuthorityRecord.ts
+++ b/token-metadata/js/src/generated/accounts/UseAuthorityRecord.ts
@@ -61,9 +61,8 @@ export class UseAuthorityRecord implements UseAuthorityRecordArgs {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
-    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<UseAuthorityRecord> {
-    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
+    const accountInfo = await connection.getAccountInfo(address);
     if (accountInfo == null) {
       throw new Error(`Unable to find UseAuthorityRecord account at ${address}`);
     }

--- a/token-metadata/js/src/generated/instructions/ApproveCollectionAuthority.ts
+++ b/token-metadata/js/src/generated/instructions/ApproveCollectionAuthority.ts
@@ -45,11 +45,6 @@ export const approveCollectionAuthorityInstructionDiscriminator = 23;
 /**
  * Creates a _ApproveCollectionAuthority_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category ApproveCollectionAuthority

--- a/token-metadata/js/src/generated/instructions/ApproveUseAuthority.ts
+++ b/token-metadata/js/src/generated/instructions/ApproveUseAuthority.ts
@@ -71,11 +71,6 @@ export const approveUseAuthorityInstructionDiscriminator = 20;
 /**
  * Creates a _ApproveUseAuthority_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/BubblegumSetCollectionSize.ts
+++ b/token-metadata/js/src/generated/instructions/BubblegumSetCollectionSize.ts
@@ -58,11 +58,6 @@ export const bubblegumSetCollectionSizeInstructionDiscriminator = 36;
 /**
  * Creates a _BubblegumSetCollectionSize_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/BurnNft.ts
+++ b/token-metadata/js/src/generated/instructions/BurnNft.ts
@@ -46,11 +46,6 @@ export const burnNftInstructionDiscriminator = 29;
 /**
  * Creates a _BurnNft_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category BurnNft

--- a/token-metadata/js/src/generated/instructions/CreateEscrowAccount.ts
+++ b/token-metadata/js/src/generated/instructions/CreateEscrowAccount.ts
@@ -48,11 +48,6 @@ export const createEscrowAccountInstructionDiscriminator = 38;
 /**
  * Creates a _CreateEscrowAccount_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category CreateEscrowAccount

--- a/token-metadata/js/src/generated/instructions/CreateMasterEditionV3.ts
+++ b/token-metadata/js/src/generated/instructions/CreateMasterEditionV3.ts
@@ -67,11 +67,6 @@ export const createMasterEditionV3InstructionDiscriminator = 17;
 /**
  * Creates a _CreateMasterEditionV3_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/CreateMetadataAccountV2.ts
+++ b/token-metadata/js/src/generated/instructions/CreateMetadataAccountV2.ts
@@ -63,11 +63,6 @@ export const createMetadataAccountV2InstructionDiscriminator = 16;
 /**
  * Creates a _CreateMetadataAccountV2_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/CreateMetadataAccountV3.ts
+++ b/token-metadata/js/src/generated/instructions/CreateMetadataAccountV3.ts
@@ -63,11 +63,6 @@ export const createMetadataAccountV3InstructionDiscriminator = 33;
 /**
  * Creates a _CreateMetadataAccountV3_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/DeprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
+++ b/token-metadata/js/src/generated/instructions/DeprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
@@ -63,11 +63,6 @@ export const deprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructio
 /**
  * Creates a _DeprecatedMintNewEditionFromMasterEditionViaPrintingToken_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category DeprecatedMintNewEditionFromMasterEditionViaPrintingToken

--- a/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaToken.ts
+++ b/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaToken.ts
@@ -80,11 +80,6 @@ export const mintNewEditionFromMasterEditionViaTokenInstructionDiscriminator = 1
 /**
  * Creates a _MintNewEditionFromMasterEditionViaToken_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaVaultProxy.ts
+++ b/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaVaultProxy.ts
@@ -86,11 +86,6 @@ export const mintNewEditionFromMasterEditionViaVaultProxyInstructionDiscriminato
 /**
  * Creates a _MintNewEditionFromMasterEditionViaVaultProxy_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/RevokeUseAuthority.ts
+++ b/token-metadata/js/src/generated/instructions/RevokeUseAuthority.ts
@@ -47,11 +47,6 @@ export const revokeUseAuthorityInstructionDiscriminator = 21;
 /**
  * Creates a _RevokeUseAuthority_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category RevokeUseAuthority

--- a/token-metadata/js/src/generated/instructions/SetAndVerifyCollection.ts
+++ b/token-metadata/js/src/generated/instructions/SetAndVerifyCollection.ts
@@ -47,11 +47,6 @@ export const setAndVerifyCollectionInstructionDiscriminator = 25;
 /**
  * Creates a _SetAndVerifyCollection_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category SetAndVerifyCollection

--- a/token-metadata/js/src/generated/instructions/SetAndVerifySizedCollectionItem.ts
+++ b/token-metadata/js/src/generated/instructions/SetAndVerifySizedCollectionItem.ts
@@ -47,11 +47,6 @@ export const setAndVerifySizedCollectionItemInstructionDiscriminator = 32;
 /**
  * Creates a _SetAndVerifySizedCollectionItem_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category SetAndVerifySizedCollectionItem

--- a/token-metadata/js/src/generated/instructions/SetCollectionSize.ts
+++ b/token-metadata/js/src/generated/instructions/SetCollectionSize.ts
@@ -56,11 +56,6 @@ export const setCollectionSizeInstructionDiscriminator = 34;
 /**
  * Creates a _SetCollectionSize_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/SetTokenStandard.ts
+++ b/token-metadata/js/src/generated/instructions/SetTokenStandard.ts
@@ -40,11 +40,6 @@ export const setTokenStandardInstructionDiscriminator = 35;
 /**
  * Creates a _SetTokenStandard_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category SetTokenStandard

--- a/token-metadata/js/src/generated/instructions/TransferOutOfEscrow.ts
+++ b/token-metadata/js/src/generated/instructions/TransferOutOfEscrow.ts
@@ -75,11 +75,6 @@ export const transferOutOfEscrowInstructionDiscriminator = 40;
 /**
  * Creates a _TransferOutOfEscrow_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/UnverifyCollection.ts
+++ b/token-metadata/js/src/generated/instructions/UnverifyCollection.ts
@@ -43,11 +43,6 @@ export const unverifyCollectionInstructionDiscriminator = 22;
 /**
  * Creates a _UnverifyCollection_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category UnverifyCollection

--- a/token-metadata/js/src/generated/instructions/UnverifySizedCollectionItem.ts
+++ b/token-metadata/js/src/generated/instructions/UnverifySizedCollectionItem.ts
@@ -45,11 +45,6 @@ export const unverifySizedCollectionItemInstructionDiscriminator = 31;
 /**
  * Creates a _UnverifySizedCollectionItem_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category UnverifySizedCollectionItem

--- a/token-metadata/js/src/generated/instructions/Utilize.ts
+++ b/token-metadata/js/src/generated/instructions/Utilize.ts
@@ -67,11 +67,6 @@ export const utilizeInstructionDiscriminator = 19;
 /**
  * Creates a _Utilize_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/VerifySizedCollectionItem.ts
+++ b/token-metadata/js/src/generated/instructions/VerifySizedCollectionItem.ts
@@ -45,11 +45,6 @@ export const verifySizedCollectionItemInstructionDiscriminator = 30;
 /**
  * Creates a _VerifySizedCollectionItem_ instruction.
  *
- * Optional accounts that are not provided will be omitted from the accounts
- * array passed with the instruction.
- * An optional account that is set cannot follow an optional account that is unset.
- * Otherwise an Error is raised.
- *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category VerifySizedCollectionItem

--- a/token-metadata/js/src/generated/types/EscrowAuthority.ts
+++ b/token-metadata/js/src/generated/types/EscrowAuthority.ts
@@ -5,54 +5,21 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as web3 from '@solana/web3.js';
 import * as beet from '@metaplex-foundation/beet';
-import * as beetSolana from '@metaplex-foundation/beet-solana';
 /**
- * This type is used to derive the {@link EscrowAuthority} type as well as the de/serializer.
- * However don't refer to it in your code but use the {@link EscrowAuthority} type instead.
- *
- * @category userTypes
- * @category enums
- * @category generated
- * @private
- */
-export type EscrowAuthorityRecord = {
-  TokenOwner: void /* scalar variant */;
-  Creator: { fields: [web3.PublicKey] };
-};
-
-/**
- * Union type respresenting the EscrowAuthority data enum defined in Rust.
- *
- * NOTE: that it includes a `__kind` property which allows to narrow types in
- * switch/if statements.
- * Additionally `isEscrowAuthority*` type guards are exposed below to narrow to a specific variant.
- *
- * @category userTypes
  * @category enums
  * @category generated
  */
-export type EscrowAuthority = beet.DataEnumKeyAsKind<EscrowAuthorityRecord>;
-
-export const isEscrowAuthorityTokenOwner = (
-  x: EscrowAuthority,
-): x is EscrowAuthority & { __kind: 'TokenOwner' } => x.__kind === 'TokenOwner';
-export const isEscrowAuthorityCreator = (
-  x: EscrowAuthority,
-): x is EscrowAuthority & { __kind: 'Creator' } => x.__kind === 'Creator';
+export enum EscrowAuthority {
+  TokenOwner,
+  Creator,
+}
 
 /**
  * @category userTypes
  * @category generated
  */
-export const escrowAuthorityBeet = beet.dataEnum<EscrowAuthorityRecord>([
-  ['TokenOwner', beet.unit],
-  [
-    'Creator',
-    new beet.BeetArgsStruct<EscrowAuthorityRecord['Creator']>(
-      [['fields', beet.fixedSizeTuple([beetSolana.publicKey])]],
-      'EscrowAuthorityRecord["Creator"]',
-    ),
-  ],
-]) as beet.FixableBeet<EscrowAuthority>;
+export const escrowAuthorityBeet = beet.fixedScalarEnum(EscrowAuthority) as beet.FixedSizeBeet<
+  EscrowAuthority,
+  EscrowAuthority
+>;

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpl-token-metadata"
-version = "1.6.2"
+version = "1.6.3"
 description = "Metaplex Metadata"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/metaplex-program-library"

--- a/token-metadata/program/src/utils/metadata.rs
+++ b/token-metadata/program/src/utils/metadata.rs
@@ -1,8 +1,7 @@
 use borsh::{maybestd::io::Error as BorshError, BorshDeserialize, BorshSerialize};
 use mpl_utils::{create_or_allocate_account_raw, token::get_mint_authority};
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program_option::COption,
-    pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, program_option::COption, pubkey::Pubkey,
 };
 
 use super::{compression::is_decompression, *};

--- a/token-metadata/program/src/utils/metadata.rs
+++ b/token-metadata/program/src/utils/metadata.rs
@@ -1,7 +1,7 @@
 use borsh::{maybestd::io::Error as BorshError, BorshDeserialize, BorshSerialize};
 use mpl_utils::{create_or_allocate_account_raw, token::get_mint_authority};
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program_option::COption, pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, program_option::COption,
     pubkey::Pubkey,
 };
 
@@ -116,7 +116,7 @@ pub fn process_create_metadata_accounts_logic(
 
     // This allows the Bubblegum program to create metadata with verified creators since they were
     // verified already by the Bubblegum program.
-    // 
+    //
     let allow_direct_creator_writes =
         allow_direct_creator_writes || is_decompression(mint_info, mint_authority_info);
 


### PR DESCRIPTION
1.6.3 which is alreay on dev and mainnet because it was a security fix needs to be represented in the cargo.