### PR TITLE
bump mpl-utils version to reduce binary size

### DIFF
--- a/token-metadata/Cargo.lock
+++ b/token-metadata/Cargo.lock
@@ -1967,7 +1967,7 @@ dependencies = [
  "borsh",
  "mpl-token-auth-rules",
  "mpl-token-metadata-context-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mpl-utils 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mpl-utils 0.0.6",
  "num-derive",
  "num-traits",
  "shank 0.0.11",
@@ -1985,7 +1985,7 @@ dependencies = [
  "borsh",
  "mpl-token-auth-rules",
  "mpl-token-metadata-context-derive 0.2.1",
- "mpl-utils 0.0.6",
+ "mpl-utils 0.1.0",
  "num-derive",
  "num-traits",
  "rmp-serde",
@@ -2034,6 +2034,8 @@ dependencies = [
 [[package]]
 name = "mpl-utils"
 version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6195ce98b92f1d0ea06d0cc9b2392d81673e02b8fb063589926fa73ee6b071a"
 dependencies = [
  "arrayref",
  "borsh",
@@ -2043,9 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-utils"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6195ce98b92f1d0ea06d0cc9b2392d81673e02b8fb063589926fa73ee6b071a"
+version = "0.1.0"
 dependencies = [
  "arrayref",
  "borsh",

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -26,7 +26,7 @@ borsh = "0.9.2"
 shank = { version = "0.0.11" }
 serde = { version = "1.0.149", optional = true }
 serde_with = { version = "1.14.0", optional = true }
-mpl-utils = { version = "0.0.6", path="../../core/rust/utils" }
+mpl-utils = { version = "0.1.0", path="../../core/rust/utils" }
 mpl-token-metadata-context-derive = { version = "0.2.1", path = "../macro" }
 
 [dev-dependencies]


### PR DESCRIPTION
This reduces the Token Metadata binary size from 690,120 to 666,728 bytes by bumping to a version of `mpl-utils` that does not force inlining of functions. Thanks to @blockiosaurus for the work figuring out how to reduce binary size.