### PR TITLE
Relax token standard check

### DIFF
--- a/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/token-metadata/program/src/processor/delegate/delegate.rs
@@ -377,13 +377,10 @@ fn create_persistent_delegate_v1(
                 return Err(MetadataError::MissingEditionAccount.into());
             }
         }
-        Some(_) => {
+        _ => {
             if !matches!(role, TokenDelegateRole::Standard) {
                 return Err(MetadataError::InvalidDelegateRole.into());
             }
-        }
-        None => {
-            return Err(MetadataError::CouldNotDetermineTokenStandard.into());
         }
     }
 

--- a/token-metadata/program/src/processor/delegate/revoke.rs
+++ b/token-metadata/program/src/processor/delegate/revoke.rs
@@ -246,13 +246,10 @@ fn revoke_persistent_delegate(
                 return Err(MetadataError::MissingEditionAccount.into());
             }
         }
-        Some(_) => {
+        _ => {
             if !matches!(role, TokenDelegateRole::Standard) {
                 return Err(MetadataError::InvalidDelegateRole.into());
             }
-        }
-        None => {
-            return Err(MetadataError::CouldNotDetermineTokenStandard.into());
         }
     }
 


### PR DESCRIPTION
This PR relaxes the token standard check on `Delegate` and `Revoke`.