### PR TITLE
serialize pubkeys with As DisplayFromStr; clippy fixes

### DIFF
--- a/token-metadata/program/src/processor/escrow/create_escrow_account.rs
+++ b/token-metadata/program/src/processor/escrow/create_escrow_account.rs
@@ -115,7 +115,7 @@ pub fn process_create_escrow_account(
     )?;
 
     sol_memcpy(
-        &mut **escrow_account_info.try_borrow_mut_data().unwrap(),
+        &mut escrow_account_info.try_borrow_mut_data().unwrap(),
         &serialized_data,
         serialized_data.len(),
     );

--- a/token-metadata/program/src/processor/uses/approve_use_authority.rs
+++ b/token-metadata/program/src/processor/uses/approve_use_authority.rs
@@ -102,7 +102,7 @@ pub fn process_approve_use_authority(
         )?;
     }
     let mutable_data = &mut *use_authority_record_info.try_borrow_mut_data()?;
-    let mut record = UseAuthorityRecord::from_bytes(*mutable_data)?;
+    let mut record = UseAuthorityRecord::from_bytes(mutable_data)?;
     record.key = Key::UseAuthorityRecord;
     record.allowed_uses = number_of_uses;
     record.bump = bump_seed;

--- a/token-metadata/program/src/state/collection.rs
+++ b/token-metadata/program/src/state/collection.rs
@@ -7,6 +7,7 @@ pub const COLLECTION_AUTHORITY_RECORD_SIZE: usize = 35;
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Collection {
     pub verified: bool,
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub key: Pubkey,
 }
 

--- a/token-metadata/program/src/state/edition.rs
+++ b/token-metadata/program/src/state/edition.rs
@@ -13,6 +13,7 @@ pub struct Edition {
     pub key: Key,
 
     /// Points at MasterEdition struct
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub parent: Pubkey,
 
     /// Starting at 0 for master record, this is incremented for each edition minted.

--- a/token-metadata/program/src/state/metadata.rs
+++ b/token-metadata/program/src/state/metadata.rs
@@ -34,7 +34,9 @@ pub const MAX_DATA_SIZE: usize = 4
 #[derive(Clone, BorshSerialize, Debug, PartialEq, Eq, ShankAccount)]
 pub struct Metadata {
     pub key: Key,
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub update_authority: Pubkey,
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub mint: Pubkey,
     pub data: Data,
     // Immutable, once flipped, all sales of this metadata are considered secondary.

--- a/token-metadata/program/src/utils/compression.rs
+++ b/token-metadata/program/src/utils/compression.rs
@@ -1,7 +1,6 @@
 use mpl_utils::cmp_pubkeys;
 use solana_program::{account_info::AccountInfo, pubkey, pubkey::Pubkey};
 
-use super::*;
 pub const BUBBLEGUM_PROGRAM_ADDRESS: Pubkey =
     pubkey!("BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY");
 

--- a/token-metadata/program/tests/create_metadata_account.rs
+++ b/token-metadata/program/tests/create_metadata_account.rs
@@ -577,7 +577,7 @@ mod create_meta_accounts {
 
     #[tokio::test]
     async fn fail_bubblegum_owner() {
-        let mut context = &mut program_test().start_with_context().await;
+        let context = &mut program_test().start_with_context().await;
         let test_metadata = Metadata::new();
         let name = "Test".to_string();
         let symbol = "TST".to_string();
@@ -654,7 +654,7 @@ mod create_meta_accounts {
         };
 
         let create_tx = Transaction::new_signed_with_payer(
-            &[instruction::create_metadata_accounts_v2(
+            &[instruction::create_metadata_accounts_v3(
                 id(),
                 test_metadata.pubkey,
                 test_metadata.mint.pubkey(),
@@ -670,6 +670,7 @@ mod create_meta_accounts {
                 true,
                 None,
                 uses.to_owned(),
+                None,
             )],
             Some(&context.payer.pubkey()),
             &[&context.payer, &mint_authority],

--- a/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
+++ b/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
@@ -2,12 +2,12 @@
 pub mod utils;
 
 use borsh::BorshSerialize;
+use mpl_token_metadata::state::Collection;
 use mpl_token_metadata::{
     error::MetadataError,
     id, instruction,
     state::{Creator, Key, MAX_MASTER_EDITION_LEN},
 };
-use mpl_token_metadata::{instruction::sign_metadata, state::Collection};
 use num_traits::FromPrimitive;
 use solana_program_test::*;
 use solana_sdk::{
@@ -68,7 +68,6 @@ mod mint_new_edition_from_master_edition_via_token {
     async fn success_v2() {
         let mut context = program_test().start_with_context().await;
         let test_metadata = Metadata::new();
-        let payer_key = context.payer.pubkey().clone();
         let creator = Keypair::new();
 
         let creator_pub = creator.pubkey().clone();
@@ -124,7 +123,7 @@ mod mint_new_edition_from_master_edition_via_token {
             &[&creator],
             context.last_blockhash,
         );
-        let result = context.banks_client.process_transaction(tx).await;
+        context.banks_client.process_transaction(tx).await.unwrap();
 
         let kpbytes = &context.payer;
         let kp = Keypair::from_bytes(&kpbytes.to_bytes()).unwrap();


### PR DESCRIPTION
Uses `As::DisplayFromStr` on data struct `Pubkey`s to have them serialized as a Base58 strings instead of a `Vec<u8>`. Fix es some clippy lints and unused test items. 