### PR TITLE
Fix: re-export assertions and mpl-utils methods from TM to undo breaking change

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,2 @@
 consolidate-commits = false
-dependent-version = "ignore"
 pre-release-commit-message = "(cargo-release) {{crate_name}} v{{version}}"

--- a/token-metadata/js/src/generated/accounts/CollectionAuthorityRecord.ts
+++ b/token-metadata/js/src/generated/accounts/CollectionAuthorityRecord.ts
@@ -61,8 +61,9 @@ export class CollectionAuthorityRecord implements CollectionAuthorityRecordArgs 
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
+    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<CollectionAuthorityRecord> {
-    const accountInfo = await connection.getAccountInfo(address);
+    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
     if (accountInfo == null) {
       throw new Error(`Unable to find CollectionAuthorityRecord account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/Edition.ts
+++ b/token-metadata/js/src/generated/accounts/Edition.ts
@@ -58,8 +58,9 @@ export class Edition implements EditionArgs {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
+    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<Edition> {
-    const accountInfo = await connection.getAccountInfo(address);
+    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
     if (accountInfo == null) {
       throw new Error(`Unable to find Edition account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/EditionMarker.ts
+++ b/token-metadata/js/src/generated/accounts/EditionMarker.ts
@@ -56,8 +56,9 @@ export class EditionMarker implements EditionMarkerArgs {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
+    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<EditionMarker> {
-    const accountInfo = await connection.getAccountInfo(address);
+    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
     if (accountInfo == null) {
       throw new Error(`Unable to find EditionMarker account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/MasterEditionV1.ts
+++ b/token-metadata/js/src/generated/accounts/MasterEditionV1.ts
@@ -71,8 +71,9 @@ export class MasterEditionV1 implements MasterEditionV1Args {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
+    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<MasterEditionV1> {
-    const accountInfo = await connection.getAccountInfo(address);
+    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
     if (accountInfo == null) {
       throw new Error(`Unable to find MasterEditionV1 account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/MasterEditionV2.ts
+++ b/token-metadata/js/src/generated/accounts/MasterEditionV2.ts
@@ -61,8 +61,9 @@ export class MasterEditionV2 implements MasterEditionV2Args {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
+    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<MasterEditionV2> {
-    const accountInfo = await connection.getAccountInfo(address);
+    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
     if (accountInfo == null) {
       throw new Error(`Unable to find MasterEditionV2 account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/Metadata.ts
+++ b/token-metadata/js/src/generated/accounts/Metadata.ts
@@ -92,8 +92,9 @@ export class Metadata implements MetadataArgs {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
+    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<Metadata> {
-    const accountInfo = await connection.getAccountInfo(address);
+    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
     if (accountInfo == null) {
       throw new Error(`Unable to find Metadata account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/ReservationListV1.ts
+++ b/token-metadata/js/src/generated/accounts/ReservationListV1.ts
@@ -69,8 +69,9 @@ export class ReservationListV1 implements ReservationListV1Args {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
+    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<ReservationListV1> {
-    const accountInfo = await connection.getAccountInfo(address);
+    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
     if (accountInfo == null) {
       throw new Error(`Unable to find ReservationListV1 account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/ReservationListV2.ts
+++ b/token-metadata/js/src/generated/accounts/ReservationListV2.ts
@@ -75,8 +75,9 @@ export class ReservationListV2 implements ReservationListV2Args {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
+    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<ReservationListV2> {
-    const accountInfo = await connection.getAccountInfo(address);
+    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
     if (accountInfo == null) {
       throw new Error(`Unable to find ReservationListV2 account at ${address}`);
     }

--- a/token-metadata/js/src/generated/accounts/UseAuthorityRecord.ts
+++ b/token-metadata/js/src/generated/accounts/UseAuthorityRecord.ts
@@ -61,8 +61,9 @@ export class UseAuthorityRecord implements UseAuthorityRecordArgs {
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
+    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<UseAuthorityRecord> {
-    const accountInfo = await connection.getAccountInfo(address);
+    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
     if (accountInfo == null) {
       throw new Error(`Unable to find UseAuthorityRecord account at ${address}`);
     }

--- a/token-metadata/js/src/generated/instructions/ApproveCollectionAuthority.ts
+++ b/token-metadata/js/src/generated/instructions/ApproveCollectionAuthority.ts
@@ -45,6 +45,11 @@ export const approveCollectionAuthorityInstructionDiscriminator = 23;
 /**
  * Creates a _ApproveCollectionAuthority_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category ApproveCollectionAuthority

--- a/token-metadata/js/src/generated/instructions/ApproveUseAuthority.ts
+++ b/token-metadata/js/src/generated/instructions/ApproveUseAuthority.ts
@@ -71,6 +71,11 @@ export const approveUseAuthorityInstructionDiscriminator = 20;
 /**
  * Creates a _ApproveUseAuthority_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/BubblegumSetCollectionSize.ts
+++ b/token-metadata/js/src/generated/instructions/BubblegumSetCollectionSize.ts
@@ -58,6 +58,11 @@ export const bubblegumSetCollectionSizeInstructionDiscriminator = 36;
 /**
  * Creates a _BubblegumSetCollectionSize_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/BurnNft.ts
+++ b/token-metadata/js/src/generated/instructions/BurnNft.ts
@@ -46,6 +46,11 @@ export const burnNftInstructionDiscriminator = 29;
 /**
  * Creates a _BurnNft_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category BurnNft

--- a/token-metadata/js/src/generated/instructions/CreateEscrowAccount.ts
+++ b/token-metadata/js/src/generated/instructions/CreateEscrowAccount.ts
@@ -48,6 +48,11 @@ export const createEscrowAccountInstructionDiscriminator = 38;
 /**
  * Creates a _CreateEscrowAccount_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category CreateEscrowAccount

--- a/token-metadata/js/src/generated/instructions/CreateMasterEditionV3.ts
+++ b/token-metadata/js/src/generated/instructions/CreateMasterEditionV3.ts
@@ -67,6 +67,11 @@ export const createMasterEditionV3InstructionDiscriminator = 17;
 /**
  * Creates a _CreateMasterEditionV3_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/CreateMetadataAccountV2.ts
+++ b/token-metadata/js/src/generated/instructions/CreateMetadataAccountV2.ts
@@ -63,6 +63,11 @@ export const createMetadataAccountV2InstructionDiscriminator = 16;
 /**
  * Creates a _CreateMetadataAccountV2_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/CreateMetadataAccountV3.ts
+++ b/token-metadata/js/src/generated/instructions/CreateMetadataAccountV3.ts
@@ -63,6 +63,11 @@ export const createMetadataAccountV3InstructionDiscriminator = 33;
 /**
  * Creates a _CreateMetadataAccountV3_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/DeprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
+++ b/token-metadata/js/src/generated/instructions/DeprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
@@ -63,6 +63,11 @@ export const deprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructio
 /**
  * Creates a _DeprecatedMintNewEditionFromMasterEditionViaPrintingToken_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category DeprecatedMintNewEditionFromMasterEditionViaPrintingToken

--- a/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaToken.ts
+++ b/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaToken.ts
@@ -80,6 +80,11 @@ export const mintNewEditionFromMasterEditionViaTokenInstructionDiscriminator = 1
 /**
  * Creates a _MintNewEditionFromMasterEditionViaToken_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaVaultProxy.ts
+++ b/token-metadata/js/src/generated/instructions/MintNewEditionFromMasterEditionViaVaultProxy.ts
@@ -86,6 +86,11 @@ export const mintNewEditionFromMasterEditionViaVaultProxyInstructionDiscriminato
 /**
  * Creates a _MintNewEditionFromMasterEditionViaVaultProxy_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/RevokeUseAuthority.ts
+++ b/token-metadata/js/src/generated/instructions/RevokeUseAuthority.ts
@@ -47,6 +47,11 @@ export const revokeUseAuthorityInstructionDiscriminator = 21;
 /**
  * Creates a _RevokeUseAuthority_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category RevokeUseAuthority

--- a/token-metadata/js/src/generated/instructions/SetAndVerifyCollection.ts
+++ b/token-metadata/js/src/generated/instructions/SetAndVerifyCollection.ts
@@ -47,6 +47,11 @@ export const setAndVerifyCollectionInstructionDiscriminator = 25;
 /**
  * Creates a _SetAndVerifyCollection_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category SetAndVerifyCollection

--- a/token-metadata/js/src/generated/instructions/SetAndVerifySizedCollectionItem.ts
+++ b/token-metadata/js/src/generated/instructions/SetAndVerifySizedCollectionItem.ts
@@ -47,6 +47,11 @@ export const setAndVerifySizedCollectionItemInstructionDiscriminator = 32;
 /**
  * Creates a _SetAndVerifySizedCollectionItem_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category SetAndVerifySizedCollectionItem

--- a/token-metadata/js/src/generated/instructions/SetCollectionSize.ts
+++ b/token-metadata/js/src/generated/instructions/SetCollectionSize.ts
@@ -56,6 +56,11 @@ export const setCollectionSizeInstructionDiscriminator = 34;
 /**
  * Creates a _SetCollectionSize_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/SetTokenStandard.ts
+++ b/token-metadata/js/src/generated/instructions/SetTokenStandard.ts
@@ -40,6 +40,11 @@ export const setTokenStandardInstructionDiscriminator = 35;
 /**
  * Creates a _SetTokenStandard_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category SetTokenStandard

--- a/token-metadata/js/src/generated/instructions/TransferOutOfEscrow.ts
+++ b/token-metadata/js/src/generated/instructions/TransferOutOfEscrow.ts
@@ -75,6 +75,11 @@ export const transferOutOfEscrowInstructionDiscriminator = 40;
 /**
  * Creates a _TransferOutOfEscrow_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/UnverifyCollection.ts
+++ b/token-metadata/js/src/generated/instructions/UnverifyCollection.ts
@@ -43,6 +43,11 @@ export const unverifyCollectionInstructionDiscriminator = 22;
 /**
  * Creates a _UnverifyCollection_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category UnverifyCollection

--- a/token-metadata/js/src/generated/instructions/UnverifySizedCollectionItem.ts
+++ b/token-metadata/js/src/generated/instructions/UnverifySizedCollectionItem.ts
@@ -45,6 +45,11 @@ export const unverifySizedCollectionItemInstructionDiscriminator = 31;
 /**
  * Creates a _UnverifySizedCollectionItem_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category UnverifySizedCollectionItem

--- a/token-metadata/js/src/generated/instructions/Utilize.ts
+++ b/token-metadata/js/src/generated/instructions/Utilize.ts
@@ -67,6 +67,11 @@ export const utilizeInstructionDiscriminator = 19;
 /**
  * Creates a _Utilize_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *

--- a/token-metadata/js/src/generated/instructions/VerifySizedCollectionItem.ts
+++ b/token-metadata/js/src/generated/instructions/VerifySizedCollectionItem.ts
@@ -45,6 +45,11 @@ export const verifySizedCollectionItemInstructionDiscriminator = 30;
 /**
  * Creates a _VerifySizedCollectionItem_ instruction.
  *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+ *
  * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category VerifySizedCollectionItem

--- a/token-metadata/js/src/generated/types/EscrowAuthority.ts
+++ b/token-metadata/js/src/generated/types/EscrowAuthority.ts
@@ -5,21 +5,54 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
+import * as web3 from '@solana/web3.js';
 import * as beet from '@metaplex-foundation/beet';
+import * as beetSolana from '@metaplex-foundation/beet-solana';
 /**
+ * This type is used to derive the {@link EscrowAuthority} type as well as the de/serializer.
+ * However don't refer to it in your code but use the {@link EscrowAuthority} type instead.
+ *
+ * @category userTypes
+ * @category enums
+ * @category generated
+ * @private
+ */
+export type EscrowAuthorityRecord = {
+  TokenOwner: void /* scalar variant */;
+  Creator: { fields: [web3.PublicKey] };
+};
+
+/**
+ * Union type respresenting the EscrowAuthority data enum defined in Rust.
+ *
+ * NOTE: that it includes a `__kind` property which allows to narrow types in
+ * switch/if statements.
+ * Additionally `isEscrowAuthority*` type guards are exposed below to narrow to a specific variant.
+ *
+ * @category userTypes
  * @category enums
  * @category generated
  */
-export enum EscrowAuthority {
-  TokenOwner,
-  Creator,
-}
+export type EscrowAuthority = beet.DataEnumKeyAsKind<EscrowAuthorityRecord>;
+
+export const isEscrowAuthorityTokenOwner = (
+  x: EscrowAuthority,
+): x is EscrowAuthority & { __kind: 'TokenOwner' } => x.__kind === 'TokenOwner';
+export const isEscrowAuthorityCreator = (
+  x: EscrowAuthority,
+): x is EscrowAuthority & { __kind: 'Creator' } => x.__kind === 'Creator';
 
 /**
  * @category userTypes
  * @category generated
  */
-export const escrowAuthorityBeet = beet.fixedScalarEnum(EscrowAuthority) as beet.FixedSizeBeet<
-  EscrowAuthority,
-  EscrowAuthority
->;
+export const escrowAuthorityBeet = beet.dataEnum<EscrowAuthorityRecord>([
+  ['TokenOwner', beet.unit],
+  [
+    'Creator',
+    new beet.BeetArgsStruct<EscrowAuthorityRecord['Creator']>(
+      [['fields', beet.fixedSizeTuple([beetSolana.publicKey])]],
+      'EscrowAuthorityRecord["Creator"]',
+    ),
+  ],
+]) as beet.FixableBeet<EscrowAuthority>;

--- a/token-metadata/program/src/utils/mod.rs
+++ b/token-metadata/program/src/utils/mod.rs
@@ -3,11 +3,30 @@ pub(crate) mod compression;
 pub(crate) mod master_edition;
 pub(crate) mod metadata;
 
+pub use crate::assertions::{
+    assert_delegated_tokens, assert_derivation, assert_freeze_authority_matches_mint,
+    assert_initialized, assert_mint_authority_matches_mint, assert_owned_by, assert_rent_exempt,
+    assert_token_program_matches_package,
+    edition::{
+        assert_edition_is_not_mint_authority, assert_edition_valid, assert_supply_invariance,
+    },
+    metadata::{
+        assert_currently_holding, assert_data_valid, assert_update_authority_is_correct,
+        assert_verified_member_of_collection,
+    },
+};
 pub use collection::*;
 pub use compression::*;
 pub use master_edition::*;
 pub use metadata::*;
-use mpl_utils::token::{get_mint_decimals, get_mint_freeze_authority, get_mint_supply};
+pub use mpl_utils::{
+    assert_signer, close_account_raw, create_or_allocate_account_raw,
+    resize_or_reallocate_account_raw,
+    token::{
+        get_mint_authority, get_mint_decimals, get_mint_freeze_authority, get_mint_supply,
+        get_owner_from_token_account, spl_token_burn, spl_token_close, spl_token_mint_to,
+    },
+};
 use solana_program::{
     account_info::AccountInfo, borsh::try_from_slice_unchecked, entrypoint::ProgramResult, msg,
     program::invoke_signed, program_error::ProgramError, pubkey::Pubkey,
@@ -15,7 +34,6 @@ use solana_program::{
 use spl_token::instruction::{set_authority, AuthorityType};
 
 use crate::{
-    assertions::edition::assert_edition_is_not_mint_authority,
     error::MetadataError,
     state::{
         Edition, Key, MasterEditionV2, Metadata, TokenMetadataAccount, TokenStandard,


### PR DESCRIPTION
replaces #914 