### PR TITLE
Add length check on edition byte test

### DIFF
--- a/token-metadata/program/src/assertions/edition.rs
+++ b/token-metadata/program/src/assertions/edition.rs
@@ -26,7 +26,9 @@ pub fn assert_edition_is_not_mint_authority(mint_account_info: &AccountInfo) -> 
 pub fn assert_edition_is_not_programmable(master_edition_info: &AccountInfo) -> ProgramResult {
     let edition_data = master_edition_info.data.borrow();
 
-    if edition_data[TOKEN_STANDARD_INDEX] == TokenStandard::ProgrammableNonFungible as u8 {
+    if edition_data.len() > TOKEN_STANDARD_INDEX
+        && edition_data[TOKEN_STANDARD_INDEX] == TokenStandard::ProgrammableNonFungible as u8
+    {
         return Err(MetadataError::InvalidTokenStandard.into());
     }
 

--- a/token-metadata/program/src/error.rs
+++ b/token-metadata/program/src/error.rs
@@ -639,6 +639,10 @@ pub enum MetadataError {
     /// 161
     #[error("Missing token owner")]
     MissingTokenOwnerAccount,
+
+    /// 162
+    #[error("Master edition account has an invalid length")]
+    InvalidMasterEditionAccountLength,
 }
 
 impl PrintProgramError for MetadataError {

--- a/token-metadata/program/src/processor/metadata/create.rs
+++ b/token-metadata/program/src/processor/metadata/create.rs
@@ -9,7 +9,8 @@ use crate::{
     error::MetadataError,
     instruction::{Context, Create, CreateArgs},
     state::{
-        Metadata, ProgrammableConfig, TokenMetadataAccount, TokenStandard, TOKEN_STANDARD_INDEX,
+        Metadata, ProgrammableConfig, TokenMetadataAccount, TokenStandard, MAX_MASTER_EDITION_LEN,
+        TOKEN_STANDARD_INDEX,
     },
     utils::{
         create_master_edition, process_create_metadata_accounts_logic,
@@ -162,8 +163,13 @@ fn create_v1(program_id: &Pubkey, ctx: Context<Create>, args: CreateArgs) -> Pro
                 asset_data.token_standard,
                 TokenStandard::ProgrammableNonFungible
             ) {
-                master_edition.data.borrow_mut()[TOKEN_STANDARD_INDEX] =
-                    TokenStandard::ProgrammableNonFungible as u8;
+                let mut data = master_edition.data.borrow_mut();
+
+                if data.len() < MAX_MASTER_EDITION_LEN {
+                    return Err(MetadataError::InvalidMasterEditionAccountLength.into());
+                }
+
+                data[TOKEN_STANDARD_INDEX] = TokenStandard::ProgrammableNonFungible as u8;
             }
         } else {
             return Err(MetadataError::InvalidMasterEdition.into());


### PR DESCRIPTION
Add a check on the length of the edition account before indexing for the programmable byte test.