### PR TITLE
Token address on token record seed

### DIFF
--- a/token-metadata/js/test/delegate.test.ts
+++ b/token-metadata/js/test/delegate.test.ts
@@ -93,7 +93,7 @@ test('Delegate: create sale delegate', async (t) => {
 
   const [delegate] = await API.getKeypair('Delegate');
   // token record PDA
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const args: DelegateArgs = {
@@ -152,7 +152,7 @@ test('Delegate: owner as sale delegate', async (t) => {
   // creates a delegate
 
   // token record PDA
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const args: DelegateArgs = {
@@ -212,7 +212,7 @@ test('Delegate: create transfer delegate', async (t) => {
 
   const [delegate] = await API.getKeypair('Delegate');
   // token record PDA
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const args: DelegateArgs = {
@@ -271,7 +271,7 @@ test('Delegate: fail to create sale delegate on NFT', async (t) => {
 
   const [delegate] = await API.getKeypair('Delegate');
   // token record PDA
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const args: DelegateArgs = {
@@ -314,7 +314,7 @@ test('Delegate: fail to replace pNFT transfer delegate', async (t) => {
 
   const [delegate] = await API.getKeypair('Delegate');
   // token record PDA
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const args: DelegateArgs = {
@@ -393,7 +393,7 @@ test('Delegate: create utility delegate', async (t) => {
 
   const [delegate] = await API.getKeypair('Delegate');
   // token record PDA
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const args: DelegateArgs = {
@@ -452,7 +452,7 @@ test('Delegate: try replace sale delegate', async (t) => {
 
   const [delegate] = await API.getKeypair('Delegate');
   // token record PDA
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const args: DelegateArgs = {

--- a/token-metadata/js/test/lock.test.ts
+++ b/token-metadata/js/test/lock.test.ts
@@ -73,7 +73,7 @@ test('Lock: owner lock ProgrammableNonFungible asset', async (t) => {
   }
 
   // token record PDA
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const pda = await TokenRecord.fromAccountAddress(connection, tokenRecord);
@@ -120,7 +120,7 @@ test('Lock: delegate lock ProgrammableNonFungible asset', async (t) => {
   }
 
   // token record PDA
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   let pda = await TokenRecord.fromAccountAddress(connection, tokenRecord);
@@ -344,7 +344,7 @@ test('Lock: lock ProgrammableNonFungible asset with wrong authority', async (t) 
   }
 
   // token record PDA
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const pda = await TokenRecord.fromAccountAddress(connection, tokenRecord);
@@ -445,7 +445,7 @@ test('Lock: wrong delegate lock ProgrammableNonFungible asset', async (t) => {
     TokenStandard.ProgrammableNonFungible,
   );
 
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const pda = await TokenRecord.fromAccountAddress(connection, tokenRecord);
@@ -519,7 +519,7 @@ test('Lock: already locked ProgrammableNonFungible asset', async (t) => {
     TokenStandard.ProgrammableNonFungible,
   );
 
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   let pda = await TokenRecord.fromAccountAddress(connection, tokenRecord);

--- a/token-metadata/js/test/revoke.test.ts
+++ b/token-metadata/js/test/revoke.test.ts
@@ -36,7 +36,7 @@ test('Revoke: revoke transfer delegate', async (t) => {
 
   const [delegate] = await API.getKeypair('Delegate');
   // token record PDA
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const delegateArgs: DelegateArgs = {

--- a/token-metadata/js/test/setup/txs-init.ts
+++ b/token-metadata/js/test/setup/txs-init.ts
@@ -221,7 +221,7 @@ export class InitTransactions {
     }
 
     if (!tokenRecord) {
-      tokenRecord = findTokenRecordPda(mint, tokenOwner);
+      tokenRecord = findTokenRecordPda(mint, token);
     }
 
     amman.addr.addLabel('Token Account', token);

--- a/token-metadata/js/test/transfer.test.ts
+++ b/token-metadata/js/test/transfer.test.ts
@@ -156,10 +156,10 @@ test('Transfer: ProgrammableNonFungible (wallet-to-wallet)', async (t) => {
   );
 
   // owner token record
-  const ownerTokenRecord = findTokenRecordPda(mint, owner.publicKey);
+  const ownerTokenRecord = findTokenRecordPda(mint, token);
   amman.addr.addLabel('Owner Token Record', ownerTokenRecord);
   // destination token record
-  const destinationTokenRecord = findTokenRecordPda(mint, destination.publicKey);
+  const destinationTokenRecord = findTokenRecordPda(mint, destinationToken);
   amman.addr.addLabel('Destination Token Record', destinationTokenRecord);
 
   // Transfer the NFT to the destination account, this should work since
@@ -279,10 +279,10 @@ test('Transfer: ProgrammableNonFungible (program-owned)', async (t) => {
   await sendAndConfirmTransaction(connection, invalidAtaTx, [payer]);
 
   // owner token record
-  const ownerTokenRecord = findTokenRecordPda(mint, owner.publicKey);
+  const ownerTokenRecord = findTokenRecordPda(mint, token);
   amman.addr.addLabel('Owner Token Record', ownerTokenRecord);
   // destination token record
-  let destinationTokenRecord = findTokenRecordPda(mint, invalidDestination);
+  let destinationTokenRecord = findTokenRecordPda(mint, invalidDestinationToken);
   amman.addr.addLabel('Destination Token Record', destinationTokenRecord);
 
   // Transfer the NFT to the invalid destination account, this should fail.
@@ -353,7 +353,7 @@ test('Transfer: ProgrammableNonFungible (program-owned)', async (t) => {
   await sendAndConfirmTransaction(connection, ataTx, [payer]);
 
   // destination token record
-  destinationTokenRecord = findTokenRecordPda(mint, metadata);
+  destinationTokenRecord = findTokenRecordPda(mint, destinationToken);
   amman.addr.addLabel('Destination Token Record', destinationTokenRecord);
 
   // Transfer the NFT to the destination account, this should work since
@@ -841,10 +841,10 @@ test('Transfer: ProgrammableNonFungible (uninitialized wallet-to-wallet)', async
   );
 
   // owner token record
-  const ownerTokenRecord = findTokenRecordPda(mint, owner.publicKey);
+  const ownerTokenRecord = findTokenRecordPda(mint, token);
   amman.addr.addLabel('Owner Token Record', ownerTokenRecord);
   // destination token record
-  const destinationTokenRecord = findTokenRecordPda(mint, destination.publicKey);
+  const destinationTokenRecord = findTokenRecordPda(mint, destinationToken);
   amman.addr.addLabel('Destination Token Record', destinationTokenRecord);
 
   // Transfer the NFT to the destination account, this should work since
@@ -932,7 +932,7 @@ test('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
   const [, delegate] = await API.getKeypair('Delegate');
   amman.airdrop(connection, delegate.publicKey, 1);
   // token record PDA
-  const tokenRecord = findTokenRecordPda(mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(mint, token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const args: DelegateArgs = {
@@ -1009,10 +1009,10 @@ test('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
   );
 
   // owner token record
-  const ownerTokenRecord = findTokenRecordPda(mint, owner.publicKey);
+  const ownerTokenRecord = findTokenRecordPda(mint, token);
   amman.addr.addLabel('Owner Token Record', ownerTokenRecord);
   // destination token record
-  const destinationTokenRecord = findTokenRecordPda(mint, metadata);
+  const destinationTokenRecord = findTokenRecordPda(mint, destinationToken);
   amman.addr.addLabel('Destination Token Record', destinationTokenRecord);
 
   // Transfer the NFT to the destination account, this should work since

--- a/token-metadata/js/test/unlock.test.ts
+++ b/token-metadata/js/test/unlock.test.ts
@@ -126,7 +126,7 @@ test('Unlock: owner unlock ProgrammableNonFungible asset', async (t) => {
     });
   }
 
-  const tokenRecord = findTokenRecordPda(manager.mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   let pda = await TokenRecord.fromAccountAddress(connection, tokenRecord);

--- a/token-metadata/js/test/update.test.ts
+++ b/token-metadata/js/test/update.test.ts
@@ -1081,14 +1081,14 @@ test('Update: Update existing pNFT rule set config to None', async (t) => {
   // Set up our rule set
   const ruleSetName = 'update_test';
   const ruleSet = {
-    version: 1,
+    libVersion: 1,
     ruleSetName: ruleSetName,
     owner: Array.from(authority.publicKey.toBytes()),
     operations: {
-      Transfer: {
+      'Transfer:Owner': {
         PubkeyMatch: {
           pubkey: Array.from(authority.publicKey.toBytes()),
-          field: 'Target',
+          field: 'Destination',
         },
       },
     },
@@ -1346,7 +1346,7 @@ test('Update: Update pNFT Config with locked token', async (t) => {
   );
 
   // token record PDA
-  const tokenRecord = findTokenRecordPda(mint, payer.publicKey);
+  const tokenRecord = findTokenRecordPda(mint, token);
   amman.addr.addLabel('Token Record', tokenRecord);
 
   const pda = await TokenRecord.fromAccountAddress(connection, tokenRecord);

--- a/token-metadata/js/test/utils/programmable.ts
+++ b/token-metadata/js/test/utils/programmable.ts
@@ -19,14 +19,14 @@ export function createPassRuleSet(
   return encode(ruleSet);
 }
 
-export function findTokenRecordPda(mint: PublicKey, tokenOwner: PublicKey): PublicKey {
+export function findTokenRecordPda(mint: PublicKey, token: PublicKey): PublicKey {
   return PublicKey.findProgramAddressSync(
     [
       Buffer.from('metadata'),
       PROGRAM_ID.toBuffer(),
       mint.toBuffer(),
       Buffer.from('token_record'),
-      tokenOwner.toBuffer(),
+      token.toBuffer(),
     ],
     PROGRAM_ID,
   )[0];

--- a/token-metadata/program/src/pda.rs
+++ b/token-metadata/program/src/pda.rs
@@ -99,14 +99,14 @@ pub fn find_metadata_delegate_record_account(
     )
 }
 
-pub fn find_token_record_account(mint: &Pubkey, token_owner: &Pubkey) -> (Pubkey, u8) {
+pub fn find_token_record_account(mint: &Pubkey, token: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[
             PREFIX.as_bytes(),
             crate::id().as_ref(),
             mint.as_ref(),
             TOKEN_RECORD_SEED.as_bytes(),
-            token_owner.as_ref(),
+            token.as_ref(),
         ],
         &crate::id(),
     )

--- a/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/token-metadata/program/src/processor/delegate/delegate.rs
@@ -192,8 +192,8 @@ fn create_persistent_delegate_v1(
 
     // authority must be the owner of the token account: spl-token required the
     // token owner to set a delegate
-    let token_account = Account::unpack(&token_info.try_borrow_data()?).unwrap();
-    if token_account.owner != *ctx.accounts.authority_info.key {
+    let token = Account::unpack(&token_info.try_borrow_data()?).unwrap();
+    if token.owner != *ctx.accounts.authority_info.key {
         return Err(MetadataError::IncorrectOwner.into());
     }
 

--- a/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/token-metadata/program/src/processor/delegate/delegate.rs
@@ -210,7 +210,7 @@ fn create_persistent_delegate_v1(
                 Some(token_record_info) => {
                     let (pda_key, _) = find_token_record_account(
                         ctx.accounts.mint_info.key,
-                        ctx.accounts.authority_info.key,
+                        token_info.key,
                     );
 
                     assert_keys_equal(&pda_key, token_record_info.key)?;

--- a/token-metadata/program/src/processor/delegate/revoke.rs
+++ b/token-metadata/program/src/processor/delegate/revoke.rs
@@ -199,7 +199,7 @@ fn revoke_persistent_delegate(
                 Some(token_record_info) => {
                     let (pda_key, _) = find_token_record_account(
                         ctx.accounts.mint_info.key,
-                        ctx.accounts.authority_info.key,
+                        token_info.key,
                     );
 
                     assert_keys_equal(&pda_key, token_record_info.key)?;

--- a/token-metadata/program/src/processor/delegate/revoke.rs
+++ b/token-metadata/program/src/processor/delegate/revoke.rs
@@ -173,12 +173,12 @@ fn revoke_persistent_delegate(
 
     // authority must be the owner of the token account: spl-token required the
     // token owner to revoke a delegate
-    let token_account = Account::unpack(&token_info.try_borrow_data()?).unwrap();
-    if token_account.owner != *ctx.accounts.authority_info.key {
+    let token = Account::unpack(&token_info.try_borrow_data()?).unwrap();
+    if token.owner != *ctx.accounts.authority_info.key {
         return Err(MetadataError::IncorrectOwner.into());
     }
 
-    if let COption::Some(existing) = &token_account.delegate {
+    if let COption::Some(existing) = &token.delegate {
         if !cmp_pubkeys(existing, ctx.accounts.delegate_info.key) {
             return Err(MetadataError::InvalidDelegate.into());
         }

--- a/token-metadata/program/src/processor/metadata/mint.rs
+++ b/token-metadata/program/src/processor/metadata/mint.rs
@@ -146,7 +146,7 @@ pub fn mint_v1(program_id: &Pubkey, ctx: Context<Mint>, args: MintArgs) -> Progr
         amount,
         ctx.accounts.mint_info.key
     );
-    let token_account: Account = assert_initialized(ctx.accounts.token_info)?;
+    let token: Account = assert_initialized(ctx.accounts.token_info)?;
 
     match metadata.token_standard {
         Some(TokenStandard::NonFungible) | Some(TokenStandard::ProgrammableNonFungible) => {
@@ -215,7 +215,7 @@ pub fn mint_v1(program_id: &Pubkey, ctx: Context<Mint>, args: MintArgs) -> Progr
             if matches!(
                 metadata.token_standard,
                 Some(TokenStandard::ProgrammableNonFungible)
-            ) && token_account.is_frozen()
+            ) && token.is_frozen()
             {
                 thaw(
                     ctx.accounts.mint_info.clone(),

--- a/token-metadata/program/src/processor/metadata/mint.rs
+++ b/token-metadata/program/src/processor/metadata/mint.rs
@@ -155,14 +155,6 @@ pub fn mint_v1(program_id: &Pubkey, ctx: Context<Mint>, args: MintArgs) -> Progr
                 metadata.token_standard,
                 Some(TokenStandard::ProgrammableNonFungible)
             ) {
-                // if we are initializing a new account, we need the token_owner
-                let token_owner_info = match ctx.accounts.token_owner_info {
-                    Some(token_owner_info) => token_owner_info,
-                    None => {
-                        return Err(MetadataError::MissingTokenOwnerAccount.into());
-                    }
-                };
-
                 // we always need the token_record_info
                 let token_record_info = match ctx.accounts.token_record_info {
                     Some(token_record_info) => token_record_info,
@@ -171,8 +163,10 @@ pub fn mint_v1(program_id: &Pubkey, ctx: Context<Mint>, args: MintArgs) -> Progr
                     }
                 };
 
-                let (pda_key, _) =
-                    find_token_record_account(ctx.accounts.mint_info.key, token_owner_info.key);
+                let (pda_key, _) = find_token_record_account(
+                    ctx.accounts.mint_info.key,
+                    ctx.accounts.token_info.key,
+                );
                 // validates the derivation
                 assert_keys_equal(&pda_key, token_record_info.key)?;
 
@@ -183,7 +177,7 @@ pub fn mint_v1(program_id: &Pubkey, ctx: Context<Mint>, args: MintArgs) -> Progr
                         program_id,
                         token_record_info,
                         ctx.accounts.mint_info,
-                        token_owner_info,
+                        ctx.accounts.token_info,
                         ctx.accounts.payer_info,
                         ctx.accounts.system_program_info,
                     )?;

--- a/token-metadata/program/src/processor/metadata/transfer.rs
+++ b/token-metadata/program/src/processor/metadata/transfer.rs
@@ -188,14 +188,15 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
     let token_standard = metadata
         .token_standard
         .ok_or(MetadataError::InvalidTokenStandard)?;
-    let token = Account::unpack(&ctx.accounts.token_info.try_borrow_data()?)?;
+    let token_account = Account::unpack(&ctx.accounts.token_info.try_borrow_data()?)?;
 
     msg!("getting authority type");
     let authority_type = AuthorityType::get_authority_type(AuthorityRequest {
         authority: ctx.accounts.authority_info.key,
         update_authority: &metadata.update_authority,
         mint: ctx.accounts.mint_info.key,
-        token: Some(&token),
+        token: Some(ctx.accounts.token_info.key),
+        token_account: Some(&token_account),
         token_record_info: ctx.accounts.owner_token_record_info,
         token_delegate_roles: vec![
             TokenDelegateRole::Sale,
@@ -254,7 +255,7 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
         AuthorityType::Delegate => {
             // the delegate has already being validated, but we need to validate
             // that it can transfer the required amount
-            if token.delegated_amount < amount || token.amount < amount {
+            if token_account.delegated_amount < amount || token_account.amount < amount {
                 return Err(MetadataError::NotEnoughTokens.into());
             }
         }
@@ -265,13 +266,15 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
 
             // the authority must be either the token owner or a delegate for the
             // transfer to succeed
-            let available_amount = if cmp_pubkeys(&token.owner, ctx.accounts.authority_info.key) {
-                token.amount
-            } else if COption::from(*ctx.accounts.authority_info.key) == token.delegate {
-                token.delegated_amount
-            } else {
-                return Err(MetadataError::InvalidAuthorityType.into());
-            };
+            let available_amount =
+                if cmp_pubkeys(&token_account.owner, ctx.accounts.authority_info.key) {
+                    token_account.amount
+                } else if COption::from(*ctx.accounts.authority_info.key) == token_account.delegate
+                {
+                    token_account.delegated_amount
+                } else {
+                    return Err(MetadataError::InvalidAuthorityType.into());
+                };
 
             if available_amount < amount {
                 return Err(MetadataError::NotEnoughTokens.into());
@@ -298,16 +301,14 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
                     return Err(MetadataError::MissingTokenRecord.into());
                 };
 
-            let (pda_key, _) = find_token_record_account(
-                ctx.accounts.mint_info.key,
-                ctx.accounts.token_owner_info.key,
-            );
+            let (pda_key, _) =
+                find_token_record_account(ctx.accounts.mint_info.key, ctx.accounts.token_info.key);
             // validates the derivation
             assert_keys_equal(&pda_key, owner_token_record_info.key)?;
 
             let (new_pda_key, _) = find_token_record_account(
                 ctx.accounts.mint_info.key,
-                ctx.accounts.destination_owner_info.key,
+                ctx.accounts.destination_info.key,
             );
             // validates the derivation
             assert_keys_equal(&new_pda_key, destination_token_record_info.key)?;
@@ -375,7 +376,7 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
                     program_id,
                     destination_token_record_info,
                     ctx.accounts.mint_info,
-                    ctx.accounts.destination_owner_info,
+                    ctx.accounts.destination_info,
                     ctx.accounts.payer_info,
                     ctx.accounts.system_program_info,
                 )?;

--- a/token-metadata/program/src/processor/metadata/update.rs
+++ b/token-metadata/program/src/processor/metadata/update.rs
@@ -116,10 +116,10 @@ fn update_v1(program_id: &Pubkey, ctx: Context<Update>, args: UpdateArgs) -> Pro
     let token_standard = metadata
         .token_standard
         .ok_or(MetadataError::InvalidTokenStandard)?;
-    let token = if let Some(token_info) = ctx.accounts.token_info {
-        Some(Account::unpack(&token_info.try_borrow_data()?)?)
+    let (token, token_account) = if let Some(token_info) = ctx.accounts.token_info {
+        (Some(token_info.key), Some(Account::unpack(&token_info.try_borrow_data()?)?))
     } else {
-        None
+        (None, None)
     };
 
     // Determines if we have a valid authority to perform the update. This must
@@ -129,7 +129,8 @@ fn update_v1(program_id: &Pubkey, ctx: Context<Update>, args: UpdateArgs) -> Pro
         authority: ctx.accounts.authority_info.key,
         update_authority: &metadata.update_authority,
         mint: ctx.accounts.mint_info.key,
-        token: token.as_ref(),
+        token,
+        token_account: token_account.as_ref(),
         metadata_delegate_record_info: ctx.accounts.delegate_record_info,
         metadata_delegate_role: Some(MetadataDelegateRole::Update),
         ..Default::default()

--- a/token-metadata/program/src/processor/metadata/update.rs
+++ b/token-metadata/program/src/processor/metadata/update.rs
@@ -116,7 +116,7 @@ fn update_v1(program_id: &Pubkey, ctx: Context<Update>, args: UpdateArgs) -> Pro
     let token_standard = metadata
         .token_standard
         .ok_or(MetadataError::InvalidTokenStandard)?;
-    let (token, token_account) = if let Some(token_info) = ctx.accounts.token_info {
+    let (token_pubkey, token) = if let Some(token_info) = ctx.accounts.token_info {
         (Some(token_info.key), Some(Account::unpack(&token_info.try_borrow_data()?)?))
     } else {
         (None, None)
@@ -129,8 +129,8 @@ fn update_v1(program_id: &Pubkey, ctx: Context<Update>, args: UpdateArgs) -> Pro
         authority: ctx.accounts.authority_info.key,
         update_authority: &metadata.update_authority,
         mint: ctx.accounts.mint_info.key,
-        token,
-        token_account: token_account.as_ref(),
+        token: token_pubkey,
+        token_account: token.as_ref(),
         metadata_delegate_record_info: ctx.accounts.delegate_record_info,
         metadata_delegate_role: Some(MetadataDelegateRole::Update),
         ..Default::default()

--- a/token-metadata/program/src/processor/state/mod.rs
+++ b/token-metadata/program/src/processor/state/mod.rs
@@ -75,9 +75,9 @@ pub(crate) fn toggle_asset_state(
         return Err(MetadataError::MintMismatch.into());
     }
 
-    let token = Account::unpack(&accounts.token_info.try_borrow_data()?)?;
+    let token_account = Account::unpack(&accounts.token_info.try_borrow_data()?)?;
     // mint must match mint account key
-    if token.mint != *accounts.mint_info.key {
+    if token_account.mint != *accounts.mint_info.key {
         return Err(MetadataError::MintMismatch.into());
     }
 
@@ -89,7 +89,8 @@ pub(crate) fn toggle_asset_state(
         authority: accounts.authority_info.key,
         update_authority: &metadata.update_authority,
         mint: accounts.mint_info.key,
-        token: Some(&token),
+        token: Some(accounts.token_info.key),
+        token_account: Some(&token_account),
         token_record_info: accounts.token_record_info,
         token_delegate_roles: vec![
             TokenDelegateRole::Utility,
@@ -136,7 +137,8 @@ pub(crate) fn toggle_asset_state(
     ) {
         let (mut token_record, token_record_info) = match accounts.token_record_info {
             Some(token_record_info) => {
-                let (pda_key, _) = find_token_record_account(accounts.mint_info.key, &token.owner);
+                let (pda_key, _) =
+                    find_token_record_account(accounts.mint_info.key, accounts.token_info.key);
 
                 assert_keys_equal(&pda_key, token_record_info.key)?;
                 assert_owned_by(token_record_info, &crate::ID)?;
@@ -183,7 +185,7 @@ pub(crate) fn toggle_asset_state(
                     }
                 };
 
-                assert_keys_equal(token_owner_info.key, &token.owner)?;
+                assert_keys_equal(token_owner_info.key, &token_account.owner)?;
 
                 (token_owner_info, false)
             }

--- a/token-metadata/program/src/processor/state/mod.rs
+++ b/token-metadata/program/src/processor/state/mod.rs
@@ -75,9 +75,9 @@ pub(crate) fn toggle_asset_state(
         return Err(MetadataError::MintMismatch.into());
     }
 
-    let token_account = Account::unpack(&accounts.token_info.try_borrow_data()?)?;
+    let token = Account::unpack(&accounts.token_info.try_borrow_data()?)?;
     // mint must match mint account key
-    if token_account.mint != *accounts.mint_info.key {
+    if token.mint != *accounts.mint_info.key {
         return Err(MetadataError::MintMismatch.into());
     }
 
@@ -90,7 +90,7 @@ pub(crate) fn toggle_asset_state(
         update_authority: &metadata.update_authority,
         mint: accounts.mint_info.key,
         token: Some(accounts.token_info.key),
-        token_account: Some(&token_account),
+        token_account: Some(&token),
         token_record_info: accounts.token_record_info,
         token_delegate_roles: vec![
             TokenDelegateRole::Utility,
@@ -185,7 +185,7 @@ pub(crate) fn toggle_asset_state(
                     }
                 };
 
-                assert_keys_equal(token_owner_info.key, &token_account.owner)?;
+                assert_keys_equal(token_owner_info.key, &token.owner)?;
 
                 (token_owner_info, false)
             }

--- a/token-metadata/program/src/state/programmable.rs
+++ b/token-metadata/program/src/state/programmable.rs
@@ -1,3 +1,4 @@
+use crate::error::MetadataError;
 use crate::processor::{TransferScenario, UpdateScenario};
 use borsh::{BorshDeserialize, BorshSerialize};
 use mpl_utils::cmp_pubkeys;
@@ -142,8 +143,10 @@ pub struct AuthorityRequest<'a, 'b> {
     pub update_authority: &'b Pubkey,
     /// Mint address.
     pub mint: &'a Pubkey,
+    /// Holder's token account info.
+    pub token: Option<&'a Pubkey>,
     /// Holder's token account.
-    pub token: Option<&'b Account>,
+    pub token_account: Option<&'b Account>,
     /// `MetadataDelegateRecord` account of the authority (when the authority is a delegate).
     pub metadata_delegate_record_info: Option<&'a AccountInfo<'a>>,
     /// Expected `MetadataDelegateRole` for the request.
@@ -161,6 +164,7 @@ impl<'a, 'b> Default for AuthorityRequest<'a, 'b> {
             update_authority: &DEFAULT_PUBKEY,
             mint: &DEFAULT_PUBKEY,
             token: None,
+            token_account: None,
             metadata_delegate_record_info: None,
             metadata_delegate_role: None,
             token_record_info: None,
@@ -179,8 +183,10 @@ impl AuthorityType {
             assert_owned_by(token_record_info, &crate::ID)?;
 
             // we can only validate if it is a token delegate when we have the token account
-            if let Some(token) = request.token {
-                let (pda_key, _) = find_token_record_account(request.mint, &token.owner);
+            if let Some(token_account) = request.token_account {
+                let token = request.token.ok_or(MetadataError::MissingTokenAccount)?;
+
+                let (pda_key, _) = find_token_record_account(request.mint, token);
                 let token_record = TokenRecord::from_account_info(token_record_info)?;
 
                 let role_matches = match token_record.delegate_role {
@@ -191,7 +197,7 @@ impl AuthorityType {
                 if cmp_pubkeys(&pda_key, token_record_info.key)
                     && Some(*request.authority) == token_record.delegate
                     && role_matches
-                    && (COption::from(token_record.delegate) == token.delegate)
+                    && (COption::from(token_record.delegate) == token_account.delegate)
                 {
                     return Ok(AuthorityType::Delegate);
                 }
@@ -225,8 +231,8 @@ impl AuthorityType {
 
         // checks if the authority is the token owner
 
-        if let Some(token) = request.token {
-            if cmp_pubkeys(&token.owner, request.authority) {
+        if let Some(token_account) = request.token_account {
+            if cmp_pubkeys(&token_account.owner, request.authority) {
                 return Ok(AuthorityType::Holder);
             }
         }

--- a/token-metadata/program/src/utils/programmable_asset.rs
+++ b/token-metadata/program/src/utils/programmable_asset.rs
@@ -29,7 +29,7 @@ pub fn create_token_record_account<'a>(
     program_id: &Pubkey,
     token_record_info: &'a AccountInfo<'a>,
     mint_info: &'a AccountInfo<'a>,
-    token_owner_info: &'a AccountInfo<'a>,
+    token_info: &'a AccountInfo<'a>,
     payer_info: &'a AccountInfo<'a>,
     system_program_info: &'a AccountInfo<'a>,
 ) -> ProgramResult {
@@ -42,7 +42,7 @@ pub fn create_token_record_account<'a>(
         crate::ID.as_ref(),
         mint_info.key.as_ref(),
         TOKEN_RECORD_SEED.as_bytes(),
-        token_owner_info.key.as_ref(),
+        token_info.key.as_ref(),
     ]);
 
     let bump = &[assert_derivation(

--- a/token-metadata/program/tests/delegate.rs
+++ b/token-metadata/program/tests/delegate.rs
@@ -52,7 +52,6 @@ mod delegate {
         let user = Keypair::new();
         let user_pubkey = user.pubkey();
         let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
-        let payer_pubkey = payer.pubkey();
 
         asset
             .delegate(
@@ -69,7 +68,7 @@ mod delegate {
 
         // asserts
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &payer_pubkey);
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
 
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
@@ -175,7 +174,6 @@ mod delegate {
         let user = Keypair::new();
         let user_pubkey = user.pubkey();
         let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
-        let payer_pubkey = payer.pubkey();
 
         asset
             .delegate(
@@ -192,7 +190,7 @@ mod delegate {
 
         // asserts
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &payer_pubkey);
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
 
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
@@ -347,7 +345,7 @@ mod delegate {
 
         // asserts
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &context.payer.pubkey());
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
 
@@ -358,7 +356,6 @@ mod delegate {
         let user = Keypair::new();
         let user_pubkey = user.pubkey();
         let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
-        let payer_pubkey = payer.pubkey();
 
         asset
             .delegate(
@@ -375,7 +372,7 @@ mod delegate {
 
         // asserts
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &payer_pubkey);
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
 
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();

--- a/token-metadata/program/tests/lock.rs
+++ b/token-metadata/program/tests/lock.rs
@@ -40,7 +40,7 @@ mod lock {
 
         // asserts
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &context.payer.pubkey());
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
 
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
@@ -114,7 +114,7 @@ mod lock {
 
         // asserts
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &context.payer.pubkey());
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
 
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
@@ -229,7 +229,7 @@ mod lock {
 
         // asserts
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &context.payer.pubkey());
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
 
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();

--- a/token-metadata/program/tests/mint.rs
+++ b/token-metadata/program/tests/mint.rs
@@ -9,7 +9,7 @@ mod mint {
 
     use mpl_token_metadata::{error::MetadataError, state::TokenStandard};
     use num_traits::FromPrimitive;
-    use solana_program::{program_pack::Pack, pubkey::Pubkey};
+    use solana_program::program_pack::Pack;
     use spl_token::state::Account;
 
     use super::*;
@@ -29,19 +29,12 @@ mod mint {
         // mints one token
 
         let payer_pubkey = context.payer.pubkey();
-        let (token, _) = Pubkey::find_program_address(
-            &[
-                &payer_pubkey.to_bytes(),
-                &spl_token::id().to_bytes(),
-                &asset.mint.pubkey().to_bytes(),
-            ],
-            &spl_associated_token_account::id(),
-        );
-        asset.token = Some(token);
 
         asset.mint(&mut context, None, None, 1).await.unwrap();
 
-        let account = get_account(&mut context, &token).await;
+        // asserts
+
+        let account = get_account(&mut context, &asset.token.unwrap()).await;
         let token_account = Account::unpack(&account.data).unwrap();
 
         assert!(token_account.is_frozen());

--- a/token-metadata/program/tests/revoke.rs
+++ b/token-metadata/program/tests/revoke.rs
@@ -52,7 +52,6 @@ mod revoke {
         let user = Keypair::new();
         let user_pubkey = user.pubkey();
         let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
-        let payer_pubkey = payer.pubkey();
 
         asset
             .delegate(
@@ -67,7 +66,7 @@ mod revoke {
             .await
             .unwrap();
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &payer_pubkey);
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
 
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
@@ -213,7 +212,6 @@ mod revoke {
         let user = Keypair::new();
         let user_pubkey = user.pubkey();
         let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
-        let payer_pubkey = payer.pubkey();
 
         asset
             .delegate(
@@ -230,7 +228,7 @@ mod revoke {
 
         // checks that the delagate exists
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &payer_pubkey);
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
 
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
@@ -293,7 +291,6 @@ mod revoke {
         let user = Keypair::new();
         let user_pubkey = user.pubkey();
         let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
-        let payer_pubkey = payer.pubkey();
 
         asset
             .delegate(
@@ -310,7 +307,7 @@ mod revoke {
 
         // checks that the delagate exists
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &payer_pubkey);
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
 
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
@@ -366,7 +363,7 @@ mod revoke {
 
         // asserts
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &context.payer.pubkey());
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
 
@@ -377,7 +374,6 @@ mod revoke {
         let user = Keypair::new();
         let user_pubkey = user.pubkey();
         let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
-        let payer_pubkey = payer.pubkey();
 
         asset
             .delegate(
@@ -394,7 +390,7 @@ mod revoke {
 
         // asserts
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &payer_pubkey);
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
 
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();

--- a/token-metadata/program/tests/transfer.rs
+++ b/token-metadata/program/tests/transfer.rs
@@ -229,7 +229,9 @@ mod standard_transfer {
             .await
             .unwrap();
 
-        let delegate_role = da.get_token_delegate_role(&mut context, source_owner).await;
+        let delegate_role = da
+            .get_token_delegate_role(&mut context, &da.token.unwrap())
+            .await;
         // Because this is a pass-through SPL token delegate there will be no role
         // set but the record will still exist.
         assert_eq!(delegate_role, None);
@@ -312,7 +314,9 @@ mod standard_transfer {
             .await
             .unwrap();
 
-        let delegate_role = da.get_token_delegate_role(&mut context, source_owner).await;
+        let delegate_role = da
+            .get_token_delegate_role(&mut context, &da.token.unwrap())
+            .await;
         // Because this is a pass-through SPL token delegate there will be no role
         // set but the record will still exist.
         assert_eq!(delegate_role, None);
@@ -643,10 +647,8 @@ mod auth_rules_transfer {
             .await
             .unwrap();
 
-        let authority = context.payer.dirty_clone();
-
         let delegate_role = nft
-            .get_token_delegate_role(&mut context, &authority.pubkey())
+            .get_token_delegate_role(&mut context, &nft.token.unwrap())
             .await;
 
         assert_eq!(delegate_role, Some(TokenDelegateRole::Transfer));
@@ -804,19 +806,12 @@ mod auth_rules_transfer {
             amount: transfer_amount,
             authorization_data: Some(auth_data.clone()),
         };
-        nft.delegate(
-            &mut context,
-            payer,
-            delegate.pubkey(),
-            delegate_args,
-        )
-        .await
-        .unwrap();
-
-        let authority = context.payer.dirty_clone();
+        nft.delegate(&mut context, payer, delegate.pubkey(), delegate_args)
+            .await
+            .unwrap();
 
         let delegate_role = nft
-            .get_token_delegate_role(&mut context, &authority.pubkey())
+            .get_token_delegate_role(&mut context, &nft.token.unwrap())
             .await;
 
         assert_eq!(delegate_role, Some(TokenDelegateRole::Sale));

--- a/token-metadata/program/tests/unlock.rs
+++ b/token-metadata/program/tests/unlock.rs
@@ -37,7 +37,7 @@ mod utility {
 
         // asserts
 
-        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &context.payer.pubkey());
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
 
         let pda = get_account(&mut context, &pda_key).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();

--- a/token-metadata/program/tests/utils/digital_asset.rs
+++ b/token-metadata/program/tests/utils/digital_asset.rs
@@ -158,7 +158,7 @@ impl DigitalAsset {
             &spl_associated_token_account::id(),
         );
 
-        let (token_record, _) = find_token_record_account(&self.mint.pubkey(), &payer_pubkey);
+        let (token_record, _) = find_token_record_account(&self.mint.pubkey(), &token);
 
         let token_record_opt = if self.is_pnft(context).await {
             Some(token_record)
@@ -258,7 +258,7 @@ impl DigitalAsset {
             | DelegateArgs::UtilityV1 { .. }
             | DelegateArgs::StakingV1 { .. } => {
                 let (token_record, _) =
-                    find_token_record_account(&self.mint.pubkey(), &payer.pubkey());
+                    find_token_record_account(&self.mint.pubkey(), &self.token.unwrap());
                 builder.token_record(token_record);
             }
             DelegateArgs::UpdateV1 { .. } => {
@@ -364,7 +364,7 @@ impl DigitalAsset {
             | RevokeArgs::UtilityV1
             | RevokeArgs::StakingV1 => {
                 let (token_record, _) =
-                    find_token_record_account(&self.mint.pubkey(), &payer.pubkey());
+                    find_token_record_account(&self.mint.pubkey(), &self.token.unwrap());
                 builder.token_record(token_record);
             }
             RevokeArgs::UpdateV1 => {
@@ -447,7 +447,7 @@ impl DigitalAsset {
 
         // This can be optional for non pNFTs but always include it for now.
         let (destination_token_record, _bump) =
-            find_token_record_account(&self.mint.pubkey(), &destination_owner);
+            find_token_record_account(&self.mint.pubkey(), &destination_token);
         builder.destination_token_record(destination_token_record);
 
         if let Some(master_edition) = self.master_edition {
@@ -601,12 +601,12 @@ impl DigitalAsset {
 
         // This can be optional for non pNFTs but always include it for now.
         let (owner_token_record, _bump) =
-            find_token_record_account(&self.mint.pubkey(), source_owner);
+            find_token_record_account(&self.mint.pubkey(), source_token);
         builder.owner_token_record(owner_token_record);
 
         // This can be optional for non pNFTs but always include it for now.
         let (destination_token_record, _bump) =
-            find_token_record_account(&self.mint.pubkey(), &destination_owner);
+            find_token_record_account(&self.mint.pubkey(), &destination_token);
         builder.destination_token_record(destination_token_record);
 
         if let Some(master_edition) = self.master_edition {
@@ -661,10 +661,10 @@ impl DigitalAsset {
     pub async fn get_token_delegate_role(
         &self,
         context: &mut ProgramTestContext,
-        token_owner: &Pubkey,
+        token: &Pubkey,
     ) -> Option<TokenDelegateRole> {
         let (delegate_record_pubkey, _) =
-            find_token_record_account(&self.mint.pubkey(), token_owner);
+            find_token_record_account(&self.mint.pubkey(), token);
         let delegate_record_account = context
             .banks_client
             .get_account(delegate_record_pubkey)


### PR DESCRIPTION
PR to use the token account address as part of the token record seed, given that there is a 1:1 relationship between token account and token record.