### PR TITLE
add ser/deser implementations for pubkeys

### DIFF
--- a/token-metadata/program/src/state/asset_data.rs
+++ b/token-metadata/program/src/state/asset_data.rs
@@ -1,9 +1,7 @@
-use borsh::{BorshDeserialize, BorshSerialize};
 #[cfg(feature = "serde-feature")]
-use serde::{Deserialize, Serialize};
+use super::*;
+use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::pubkey::Pubkey;
-
-use super::{Collection, CollectionDetails, Creator, Data, DataV2, TokenStandard, Uses};
 
 /// Data representation of an asset.
 #[repr(C)]
@@ -11,6 +9,7 @@ use super::{Collection, CollectionDetails, Creator, Data, DataV2, TokenStandard,
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 pub struct AssetData {
     /// Update Authority for the asset.
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub update_authority: Pubkey,
     /// The name of the asset.
     pub name: String,
@@ -35,6 +34,13 @@ pub struct AssetData {
     /// Collection item details.
     pub collection_details: Option<CollectionDetails>,
     /// Programmable rule set for the asset.
+    #[cfg_attr(
+        feature = "serde-feature",
+        serde(
+            deserialize_with = "deser_option_pubkey",
+            serialize_with = "ser_option_pubkey"
+        )
+    )]
     pub rule_set: Option<Pubkey>,
 }
 

--- a/token-metadata/program/src/state/collection.rs
+++ b/token-metadata/program/src/state/collection.rs
@@ -7,6 +7,7 @@ pub const COLLECTION_AUTHORITY_RECORD_SIZE: usize = 35;
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Collection {
     pub verified: bool,
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub key: Pubkey,
 }
 

--- a/token-metadata/program/src/state/delegate.rs
+++ b/token-metadata/program/src/state/delegate.rs
@@ -14,10 +14,13 @@ const SIZE: usize = 98;
 ///     delegate id
 /// ]
 pub struct MetadataDelegateRecord {
-    pub key: Key,                 // 1
-    pub bump: u8,                 // 1
-    pub mint: Pubkey,             // 32
-    pub delegate: Pubkey,         // 32
+    pub key: Key, // 1
+    pub bump: u8, // 1
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
+    pub mint: Pubkey, // 32
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
+    pub delegate: Pubkey, // 32
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub update_authority: Pubkey, // 32
 }
 

--- a/token-metadata/program/src/state/edition.rs
+++ b/token-metadata/program/src/state/edition.rs
@@ -13,6 +13,7 @@ pub struct Edition {
     pub key: Key,
 
     /// Points at MasterEdition struct
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub parent: Pubkey,
 
     /// Starting at 0 for master record, this is incremented for each edition minted.

--- a/token-metadata/program/src/state/metadata.rs
+++ b/token-metadata/program/src/state/metadata.rs
@@ -46,8 +46,10 @@ pub struct Metadata {
     /// Account discriminator.
     pub key: Key,
     /// Address of the update authority.
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub update_authority: Pubkey,
     /// Address of the mint.
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
     pub mint: Pubkey,
     /// Asset data.
     pub data: Data,
@@ -265,6 +267,13 @@ impl borsh::de::BorshDeserialize for Metadata {
 pub enum ProgrammableConfig {
     V1 {
         /// Programmable authorization rules.
+        #[cfg_attr(
+            feature = "serde-feature",
+            serde(
+                deserialize_with = "deser_option_pubkey",
+                serialize_with = "ser_option_pubkey"
+            )
+        )]
         rule_set: Option<Pubkey>,
     },
 }

--- a/token-metadata/program/src/state/mod.rs
+++ b/token-metadata/program/src/state/mod.rs
@@ -38,10 +38,10 @@ use solana_program::{
     pubkey::Pubkey,
 };
 pub use uses::*;
-#[cfg(feature = "serde-feature")]
 use {
-    serde::{Deserialize, Serialize},
+    serde::{Deserialize, Deserializer, Serialize},
     serde_with::{As, DisplayFromStr},
+    std::str::FromStr,
 };
 
 // Re-export constants to maintain compatibility.
@@ -134,4 +134,24 @@ pub enum Key {
     TokenOwnedEscrow,
     TokenRecord,
     MetadataDelegate,
+}
+
+#[cfg(feature = "serde-feature")]
+fn deser_option_pubkey<'de, D>(deserializer: D) -> Result<Option<Pubkey>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    <Option<String> as serde::de::Deserialize>::deserialize(deserializer)?
+        .map(|s| Pubkey::from_str(&s))
+        .transpose()
+        .map_err(serde::de::Error::custom)
+}
+
+#[cfg(feature = "serde-feature")]
+fn ser_option_pubkey<S>(pubkey: &Option<Pubkey>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let pubkey_string = pubkey.as_ref().map(|p| p.to_string());
+    serde::ser::Serialize::serialize(&pubkey_string, serializer)
 }

--- a/token-metadata/program/src/state/programmable.rs
+++ b/token-metadata/program/src/state/programmable.rs
@@ -13,7 +13,7 @@ use solana_program::{
 };
 use spl_token::state::Account;
 
-use super::{Key, MetadataDelegateRecord, TokenMetadataAccount};
+use super::*;
 use crate::instruction::MetadataDelegateRole;
 use crate::pda::{find_metadata_delegate_record_account, find_token_record_account};
 use crate::state::BorshError;
@@ -48,6 +48,13 @@ pub struct TokenRecord {
     pub bump: u8,
     pub state: TokenState,
     pub rule_set_revision: Option<u64>,
+    #[cfg_attr(
+        feature = "serde-feature",
+        serde(
+            deserialize_with = "deser_option_pubkey",
+            serialize_with = "ser_option_pubkey"
+        )
+    )]
     pub delegate: Option<Pubkey>,
     pub delegate_role: Option<TokenDelegateRole>,
 }


### PR DESCRIPTION
Allow conditional compilation serde implementations for `Pubkey`s to serialize into and from strings instead of `u8` arrays.

This adds support for most public `Pubkey` and `Option<Pubkey>` types, but not all of them. Escrow, notably, is left out as it has a wrapper around its Pubkey. We can add support for this later as it won't be a breaking change. 