### PR TITLE
[AH] Ensure either the seller or the authority is passed as signer on the sell instruction

### DIFF
--- a/auction-house/js/idl/auction_house.json
+++ b/auction-house/js/idl/auction_house.json
@@ -3329,6 +3329,11 @@
       "code": 6043,
       "name": "InsufficientFunds",
       "msg": "Insufficient funds in escrow account to purchase."
+    },
+    {
+      "code": 6044,
+      "name": "SaleRequiresExactlyOneSigner",
+      "msg": "This sale requires exactly one signer: either the seller or the authority."
     }
   ],
   "metadata": {

--- a/auction-house/js/src/generated/errors/index.ts
+++ b/auction-house/js/src/generated/errors/index.ts
@@ -940,6 +940,29 @@ createErrorFromCodeLookup.set(0x179b, () => new InsufficientFundsError());
 createErrorFromNameLookup.set('InsufficientFunds', () => new InsufficientFundsError());
 
 /**
+ * SaleRequiresExactlyOneSigner: 'This sale requires exactly one signer: either the seller or the authority.'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class SaleRequiresExactlyOneSignerError extends Error {
+  readonly code: number = 0x179c;
+  readonly name: string = 'SaleRequiresExactlyOneSigner';
+  constructor() {
+    super('This sale requires exactly one signer: either the seller or the authority.');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, SaleRequiresExactlyOneSignerError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x179c, () => new SaleRequiresExactlyOneSignerError());
+createErrorFromNameLookup.set(
+  'SaleRequiresExactlyOneSigner',
+  () => new SaleRequiresExactlyOneSignerError(),
+);
+
+/**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors
  * @category generated

--- a/auction-house/program/src/errors.rs
+++ b/auction-house/program/src/errors.rs
@@ -177,4 +177,8 @@ pub enum AuctionHouseError {
     // 6043
     #[msg("Insufficient funds in escrow account to purchase.")]
     InsufficientFunds,
+
+    // 6044
+    #[msg("This sale requires exactly one signer: either the seller or the authority.")]
+    SaleRequiresExactlyOneSigner,
 }

--- a/auction-house/program/src/sell/mod.rs
+++ b/auction-house/program/src/sell/mod.rs
@@ -371,6 +371,9 @@ fn sell_logic<'info>(
     {
         return Err(AuctionHouseError::SaleRequiresSigner.into());
     }
+    if wallet.to_account_info().is_signer && authority.to_account_info().is_signer {
+        return Err(AuctionHouseError::SaleRequiresExactlyOneSigner.into());
+    }
 
     let auction_house_key = auction_house.key();
 


### PR DESCRIPTION
- Creates a new `SaleRequiresExactlyOneSigner` error.
- Throw the new error when both the seller and the authority are passed as signers in the sell instruction.

See #911 