### PR TITLE
Add address lookup table creation to mint instruction

### DIFF
--- a/token-metadata/Cargo.lock
+++ b/token-metadata/Cargo.lock
@@ -1993,6 +1993,7 @@ dependencies = [
  "serde",
  "serde_with",
  "shank 0.0.11",
+ "solana-address-lookup-table-program",
  "solana-program",
  "solana-program-test",
  "solana-sdk",

--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -2588,6 +2588,20 @@
           "isSigner": false,
           "desc": "Token Authorization Rules account",
           "optional": true
+        },
+        {
+          "name": "addressLookupTableProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Address Lookup Table program",
+          "optional": true
+        },
+        {
+          "name": "addressLookupTable",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Address Lookup Table account",
+          "optional": true
         }
       ],
       "args": [
@@ -4738,6 +4752,12 @@
                     "defined": "AuthorizationData"
                   }
                 }
+              },
+              {
+                "name": "recent_slot",
+                "type": {
+                  "option": "u64"
+                }
               }
             ]
           }
@@ -6153,6 +6173,16 @@
       "code": 168,
       "name": "AmountMustBeGreaterThanZero",
       "msg": "Amount must be greater than zero"
+    },
+    {
+      "code": 169,
+      "name": "MissingRecentSlot",
+      "msg": "Missing recent slot argument for LUT creation"
+    },
+    {
+      "code": 170,
+      "name": "InvalidAddessLookupTableAuthority",
+      "msg": "Invalid LUT authority"
     }
   ],
   "metadata": {

--- a/token-metadata/js/src/generated/errors/index.ts
+++ b/token-metadata/js/src/generated/errors/index.ts
@@ -3617,6 +3617,49 @@ createErrorFromNameLookup.set(
 );
 
 /**
+ * MissingRecentSlot: 'Missing recent slot argument for LUT creation'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class MissingRecentSlotError extends Error {
+  readonly code: number = 0xa9;
+  readonly name: string = 'MissingRecentSlot';
+  constructor() {
+    super('Missing recent slot argument for LUT creation');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, MissingRecentSlotError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0xa9, () => new MissingRecentSlotError());
+createErrorFromNameLookup.set('MissingRecentSlot', () => new MissingRecentSlotError());
+
+/**
+ * InvalidAddessLookupTableAuthority: 'Invalid LUT authority'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class InvalidAddessLookupTableAuthorityError extends Error {
+  readonly code: number = 0xaa;
+  readonly name: string = 'InvalidAddessLookupTableAuthority';
+  constructor() {
+    super('Invalid LUT authority');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, InvalidAddessLookupTableAuthorityError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0xaa, () => new InvalidAddessLookupTableAuthorityError());
+createErrorFromNameLookup.set(
+  'InvalidAddessLookupTableAuthority',
+  () => new InvalidAddessLookupTableAuthorityError(),
+);
+
+/**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors
  * @category generated

--- a/token-metadata/js/src/generated/instructions/Mint.ts
+++ b/token-metadata/js/src/generated/instructions/Mint.ts
@@ -50,6 +50,8 @@ export const MintStruct = new beet.FixableBeetArgsStruct<
  * @property [] splAtaProgram SPL Associated Token Account program
  * @property [] authorizationRulesProgram (optional) Token Authorization Rules program
  * @property [] authorizationRules (optional) Token Authorization Rules account
+ * @property [] addressLookupTableProgram (optional) Address Lookup Table program
+ * @property [_writable_] addressLookupTable (optional) Address Lookup Table account
  * @category Instructions
  * @category Mint
  * @category generated
@@ -70,6 +72,8 @@ export type MintInstructionAccounts = {
   splAtaProgram: web3.PublicKey;
   authorizationRulesProgram?: web3.PublicKey;
   authorizationRules?: web3.PublicKey;
+  addressLookupTableProgram?: web3.PublicKey;
+  addressLookupTable?: web3.PublicKey;
 };
 
 export const mintInstructionDiscriminator = 43;
@@ -170,6 +174,16 @@ export function createMintInstruction(
     {
       pubkey: accounts.authorizationRules ?? programId,
       isWritable: false,
+      isSigner: false,
+    },
+    {
+      pubkey: accounts.addressLookupTableProgram ?? programId,
+      isWritable: false,
+      isSigner: false,
+    },
+    {
+      pubkey: accounts.addressLookupTable ?? programId,
+      isWritable: accounts.addressLookupTable != null,
       isSigner: false,
     },
   ];

--- a/token-metadata/js/src/generated/types/MintArgs.ts
+++ b/token-metadata/js/src/generated/types/MintArgs.ts
@@ -17,7 +17,11 @@ import { AuthorizationData, authorizationDataBeet } from './AuthorizationData';
  * @private
  */
 export type MintArgsRecord = {
-  V1: { amount: beet.bignum; authorizationData: beet.COption<AuthorizationData> };
+  V1: {
+    amount: beet.bignum;
+    authorizationData: beet.COption<AuthorizationData>;
+    recentSlot: beet.COption<beet.bignum>;
+  };
 };
 
 /**
@@ -46,6 +50,7 @@ export const mintArgsBeet = beet.dataEnum<MintArgsRecord>([
       [
         ['amount', beet.u64],
         ['authorizationData', beet.coption(authorizationDataBeet)],
+        ['recentSlot', beet.coption(beet.u64)],
       ],
       'MintArgsRecord["V1"]',
     ),

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0.149", optional = true }
 serde_with = { version = "1.14.0", optional = true }
 mpl-utils = { version = "0.0.6", path="../../core/rust/utils" }
 mpl-token-metadata-context-derive = { version = "0.2.0", path = "../macro" }
+solana-address-lookup-table-program = "1.14"
 
 [dev-dependencies]
 rmp-serde = "1.1.1"

--- a/token-metadata/program/src/error.rs
+++ b/token-metadata/program/src/error.rs
@@ -667,6 +667,14 @@ pub enum MetadataError {
     /// 168
     #[error("Amount must be greater than zero")]
     AmountMustBeGreaterThanZero,
+
+    /// 169
+    #[error("Missing recent slot argument for LUT creation")]
+    MissingRecentSlot,
+
+    /// 170
+    #[error("Invalid LUT authority")]
+    InvalidAddessLookupTableAuthority,
 }
 
 impl PrintProgramError for MetadataError {

--- a/token-metadata/program/src/instruction/metadata.rs
+++ b/token-metadata/program/src/instruction/metadata.rs
@@ -55,6 +55,8 @@ pub enum MintArgs {
         amount: u64,
         /// Required authorization data to validate the request.
         authorization_data: Option<AuthorizationData>,
+        /// Required if initializing a address lookup table.
+        recent_slot: Option<u64>,
     },
 }
 
@@ -593,6 +595,17 @@ impl InstructionBuilder for super::builders::Mint {
         if let Some(rules) = &self.authorization_rules {
             accounts.push(AccountMeta::new_readonly(mpl_token_auth_rules::ID, false));
             accounts.push(AccountMeta::new_readonly(*rules, false));
+        } else {
+            accounts.push(AccountMeta::new_readonly(crate::ID, false));
+            accounts.push(AccountMeta::new_readonly(crate::ID, false));
+        }
+        // Optional address lookup table
+        if let Some(lookup_table) = &self.address_lookup_table {
+            accounts.push(AccountMeta::new_readonly(
+                solana_address_lookup_table_program::ID,
+                false,
+            ));
+            accounts.push(AccountMeta::new(*lookup_table, false));
         } else {
             accounts.push(AccountMeta::new_readonly(crate::ID, false));
             accounts.push(AccountMeta::new_readonly(crate::ID, false));

--- a/token-metadata/program/src/instruction/mod.rs
+++ b/token-metadata/program/src/instruction/mod.rs
@@ -556,6 +556,8 @@ pub enum MetadataInstruction {
     #[account(12, name="spl_ata_program", desc="SPL Associated Token Account program")]
     #[account(13, optional, name="authorization_rules_program", desc="Token Authorization Rules program")]
     #[account(14, optional, name="authorization_rules", desc="Token Authorization Rules account")]
+    #[account(15, optional, name="address_lookup_table_program", desc="Address Lookup Table program")]
+    #[account(16, optional, writable, name="address_lookup_table", desc="Address Lookup Table account")]
     #[default_optional_accounts]
     Mint(MintArgs),
 

--- a/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/token-metadata/program/src/processor/delegate/delegate.rs
@@ -268,7 +268,7 @@ fn create_persistent_delegate_v1(
 
             token_record.delegate = Some(*ctx.accounts.delegate_info.key);
             token_record.delegate_role = Some(role);
-            token_record.save(*token_record_info.try_borrow_mut_data()?)?;
+            token_record.save(&mut token_record_info.try_borrow_mut_data()?)?;
 
             if let Some(master_edition_info) = ctx.accounts.master_edition_info {
                 assert_owned_by(master_edition_info, &crate::ID)?;

--- a/token-metadata/program/src/processor/delegate/revoke.rs
+++ b/token-metadata/program/src/processor/delegate/revoke.rs
@@ -220,7 +220,7 @@ fn revoke_persistent_delegate(
                 if token_record.delegate_role == Some(role) {
                     // resets the token record (state, rule_set_revision and delegate info)
                     token_record.reset();
-                    token_record.save(*token_record_info.try_borrow_mut_data()?)?;
+                    token_record.save(&mut token_record_info.try_borrow_mut_data()?)?;
                 } else {
                     return Err(MetadataError::InvalidDelegate.into());
                 }

--- a/token-metadata/program/src/processor/metadata/migrate.rs
+++ b/token-metadata/program/src/processor/metadata/migrate.rs
@@ -211,7 +211,7 @@ pub fn migrate_v1(program_id: &Pubkey, ctx: Context<Migrate>, args: MigrateArgs)
                 token_record.delegate_role = Some(TokenDelegateRole::Migration);
             }
 
-            token_record.save(*ctx.accounts.token_record_info.try_borrow_mut_data()?)?;
+            token_record.save(&mut ctx.accounts.token_record_info.try_borrow_mut_data()?)?;
 
             // Migrate the token.
             metadata.token_standard = Some(TokenStandard::ProgrammableNonFungible);

--- a/token-metadata/program/tests/utils/digital_asset.rs
+++ b/token-metadata/program/tests/utils/digital_asset.rs
@@ -188,6 +188,7 @@ impl DigitalAsset {
             .build(MintArgs::V1 {
                 amount,
                 authorization_data,
+                recent_slot: None,
             })
             .unwrap()
             .instruction();


### PR DESCRIPTION
This PR adds the creation of a lookup table (LUT) during the mint of a Programmable NFT. The advantage of this approach is that the lookup table will be ready to be used by any client and can be queried from the associated token record PDA.

The table contains the addresses of 7 accounts:
1. token owner
2. token
3. metadata
4. master edition
5. mint
6. token record
7. sysvar instructions

When a `pNFT` is transferred, the sender LUT can be closed and a new LUT for the receiver can be created.