### PR TITLE
Bump auth rules version

### DIFF
--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.14"
 spl-token = { version = "3.2.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "1.1.1", features = ["no-entrypoint"] }
-mpl-token-auth-rules = { version = "0.2.5", features = ["no-entrypoint"] }
+mpl-token-auth-rules = { version = "1.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 borsh = "0.9.2"
 shank = { version = "0.0.11" }


### PR DESCRIPTION
Bump Token Authorization Rules crate to `v1.0`.