### PR TITLE
No default for optional accounts

### DIFF
--- a/token-metadata/program/tests/utils/digital_asset.rs
+++ b/token-metadata/program/tests/utils/digital_asset.rs
@@ -241,7 +241,8 @@ impl DigitalAsset {
             .mint(self.mint.pubkey())
             .metadata(self.metadata)
             .payer(payer.pubkey())
-            .authority(payer.pubkey());
+            .authority(payer.pubkey())
+            .spl_token_program(spl_token::ID);
 
         match args {
             DelegateArgs::CollectionV1 { .. } => {
@@ -290,6 +291,7 @@ impl DigitalAsset {
         }) = metadata.programmable_config
         {
             builder.authorization_rules(rule_set);
+            builder.authorization_rules_program(mpl_token_auth_rules::ID);
         }
 
         let delegate_ix = builder.build(args.clone()).unwrap().instruction();
@@ -484,7 +486,8 @@ impl DigitalAsset {
             .authority(delegate.pubkey())
             .mint(self.mint.pubkey())
             .metadata(self.metadata)
-            .payer(payer.pubkey());
+            .payer(payer.pubkey())
+            .spl_token_program(spl_token::ID);
 
         if let Some(token_record) = token_record {
             builder.token_record(token_record);
@@ -527,7 +530,8 @@ impl DigitalAsset {
             .authority(delegate.pubkey())
             .mint(self.mint.pubkey())
             .metadata(self.metadata)
-            .payer(payer.pubkey());
+            .payer(payer.pubkey())
+            .spl_token_program(spl_token::ID);
 
         if let Some(token_record) = token_record {
             builder.token_record(token_record);

--- a/token-metadata/program/tests/utils/digital_asset.rs
+++ b/token-metadata/program/tests/utils/digital_asset.rs
@@ -349,7 +349,8 @@ impl DigitalAsset {
             .mint(self.mint.pubkey())
             .metadata(self.metadata)
             .payer(approver.pubkey())
-            .authority(approver.pubkey());
+            .authority(approver.pubkey())
+            .spl_token_program(spl_token::ID);
 
         match args {
             RevokeArgs::CollectionV1 => {
@@ -458,6 +459,7 @@ impl DigitalAsset {
 
         if let Some(authorization_rules) = authorization_rules {
             builder.authorization_rules(authorization_rules);
+            builder.authorization_rules_program(mpl_token_auth_rules::ID);
         }
 
         let transfer_ix = builder.build(args).unwrap().instruction();
@@ -619,6 +621,7 @@ impl DigitalAsset {
 
         if let Some(authorization_rules) = authorization_rules {
             builder.authorization_rules(authorization_rules);
+            builder.authorization_rules_program(mpl_token_auth_rules::ID);
         }
 
         let transfer_ix = builder.build(args).unwrap().instruction();


### PR DESCRIPTION
This PR changes the way the macro handles default values for optional accounts. Currently, a default value will be added when the optional account is not set. This creates an undesirable behaviour since optional accounts will be present in the transaction: (1) they will take more space on the transaction; and (2) when used on a CPI call, they will need to be added to the outer instruction.

The solution is to only use the default value for required accounts, when accounts are not set.

For required accounts, the code generated is:
```rust
system_program: self.system_program.unwrap_or(solana_program::system_program::ID)
```

For optional accounts, the code generated is (even when the name of the account matches one of the default ones):
```rust
authorization_rules_program: self.authorization_rules_program
```