### PR TITLE
Add transfer test with lookup table

### DIFF
--- a/token-metadata/js/test/setup/index.ts
+++ b/token-metadata/js/test/setup/index.ts
@@ -3,6 +3,7 @@ import test from 'tape';
 export * from './amman';
 export * from './txs-init';
 export * from './log';
+export * from './lut';
 
 export function killStuckProcess() {
   test.onFinish(() => process.exit(0));

--- a/token-metadata/js/test/setup/lut.ts
+++ b/token-metadata/js/test/setup/lut.ts
@@ -23,7 +23,7 @@ export async function createLookupTable(
   connection: Connection,
 ): Promise<{ tx: ConfirmedTransactionAssertablePromise; lookupTable: PublicKey }> {
   // get current `slot`
-  let slot = await connection.getSlot();
+  const slot = await connection.getSlot();
 
   // create an Address Lookup Table
   const [lookupTableIx, address] = AddressLookupTableProgram.createLookupTable({
@@ -63,7 +63,7 @@ export async function createAndSendV0Tx(
   connection: Connection,
   lookupTables: AddressLookupTableAccount[] = [],
 ): Promise<{ response: RpcResponseAndContext<SignatureResult>; signature: string }> {
-  let latestBlockhash = await connection.getLatestBlockhash('finalized');
+  const latestBlockhash = await connection.getLatestBlockhash('finalized');
 
   const messageV0 = new TransactionMessage({
     payerKey: payer.publicKey,

--- a/token-metadata/js/test/setup/lut.ts
+++ b/token-metadata/js/test/setup/lut.ts
@@ -1,0 +1,88 @@
+import {
+  ConfirmedTransactionAssertablePromise,
+  PayerTransactionHandler,
+} from '@metaplex-foundation/amman-client';
+import {
+  AddressLookupTableAccount,
+  AddressLookupTableProgram,
+  Connection,
+  Keypair,
+  PublicKey,
+  RpcResponseAndContext,
+  SignatureResult,
+  Transaction,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
+
+export async function createLookupTable(
+  authority: PublicKey,
+  payer: Keypair,
+  handler: PayerTransactionHandler,
+  connection: Connection,
+): Promise<{ tx: ConfirmedTransactionAssertablePromise; lookupTable: PublicKey }> {
+  // get current `slot`
+  let slot = await connection.getSlot();
+
+  // create an Address Lookup Table
+  const [lookupTableIx, address] = AddressLookupTableProgram.createLookupTable({
+    authority: authority,
+    payer: payer.publicKey,
+    recentSlot: slot,
+  });
+
+  const tx = new Transaction().add(lookupTableIx);
+  // send the transaction
+  return {
+    tx: handler.sendAndConfirmTransaction(tx, [payer], 'tx: Create Lookup Table'),
+    lookupTable: address,
+  };
+}
+
+export async function addAddressesToTable(
+  lookupTable: PublicKey,
+  authority: PublicKey,
+  payer: Keypair,
+  addresses: PublicKey[],
+  connection: Connection,
+): Promise<{ response: RpcResponseAndContext<SignatureResult>; signature: string }> {
+  const addAddressesInstruction = AddressLookupTableProgram.extendLookupTable({
+    payer: payer.publicKey,
+    authority,
+    lookupTable,
+    addresses,
+  });
+
+  return await createAndSendV0Tx(payer, [addAddressesInstruction], connection);
+}
+
+export async function createAndSendV0Tx(
+  payer: Keypair,
+  instructions: TransactionInstruction[],
+  connection: Connection,
+  lookupTables: AddressLookupTableAccount[] = [],
+): Promise<{ response: RpcResponseAndContext<SignatureResult>; signature: string }> {
+  let latestBlockhash = await connection.getLatestBlockhash('finalized');
+
+  const messageV0 = new TransactionMessage({
+    payerKey: payer.publicKey,
+    recentBlockhash: latestBlockhash.blockhash,
+    instructions,
+  }).compileToV0Message(lookupTables);
+
+  // creates the versioned transaction
+  const transaction = new VersionedTransaction(messageV0);
+  //console.log('Transaction size with address lookup: ' + transaction.serialize().length + ' bytes');
+  transaction.sign([payer]);
+
+  const signature = await connection.sendTransaction(transaction, { maxRetries: 5 });
+
+  const response = await connection.confirmTransaction({
+    signature,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  });
+
+  return { response, signature };
+}

--- a/token-metadata/js/test/setup/txs-init.ts
+++ b/token-metadata/js/test/setup/txs-init.ts
@@ -734,4 +734,52 @@ export class InitTransactions {
       token: token.publicKey,
     };
   }
+
+  async getTransferInstruction(
+    authority: Keypair,
+    tokenOwner: PublicKey,
+    token: PublicKey,
+    mint: PublicKey,
+    metadata: PublicKey,
+    edition: PublicKey,
+    destinationOwner: PublicKey,
+    destination: PublicKey,
+    authorizationRules: PublicKey,
+    amount: number,
+    handler: PayerTransactionHandler,
+    tokenRecord: PublicKey | null = null,
+    destinationTokenRecord: PublicKey | null = null,
+  ): Promise<{ instruction: TransactionInstruction }> {
+    const transferAcccounts: TransferInstructionAccounts = {
+      authority: authority.publicKey,
+      tokenOwner,
+      token,
+      metadata,
+      mint,
+      edition,
+      destinationOwner,
+      destination,
+      payer: authority.publicKey,
+      splTokenProgram: splToken.TOKEN_PROGRAM_ID,
+      splAtaProgram: splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
+      systemProgram: SystemProgram.programId,
+      sysvarInstructions: SYSVAR_INSTRUCTIONS_PUBKEY,
+      authorizationRules,
+      authorizationRulesProgram: TOKEN_AUTH_RULES_ID,
+      ownerTokenRecord: tokenRecord,
+      destinationTokenRecord,
+    };
+
+    const transferArgs: TransferInstructionArgs = {
+      transferArgs: {
+        __kind: 'V1',
+        amount,
+        authorizationData: null,
+      },
+    };
+
+    const instruction = createTransferInstruction(transferAcccounts, transferArgs);
+
+    return { instruction };
+  }
 }


### PR DESCRIPTION
This PR adds a test showing how an address lookup table (LUT) can be used to reduce the transaction size of the transfer instruction. The test adds 8 accounts to the LUT:
1. `owner`
2. `owner token record`
3. `token`
4. `mint`
5. `metadata`
6. `master edition`
7.  `rule set PDA`
8. `SYSVAR_INSTRUCTIONS_PUBKEY`

Bigger transaction size reductions can be achieved if more accounts are added to the LUT.