### PR TITLE
Add validation of authorization rules on delegate

### DIFF
--- a/token-metadata/js/test/delegate.test.ts
+++ b/token-metadata/js/test/delegate.test.ts
@@ -16,6 +16,8 @@ import { BN } from 'bn.js';
 import { getAccount } from '@solana/spl-token';
 import { PublicKey } from '@solana/web3.js';
 import { findTokenRecordPda } from './utils/programmable';
+import { PROGRAM_ID as TOKEN_AUTH_RULES_ID } from '@metaplex-foundation/mpl-token-auth-rules';
+import { encode } from '@msgpack/msgpack';
 
 killStuckProcess();
 
@@ -579,4 +581,205 @@ test('Delegate: create locked transfer delegate', async (t) => {
     delegateRole: TokenDelegateRole.LockedTransfer,
     lockedTransfer: spokSamePubkey(PublicKey.default),
   });
+});
+
+test('Delegate: create sale delegate with auth rules', async (t) => {
+  const API = new InitTransactions();
+  const { fstTxHandler: handler, payerPair: payer, connection } = await API.payer();
+
+  // creates the auth rules for the delegate
+
+  const ruleSetName = 'delegate_test';
+  const ruleSetTokenMetadata = {
+    libVersion: 1,
+    ruleSetName: ruleSetName,
+    owner: Array.from(payer.publicKey.toBytes()),
+    operations: {
+      'Delegate:Sale': {
+        All: {
+          rules: [
+            {
+              ProgramOwned: {
+                program: Array.from(PROGRAM_ID.toBytes()),
+                field: 'Delegate',
+              },
+            },
+            {
+              Amount: {
+                amount: 1,
+                operator: 2,
+                field: 'Amount',
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  const [ruleSetPda] = PublicKey.findProgramAddressSync(
+    [Buffer.from('rule_set'), payer.publicKey.toBuffer(), Buffer.from(ruleSetName)],
+    TOKEN_AUTH_RULES_ID,
+  );
+
+  const { tx: createRuleSetTx } = await API.createRuleSet(
+    t,
+    payer,
+    ruleSetPda,
+    encode(ruleSetTokenMetadata),
+    handler,
+  );
+  await createRuleSetTx.assertSuccess(t);
+
+  const manager = await createAndMintDefaultAsset(
+    t,
+    connection,
+    API,
+    handler,
+    payer,
+    TokenStandard.ProgrammableNonFungible,
+    ruleSetPda,
+  );
+
+  // creates a delegate
+
+  // token record PDA (using metadata as delegate)
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
+  amman.addr.addLabel('Token Record', tokenRecord);
+
+  const args: DelegateArgs = {
+    __kind: 'SaleV1',
+    amount: 1,
+    authorizationData: null,
+  };
+
+  const { tx: delegateTx } = await API.delegate(
+    manager.metadata,
+    manager.mint,
+    manager.metadata,
+    payer.publicKey,
+    payer,
+    args,
+    handler,
+    null,
+    manager.masterEdition,
+    manager.token,
+    tokenRecord,
+    ruleSetPda,
+  );
+
+  await delegateTx.assertSuccess(t);
+
+  // asserts
+
+  const tokenAccount = await getAccount(connection, manager.token);
+
+  spok(t, tokenAccount, {
+    delegatedAmount: spokSameBigint(new BN(1)),
+    delegate: spokSamePubkey(manager.metadata),
+  });
+
+  const pda = await TokenRecord.fromAccountAddress(connection, tokenRecord);
+
+  spok(t, pda, {
+    delegate: spokSamePubkey(manager.metadata),
+    delegateRole: TokenDelegateRole.Sale,
+    state: TokenState.Listed,
+  });
+});
+
+test('Delegate: fail to create LockedTransfer delegate with auth rules', async (t) => {
+  const API = new InitTransactions();
+  const { fstTxHandler: handler, payerPair: payer, connection } = await API.payer();
+
+  // creates the auth rules for the delegate
+
+  const ruleSetName = 'delegate_test';
+  const ruleSetTokenMetadata = {
+    libVersion: 1,
+    ruleSetName: ruleSetName,
+    owner: Array.from(payer.publicKey.toBytes()),
+    operations: {
+      'Delegate:LockedTransfer': {
+        All: {
+          rules: [
+            {
+              ProgramOwned: {
+                program: Array.from(PROGRAM_ID.toBytes()),
+                field: 'Delegate',
+              },
+            },
+            {
+              Amount: {
+                amount: 1,
+                operator: 2,
+                field: 'Amount',
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  const [ruleSetPda] = PublicKey.findProgramAddressSync(
+    [Buffer.from('rule_set'), payer.publicKey.toBuffer(), Buffer.from(ruleSetName)],
+    TOKEN_AUTH_RULES_ID,
+  );
+
+  const { tx: createRuleSetTx } = await API.createRuleSet(
+    t,
+    payer,
+    ruleSetPda,
+    encode(ruleSetTokenMetadata),
+    handler,
+  );
+  await createRuleSetTx.assertSuccess(t);
+
+  const manager = await createAndMintDefaultAsset(
+    t,
+    connection,
+    API,
+    handler,
+    payer,
+    TokenStandard.ProgrammableNonFungible,
+    ruleSetPda,
+  );
+
+  // creates a delegate
+
+  // address of our invalid delegate
+  const [delegate] = await amman.genLabeledKeypair('Delegate');
+  // token record PDA
+  const tokenRecord = findTokenRecordPda(manager.mint, manager.token);
+  amman.addr.addLabel('Token Record', tokenRecord);
+
+  const args: DelegateArgs = {
+    __kind: 'LockedTransferV1',
+    amount: 1,
+    lockedAddress: PublicKey.default,
+    authorizationData: null,
+  };
+
+  const { tx: delegateTx } = await API.delegate(
+    delegate,
+    manager.mint,
+    manager.metadata,
+    payer.publicKey,
+    payer,
+    args,
+    handler,
+    null,
+    manager.masterEdition,
+    manager.token,
+    tokenRecord,
+    ruleSetPda,
+  );
+
+  delegateTx.then((x) =>
+    x.assertLogs(t, [/Program Owned check failed/i], {
+      txLabel: 'tx: Delegate',
+    }),
+  );
+  await delegateTx.assertError(t);
 });

--- a/token-metadata/js/test/transfer.test.ts
+++ b/token-metadata/js/test/transfer.test.ts
@@ -914,7 +914,7 @@ test('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
           field: 'Destination',
         },
       },
-      'Delegate:Transfer': "Pass",
+      'Delegate:Transfer': 'Pass',
     },
   };
 

--- a/token-metadata/js/test/transfer.test.ts
+++ b/token-metadata/js/test/transfer.test.ts
@@ -889,7 +889,7 @@ test('Transfer: ProgrammableNonFungible (uninitialized wallet-to-wallet)', async
   );
 });
 
-test('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
+test.only('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
   const API = new InitTransactions();
   const { fstTxHandler: handler, payerPair: payer, connection } = await API.payer();
   const owner = payer;
@@ -977,7 +977,7 @@ test('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
 
   // checks that the rule set revision has been saved
 
-  const pda = await TokenRecord.fromAccountAddress(connection, tokenRecord);
+  let pda = await TokenRecord.fromAccountAddress(connection, tokenRecord);
 
   spok(t, pda, {
     delegate: spokSamePubkey(delegate.publicKey),
@@ -1056,6 +1056,20 @@ test('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
     (await getAccount(connection, token)).amount.toString() === '0',
     'token amount after transfer equal to 0',
   );
+
+  // revision on the source token must be null
+  pda = await TokenRecord.fromAccountAddress(connection, ownerTokenRecord);
+
+  spok(t, pda, {
+    ruleSetRevision: null,
+  });
+
+  // revision on the destination token must be null
+  pda = await TokenRecord.fromAccountAddress(connection, destinationTokenRecord);
+
+  spok(t, pda, {
+    ruleSetRevision: null,
+  });
 });
 
 test('Transfer: ProgrammableNonFungible with address lookup table (LUT)', async (t) => {

--- a/token-metadata/js/test/transfer.test.ts
+++ b/token-metadata/js/test/transfer.test.ts
@@ -889,7 +889,7 @@ test('Transfer: ProgrammableNonFungible (uninitialized wallet-to-wallet)', async
   );
 });
 
-test.only('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
+test('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
   const API = new InitTransactions();
   const { fstTxHandler: handler, payerPair: payer, connection } = await API.payer();
   const owner = payer;

--- a/token-metadata/js/test/transfer.test.ts
+++ b/token-metadata/js/test/transfer.test.ts
@@ -914,6 +914,7 @@ test('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
           field: 'Destination',
         },
       },
+      'Delegate:Transfer': "Pass",
     },
   };
 

--- a/token-metadata/program/src/instruction/delegate.rs
+++ b/token-metadata/program/src/instruction/delegate.rs
@@ -88,7 +88,7 @@ impl fmt::Display for MetadataDelegateRole {
             Self::Update => "update_delegate".to_string(),
         };
 
-        write!(f, "{}", message)
+        write!(f, "{message}")
     }
 }
 

--- a/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/token-metadata/program/src/processor/delegate/delegate.rs
@@ -64,14 +64,17 @@ pub fn delegate<'a>(
 
     // checks if it is a TokenDelegate creation
     let delegate_args = match &args {
+        // Sale
         DelegateArgs::SaleV1 {
             amount,
             authorization_data,
         } => Some((TokenDelegateRole::Sale, amount, authorization_data)),
+        // Transfer
         DelegateArgs::TransferV1 {
             amount,
             authorization_data,
         } => Some((TokenDelegateRole::Transfer, amount, authorization_data)),
+        // LockedTransfer
         DelegateArgs::LockedTransferV1 {
             amount,
             authorization_data,
@@ -81,14 +84,18 @@ pub fn delegate<'a>(
             amount,
             authorization_data,
         )),
+        // Utility
         DelegateArgs::UtilityV1 {
             amount,
             authorization_data,
         } => Some((TokenDelegateRole::Utility, amount, authorization_data)),
+        // Staking
         DelegateArgs::StakingV1 {
             amount,
             authorization_data,
         } => Some((TokenDelegateRole::Staking, amount, authorization_data)),
+        // Standard
+        DelegateArgs::StandardV1 { amount } => Some((TokenDelegateRole::Standard, amount, &None)),
         // we don't need to fail if did not find a match at this point
         _ => None,
     };
@@ -308,9 +315,9 @@ fn create_persistent_delegate_v1(
                 let auth_rules_validate_params = AuthRulesValidateParams {
                     mint_info: ctx.accounts.mint_info,
                     owner_info: None,
-                    authority_info: Some(ctx.accounts.delegate_info),
+                    authority_info: None,
                     source_info: None,
-                    destination_info: None,
+                    destination_info: Some(ctx.accounts.delegate_info),
                     programmable_config: metadata.programmable_config,
                     amount,
                     auth_data: authorization_data.clone(),

--- a/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/token-metadata/program/src/processor/delegate/delegate.rs
@@ -41,7 +41,7 @@ impl Display for DelegateScenario {
                 MetadataDelegateRole::Update => "Update".to_string(),
             },
             Self::Token(role) => match role {
-                TokenDelegateRole::Sale => "Transfer".to_string(),
+                TokenDelegateRole::Sale => "Sale".to_string(),
                 TokenDelegateRole::Transfer => "Transfer".to_string(),
                 TokenDelegateRole::LockedTransfer => "LockedTransfer".to_string(),
                 TokenDelegateRole::Utility => "Utility".to_string(),

--- a/token-metadata/program/src/state/mod.rs
+++ b/token-metadata/program/src/state/mod.rs
@@ -39,7 +39,6 @@ use solana_program::{
     pubkey::Pubkey,
 };
 use spl_token::state::Account as TokenAccount;
-
 pub use uses::*;
 #[cfg(feature = "serde-feature")]
 use {

--- a/token-metadata/program/src/state/programmable.rs
+++ b/token-metadata/program/src/state/programmable.rs
@@ -2,6 +2,8 @@ use std::io::Error;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use mpl_utils::cmp_pubkeys;
+#[cfg(feature = "serde-feature")]
+use serde::{Deserialize, Serialize};
 use shank::ShankAccount;
 use solana_program::{
     account_info::AccountInfo, instruction::AccountMeta, program_error::ProgramError,
@@ -9,15 +11,12 @@ use solana_program::{
 };
 use spl_token::state::Account;
 
-#[cfg(feature = "serde-feature")]
-use serde::{Deserialize, Serialize};
-
 use super::*;
 use crate::{
     error::MetadataError,
     instruction::MetadataDelegateRole,
     pda::{find_metadata_delegate_record_account, find_token_record_account},
-    processor::{TransferScenario, UpdateScenario, DelegateScenario},
+    processor::{DelegateScenario, TransferScenario, UpdateScenario},
     utils::assert_owned_by,
 };
 

--- a/token-metadata/program/src/state/programmable.rs
+++ b/token-metadata/program/src/state/programmable.rs
@@ -17,7 +17,7 @@ use crate::{
     error::MetadataError,
     instruction::MetadataDelegateRole,
     pda::{find_metadata_delegate_record_account, find_token_record_account},
-    processor::{TransferScenario, UpdateScenario},
+    processor::{TransferScenario, UpdateScenario, DelegateScenario},
     utils::assert_owned_by,
 };
 
@@ -353,6 +353,7 @@ impl AuthorityType {
 pub enum Operation {
     Transfer { scenario: TransferScenario },
     Update { scenario: UpdateScenario },
+    Delegate { scenario: DelegateScenario },
 }
 
 impl ToString for Operation {
@@ -360,6 +361,7 @@ impl ToString for Operation {
         match self {
             Self::Transfer { scenario } => format!("Transfer:{}", scenario),
             Self::Update { scenario } => format!("Update:{}", scenario),
+            Self::Delegate { scenario } => format!("Delegate:{}", scenario),
         }
     }
 }

--- a/token-metadata/program/src/utils/programmable_asset.rs
+++ b/token-metadata/program/src/utils/programmable_asset.rs
@@ -268,6 +268,22 @@ pub fn auth_rules_validate(params: AuthRulesValidateParams) -> ProgramResult {
                         PayloadType::Pubkey(*destination_info.key),
                     );
                 }
+                Operation::Delegate { scenario: _ } => {
+                    // get account infos
+                    let destination_info =
+                        destination_info.ok_or(MetadataError::InvalidOperation)?;
+
+                    // delegate amount
+                    auth_data
+                        .payload
+                        .insert(PayloadKey::Amount.to_string(), PayloadType::Number(amount));
+
+                    // delegate authority
+                    auth_data.payload.insert(
+                        PayloadKey::Delegate.to_string(),
+                        PayloadType::Pubkey(*destination_info.key),
+                    );
+                }
                 _ => {
                     return Err(MetadataError::InvalidOperation.into());
                 }

--- a/token-metadata/program/tests/delegate.rs
+++ b/token-metadata/program/tests/delegate.rs
@@ -327,7 +327,8 @@ mod delegate {
         // creates the auth rule set
 
         let payer = context.payer.dirty_clone();
-        let (rule_set, auth_data) = create_default_metaplex_rule_set(&mut context, payer).await;
+        let (rule_set, auth_data) =
+            create_default_metaplex_rule_set(&mut context, payer, false).await;
 
         // asset
 
@@ -472,7 +473,8 @@ mod delegate {
         // creates the auth rule set
 
         let payer = context.payer.dirty_clone();
-        let (rule_set, auth_data) = create_default_metaplex_rule_set(&mut context, payer).await;
+        let (rule_set, auth_data) =
+            create_default_metaplex_rule_set(&mut context, payer, true).await;
 
         // asset
 
@@ -510,7 +512,7 @@ mod delegate {
                 payer,
                 // delegate not authorized
                 user_pubkey,
-                DelegateArgs::SaleV1 {
+                DelegateArgs::TransferV1 {
                     amount: 1,
                     authorization_data: None,
                 },

--- a/token-metadata/program/tests/delegate.rs
+++ b/token-metadata/program/tests/delegate.rs
@@ -11,6 +11,7 @@ use utils::*;
 
 mod delegate {
 
+    use mpl_token_auth_rules::error::RuleSetError;
     use mpl_token_metadata::{
         error::MetadataError,
         instruction::{DelegateArgs, MetadataDelegateRole},
@@ -320,6 +321,7 @@ mod delegate {
     async fn store_rule_set_revision_on_delegate() {
         let mut program_test = ProgramTest::new("mpl_token_metadata", mpl_token_metadata::ID, None);
         program_test.add_program("mpl_token_auth_rules", mpl_token_auth_rules::ID, None);
+        program_test.set_compute_max_units(400_000);
         let mut context = program_test.start_with_context().await;
 
         // creates the auth rule set
@@ -353,15 +355,14 @@ mod delegate {
 
         // delegates the asset for transfer
 
-        let user = Keypair::new();
-        let user_pubkey = user.pubkey();
         let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
 
         asset
             .delegate(
                 &mut context,
                 payer,
-                user_pubkey,
+                // delegate must the from Token Auth Rules or Rooster
+                rule_set,
                 DelegateArgs::SaleV1 {
                     amount: 1,
                     authorization_data: None,
@@ -378,7 +379,7 @@ mod delegate {
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
 
         assert_eq!(token_record.key, Key::TokenRecord);
-        assert_eq!(token_record.delegate, Some(user_pubkey));
+        assert_eq!(token_record.delegate, Some(rule_set));
         assert_eq!(token_record.delegate_role, Some(TokenDelegateRole::Sale));
         assert_eq!(token_record.rule_set_revision, Some(0));
 
@@ -387,7 +388,7 @@ mod delegate {
             let token_account = Account::unpack(&account.data).unwrap();
 
             assert!(token_account.is_frozen());
-            assert_eq!(token_account.delegate, COption::Some(user_pubkey));
+            assert_eq!(token_account.delegate, COption::Some(rule_set));
             assert_eq!(token_account.delegated_amount, 1);
         } else {
             panic!("Missing token account");
@@ -459,5 +460,66 @@ mod delegate {
         } else {
             panic!("Missing token account");
         }
+    }
+
+    #[tokio::test]
+    async fn delegate_not_in_allow_list() {
+        let mut program_test = ProgramTest::new("mpl_token_metadata", mpl_token_metadata::ID, None);
+        program_test.add_program("mpl_token_auth_rules", mpl_token_auth_rules::ID, None);
+        program_test.set_compute_max_units(400_000);
+        let mut context = program_test.start_with_context().await;
+
+        // creates the auth rule set
+
+        let payer = context.payer.dirty_clone();
+        let (rule_set, auth_data) = create_default_metaplex_rule_set(&mut context, payer).await;
+
+        // asset
+
+        let mut asset = DigitalAsset::default();
+        asset
+            .create_and_mint(
+                &mut context,
+                TokenStandard::ProgrammableNonFungible,
+                Some(rule_set),
+                Some(auth_data),
+                1,
+            )
+            .await
+            .unwrap();
+
+        assert!(asset.token.is_some());
+
+        // asserts
+
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
+        let pda = get_account(&mut context, &pda_key).await;
+        let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
+
+        assert_eq!(token_record.rule_set_revision, None);
+
+        // delegates the asset for transfer
+
+        let user = Keypair::new();
+        let user_pubkey = user.pubkey();
+        let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
+
+        let error = asset
+            .delegate(
+                &mut context,
+                payer,
+                // delegate not authorized
+                user_pubkey,
+                DelegateArgs::SaleV1 {
+                    amount: 1,
+                    authorization_data: None,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        // asserts
+
+        assert_custom_error_ix!(0, error, RuleSetError::ProgramOwnedListCheckFailed);
     }
 }

--- a/token-metadata/program/tests/revoke.rs
+++ b/token-metadata/program/tests/revoke.rs
@@ -344,7 +344,8 @@ mod revoke {
         // creates the auth rule set
 
         let payer = context.payer.dirty_clone();
-        let (rule_set, auth_data) = create_default_metaplex_rule_set(&mut context, payer).await;
+        let (rule_set, auth_data) =
+            create_default_metaplex_rule_set(&mut context, payer, false).await;
 
         // asset
 

--- a/token-metadata/program/tests/transfer.rs
+++ b/token-metadata/program/tests/transfer.rs
@@ -1138,6 +1138,7 @@ mod auth_rules_transfer {
 
         let (destination_token_record, _bump) =
             find_token_record_account(&nft.mint.pubkey(), &destination_token);
+        let pda = get_account(&mut context, &destination_token_record).await;
         let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
 
         assert_eq!(token_record.rule_set_revision, None);

--- a/token-metadata/program/tests/transfer.rs
+++ b/token-metadata/program/tests/transfer.rs
@@ -387,7 +387,8 @@ mod auth_rules_transfer {
 
         // Create rule-set for the transfer requiring the destination to be program owned
         // by Token Metadata program. (Token Owned Escrow scenario.)
-        let (rule_set, auth_data) = create_default_metaplex_rule_set(&mut context, payer).await;
+        let (rule_set, auth_data) =
+            create_default_metaplex_rule_set(&mut context, payer, false).await;
 
         // Create NFT for transfer tests.
         let mut nft = DigitalAsset::new();
@@ -497,7 +498,8 @@ mod auth_rules_transfer {
         let payer = context.payer.dirty_clone();
 
         // Create rule-set for the transfer; this has the Rooster program in the allowlist.
-        let (rule_set, mut auth_data) = create_default_metaplex_rule_set(&mut context, payer).await;
+        let (rule_set, mut auth_data) =
+            create_default_metaplex_rule_set(&mut context, payer, false).await;
 
         // Create NFT for transfer tests.
         let mut nft = DigitalAsset::new();
@@ -610,12 +612,14 @@ mod auth_rules_transfer {
         let mut program_test = ProgramTest::new("mpl_token_metadata", mpl_token_metadata::ID, None);
         program_test.add_program("mpl_token_auth_rules", mpl_token_auth_rules::ID, None);
         program_test.add_program("rooster", rooster::ID, None);
+        program_test.set_compute_max_units(400_000);
         let mut context = program_test.start_with_context().await;
 
         let payer = context.payer.dirty_clone();
 
         // Create rule-set for the transfer; this has the Rooster program in the allowlist.
-        let (rule_set, mut auth_data) = create_default_metaplex_rule_set(&mut context, payer).await;
+        let (rule_set, mut auth_data) =
+            create_default_metaplex_rule_set(&mut context, payer, false).await;
 
         // Create NFT for transfer tests.
         let mut nft = DigitalAsset::new();
@@ -774,12 +778,14 @@ mod auth_rules_transfer {
         let mut program_test = ProgramTest::new("mpl_token_metadata", mpl_token_metadata::ID, None);
         program_test.add_program("mpl_token_auth_rules", mpl_token_auth_rules::ID, None);
         program_test.add_program("rooster", rooster::ID, None);
+        program_test.set_compute_max_units(400_000);
         let mut context = program_test.start_with_context().await;
 
         let payer = context.payer.dirty_clone();
 
         // Create rule-set for the transfer; this has the Rooster program in the allowlist.
-        let (rule_set, mut auth_data) = create_default_metaplex_rule_set(&mut context, payer).await;
+        let (rule_set, mut auth_data) =
+            create_default_metaplex_rule_set(&mut context, payer, false).await;
 
         // Create NFT for transfer tests.
         let mut nft = DigitalAsset::new();
@@ -989,12 +995,14 @@ mod auth_rules_transfer {
         let mut program_test = ProgramTest::new("mpl_token_metadata", mpl_token_metadata::ID, None);
         program_test.add_program("mpl_token_auth_rules", mpl_token_auth_rules::ID, None);
         program_test.add_program("rooster", rooster::ID, None);
+        program_test.set_compute_max_units(400_000);
         let mut context = program_test.start_with_context().await;
 
         let payer = context.payer.dirty_clone();
 
         // create rule set for the transfer; this has the Rooster program in the allowlist
-        let (rule_set, mut auth_data) = create_default_metaplex_rule_set(&mut context, payer).await;
+        let (rule_set, mut auth_data) =
+            create_default_metaplex_rule_set(&mut context, payer, false).await;
 
         // create NFT for transfer tests
         let mut nft = DigitalAsset::new();

--- a/token-metadata/program/tests/update.rs
+++ b/token-metadata/program/tests/update.rs
@@ -111,7 +111,7 @@ mod update {
 
         // Create rule-set for the transfer
         let (authorization_rules, auth_data) =
-            create_default_metaplex_rule_set(context, authority).await;
+            create_default_metaplex_rule_set(context, authority, false).await;
 
         let update_authority = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
 
@@ -187,7 +187,7 @@ mod update {
         let authority = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
 
         let (authorization_rules, _auth_data) =
-            create_default_metaplex_rule_set(context, authority).await;
+            create_default_metaplex_rule_set(context, authority, false).await;
 
         let update_authority = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
 
@@ -328,16 +328,17 @@ mod update {
         // When a delegate is set, the rule set cannot be updated.
         let mut program_test = ProgramTest::new("mpl_token_metadata", mpl_token_metadata::ID, None);
         program_test.add_program("mpl_token_auth_rules", mpl_token_auth_rules::ID, None);
+        program_test.set_compute_max_units(400_000);
         let mut context = &mut program_test.start_with_context().await;
 
         let authority = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
 
         // Create rule-set for the transfer
         let (authorization_rules, auth_data) =
-            create_default_metaplex_rule_set(context, authority.dirty_clone()).await;
+            create_default_metaplex_rule_set(context, authority.dirty_clone(), false).await;
 
         let (new_auth_rules, new_auth_data) =
-            create_default_metaplex_rule_set(context, authority.dirty_clone()).await;
+            create_default_metaplex_rule_set(context, authority.dirty_clone(), false).await;
 
         let update_authority = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
 


### PR DESCRIPTION
## Context

Currently, the `Delegate` instruction does not validate authorization rules even when dealing with `pNFT` – it only validates that the correct rules set has been passed.

## Changes

The PR defines a set of operations for each delegate type and validates whether the delegate is authorized to get the specified delegate type.

The different scenarios are defined by the different delegate types:
```rust
pub enum DelegateScenario {
    Metadata(MetadataDelegateRole),
    Token(TokenDelegateRole),
}
```

The scenario is used to define the operation, which can then have a rule set associated:
```rust
let delegate_sale_operation = Operation::Delegate {
    scenario: DelegateScenario::Token(TokenDelegateRole::Sale),
};
```

Below is example of a rule set that validates that the delegate address is in an allow list:
```rust
Rule::ProgramOwnedList {
    programs: PROGRAM_ALLOW_LIST.to_vec(),
    field: PayloadKey::Delegate.to_string(),
}
```

## Considerations

* This change does not impact clients nor security (in a way it increases the security since the delegate address is now validated against the `pNFT` rule set).
* When this change is deployed, the rule sets will need to include an entry for each delegate type.