### PR TITLE
Remove unused update authority

### DIFF
--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -4163,10 +4163,6 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "updateAuthority",
-            "type": "publicKey"
-          },
-          {
             "name": "name",
             "type": "string"
           },

--- a/token-metadata/js/src/generated/types/AssetData.ts
+++ b/token-metadata/js/src/generated/types/AssetData.ts
@@ -5,8 +5,8 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as web3 from '@solana/web3.js';
 import * as beet from '@metaplex-foundation/beet';
+import * as web3 from '@solana/web3.js';
 import * as beetSolana from '@metaplex-foundation/beet-solana';
 import { Creator, creatorBeet } from './Creator';
 import { TokenStandard, tokenStandardBeet } from './TokenStandard';
@@ -14,7 +14,6 @@ import { Collection, collectionBeet } from './Collection';
 import { Uses, usesBeet } from './Uses';
 import { CollectionDetails, collectionDetailsBeet } from './CollectionDetails';
 export type AssetData = {
-  updateAuthority: web3.PublicKey;
   name: string;
   symbol: string;
   uri: string;
@@ -35,7 +34,6 @@ export type AssetData = {
  */
 export const assetDataBeet = new beet.FixableBeetArgsStruct<AssetData>(
   [
-    ['updateAuthority', beetSolana.publicKey],
     ['name', beet.utf8String],
     ['symbol', beet.utf8String],
     ['uri', beet.utf8String],

--- a/token-metadata/js/test/create.test.ts
+++ b/token-metadata/js/test/create.test.ts
@@ -25,7 +25,6 @@ test('Create: ProgrammableNonFungible', async (t) => {
     symbol: 'PNF',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -78,7 +77,6 @@ test('Create: ProgrammableNonFungible with existing mint account', async (t) => 
     symbol: 'PNF',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -164,7 +162,6 @@ test('Create: fail to create ProgrammableNonFungible with minted mint account', 
     symbol: 'PNF',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -195,7 +192,6 @@ test('Create: failt to create ProgrammableNonFungible with existing metadata acc
     symbol: 'PNF',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -251,7 +247,6 @@ test('Create: failt to create ProgrammableNonFungible with existing master editi
     symbol: 'PNF',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -317,7 +312,6 @@ test('Create: fail to create ProgrammableNonFungible without master edition', as
     symbol: 'PNF',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -361,7 +355,6 @@ test('Create: fail to create NonFungible without master edition', async (t) => {
     symbol: 'NF',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -435,7 +428,6 @@ test('Create: create NonFungible with minted mint account', async (t) => {
     symbol: 'NF',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -521,7 +513,6 @@ test('Create: fail to create NonFungible with more than 2 mints', async (t) => {
     symbol: 'NF',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -552,7 +543,6 @@ test('Create: Fungible', async (t) => {
     symbol: 'FUN',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -610,7 +600,6 @@ test('Create: FungibleAsset', async (t) => {
     symbol: 'FA',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -700,7 +689,6 @@ test('Create: create Fungible with minted mint account', async (t) => {
     symbol: 'FUN',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -786,7 +774,6 @@ test('Create: create FungibleAsset with minted mint account', async (t) => {
     symbol: 'FA',
     uri: 'uri',
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,

--- a/token-metadata/js/test/mint.test.ts
+++ b/token-metadata/js/test/mint.test.ts
@@ -15,7 +15,6 @@ test('Mint: ProgrammableNonFungible', async (t) => {
   const { fstTxHandler: handler, payerPair: payer, connection } = await API.payer();
 
   const data: AssetData = {
-    updateAuthority: payer.publicKey,
     name: 'ProgrammableNonFungible',
     symbol: 'PNF',
     uri: 'uri',
@@ -77,7 +76,6 @@ test('Mint: ProgrammableNonFungible with existing token account', async (t) => {
   const { fstTxHandler: handler, payerPair: payer, connection } = await API.payer();
 
   const data: AssetData = {
-    updateAuthority: payer.publicKey,
     name: 'ProgrammableNonFungible',
     symbol: 'PNF',
     uri: 'uri',
@@ -151,7 +149,6 @@ test('Mint: fail to mint zero (0) tokens from ProgrammableNonFungible', async (t
   const { fstTxHandler: handler, payerPair: payer, connection } = await API.payer();
 
   const data: AssetData = {
-    updateAuthority: payer.publicKey,
     name: 'ProgrammableNonFungible',
     symbol: 'PNF',
     uri: 'uri',
@@ -203,7 +200,6 @@ test('Mint: fail to mint multiple from ProgrammableNonFungible', async (t) => {
   const { fstTxHandler: handler, payerPair: payer, connection } = await API.payer();
 
   const data: AssetData = {
-    updateAuthority: payer.publicKey,
     name: 'ProgrammableNonFungible',
     symbol: 'PNF',
     uri: 'uri',

--- a/token-metadata/js/test/transfer.test.ts
+++ b/token-metadata/js/test/transfer.test.ts
@@ -1056,7 +1056,7 @@ test('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
   );
 });
 
-test.only('Transfer: ProgrammableNonFungible with address lookup table (LUT)', async (t) => {
+test('Transfer: ProgrammableNonFungible with address lookup table (LUT)', async (t) => {
   const API = new InitTransactions();
   const { fstTxHandler: handler, payerPair: payer, connection } = await API.payer();
 

--- a/token-metadata/js/test/update.test.ts
+++ b/token-metadata/js/test/update.test.ts
@@ -757,7 +757,6 @@ test('Update: Update Unverified Collection Key', async (t) => {
     symbol,
     uri,
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -839,7 +838,6 @@ test('Update: Fail to Verify an Unverified Collection', async (t) => {
     symbol,
     uri,
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,
@@ -922,7 +920,6 @@ test('Update: Fail to Update a Verified Collection', async (t) => {
     symbol,
     uri,
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,

--- a/token-metadata/js/test/utils/digital-asset-manager.ts
+++ b/token-metadata/js/test/utils/digital-asset-manager.ts
@@ -33,7 +33,6 @@ export class DigitalAssetManager {
       symbol: md.data.symbol,
       uri: md.data.uri,
       sellerFeeBasisPoints: md.data.sellerFeeBasisPoints,
-      updateAuthority: md.updateAuthority,
       creators: md.data.creators,
       primarySaleHappened: md.primarySaleHappened,
       isMutable: md.isMutable,
@@ -65,7 +64,6 @@ export async function createDefaultAsset(
     symbol,
     uri,
     sellerFeeBasisPoints: 0,
-    updateAuthority: payer.publicKey,
     creators: [
       {
         address: payer.publicKey,

--- a/token-metadata/program/src/state/asset_data.rs
+++ b/token-metadata/program/src/state/asset_data.rs
@@ -7,9 +7,6 @@ use solana_program::pubkey::Pubkey;
 #[cfg_attr(feature = "serde-feature", derive(Serialize, Deserialize))]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 pub struct AssetData {
-    /// Update Authority for the asset.
-    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
-    pub update_authority: Pubkey,
     /// The name of the asset.
     pub name: String,
     /// The symbol for the asset.
@@ -49,14 +46,12 @@ impl AssetData {
         name: String,
         symbol: String,
         uri: String,
-        update_authority: Pubkey,
     ) -> Self {
         Self {
             name,
             symbol,
             uri,
             seller_fee_basis_points: 0,
-            update_authority,
             creators: None,
             primary_sale_happened: false,
             is_mutable: true,

--- a/token-metadata/program/src/state/metadata.rs
+++ b/token-metadata/program/src/state/metadata.rs
@@ -201,7 +201,6 @@ impl Metadata {
             self.data.name,
             self.data.symbol,
             self.data.uri,
-            self.update_authority,
         );
         asset_data.seller_fee_basis_points = self.data.seller_fee_basis_points;
         asset_data.creators = self.data.creators;

--- a/token-metadata/program/tests/create.rs
+++ b/token-metadata/program/tests/create.rs
@@ -44,7 +44,6 @@ mod create {
             name.clone(),
             symbol.clone(),
             uri.clone(),
-            context.payer.pubkey(),
         );
         asset.seller_fee_basis_points = 500;
         asset.rule_set =
@@ -146,7 +145,6 @@ mod create {
             name.clone(),
             symbol.clone(),
             uri.clone(),
-            context.payer.pubkey(),
         );
         asset.seller_fee_basis_points = 500;
         /*
@@ -250,7 +248,6 @@ mod create {
             name.clone(),
             symbol.clone(),
             uri.clone(),
-            context.payer.pubkey(),
         );
         asset.seller_fee_basis_points = 500;
         /*

--- a/token-metadata/program/tests/utils/digital_asset.rs
+++ b/token-metadata/program/tests/utils/digital_asset.rs
@@ -75,7 +75,6 @@ impl DigitalAsset {
             String::from(DEFAULT_NAME),
             String::from(DEFAULT_SYMBOL),
             String::from(DEFAULT_URI),
-            context.payer.pubkey(),
         );
         asset.seller_fee_basis_points = 500;
 


### PR DESCRIPTION
`AssetData` required the `update_authority` pubkey but it was not used – this PR removes it.