### PR TITLE
Update Token Auth Rules dependency

### DIFF
--- a/token-metadata/Cargo.lock
+++ b/token-metadata/Cargo.lock
@@ -1941,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-auth-rules"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14e1ac5350734fd07f17d7eab733d27b7b45ca963642c565ec34ab015d9ceda"
+checksum = "12b9ceca1f8e1a6e3588e367f7d7790e5f19956165d972709f53f61bb297459e"
 dependencies = [
  "borsh",
  "mpl-token-metadata-context-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -53,7 +53,7 @@
     "@metaplex-foundation/amman": "^0.12.0",
     "@metaplex-foundation/amman-client": "^0.2.2",
     "@metaplex-foundation/solita": "^0.19.3",
-    "@metaplex-foundation/mpl-token-auth-rules": "^0.2.7",
+    "@metaplex-foundation/mpl-token-auth-rules": "^1.1.0",
     "@msgpack/msgpack": "^2.8.0",
     "@types/bn.js": "^5.1.1",
     "@types/debug": "^4.1.7",

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.14"
 spl-token = { version = "3.2.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "1.1.1", features = ["no-entrypoint"] }
-mpl-token-auth-rules = { version = "1.0", features = ["no-entrypoint"] }
+mpl-token-auth-rules = { version = "1.1", features = ["no-entrypoint"] }
 thiserror = "1.0"
 borsh = "0.9.2"
 shank = { version = "0.0.11" }

--- a/token-metadata/program/tests/delegate.rs
+++ b/token-metadata/program/tests/delegate.rs
@@ -362,7 +362,7 @@ mod delegate {
             .delegate(
                 &mut context,
                 payer,
-                // delegate must the from Token Auth Rules or Rooster
+                // delegate must be from Token Auth Rules or Rooster
                 rule_set,
                 DelegateArgs::SaleV1 {
                     amount: 1,


### PR DESCRIPTION
This PR bumps Token Auth Rules to include the non-zero byte PDA account check, which simplifies the rule sets.