### PR TITLE
Refactor lock and unlock logic

### DIFF
--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -2829,7 +2829,7 @@
           "name": "authority",
           "isMut": false,
           "isSigner": true,
-          "desc": "Delegate account"
+          "desc": "Delegate or freeze authority"
         },
         {
           "name": "tokenOwner",
@@ -2931,7 +2931,7 @@
           "name": "authority",
           "isMut": false,
           "isSigner": true,
-          "desc": "Delegate account"
+          "desc": "Delegate or freeze authority"
         },
         {
           "name": "tokenOwner",

--- a/token-metadata/js/src/generated/instructions/Lock.ts
+++ b/token-metadata/js/src/generated/instructions/Lock.ts
@@ -36,7 +36,7 @@ export const LockStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _Lock_ instruction
  *
- * @property [**signer**] authority Delegate account
+ * @property [**signer**] authority Delegate or freeze authority
  * @property [] tokenOwner (optional) Token owner account
  * @property [_writable_] token Token account
  * @property [] mint Mint account

--- a/token-metadata/js/src/generated/instructions/Unlock.ts
+++ b/token-metadata/js/src/generated/instructions/Unlock.ts
@@ -36,7 +36,7 @@ export const UnlockStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _Unlock_ instruction
  *
- * @property [**signer**] authority Delegate account
+ * @property [**signer**] authority Delegate or freeze authority
  * @property [] tokenOwner (optional) Token owner account
  * @property [_writable_] token Token account
  * @property [] mint Mint account

--- a/token-metadata/js/test/setup/txs-init.ts
+++ b/token-metadata/js/test/setup/txs-init.ts
@@ -97,6 +97,22 @@ export class InitTransactions {
     };
   }
 
+  async authority() {
+    const [authority, authorityPair] = await this.getKeypair('Payer');
+
+    const connection = new Connection(LOCALHOST, 'confirmed');
+    await amman.airdrop(connection, authority, 2);
+
+    const transactionHandler = amman.payerTransactionHandler(connection, authorityPair);
+
+    return {
+      fstTxHandler: transactionHandler,
+      connection,
+      authority,
+      authorityPair,
+    };
+  }
+
   async create(
     t: Test,
     payer: Keypair,

--- a/token-metadata/js/test/setup/txs-init.ts
+++ b/token-metadata/js/test/setup/txs-init.ts
@@ -98,7 +98,7 @@ export class InitTransactions {
   }
 
   async authority() {
-    const [authority, authorityPair] = await this.getKeypair('Payer');
+    const [authority, authorityPair] = await this.getKeypair('Authority');
 
     const connection = new Connection(LOCALHOST, 'confirmed');
     await amman.airdrop(connection, authority, 2);

--- a/token-metadata/js/test/unlock.test.ts
+++ b/token-metadata/js/test/unlock.test.ts
@@ -242,34 +242,10 @@ test('Unlock: unlock Fungible asset', async (t) => {
     });
   }
 
-  // creates a delegate
-
-  const [, delegate] = await API.getKeypair('Delegate');
-
-  const args: DelegateArgs = {
-    __kind: 'StandardV1',
-    amount: 100,
-  };
-
-  const { tx: delegateTx } = await API.delegate(
-    delegate.publicKey,
-    manager.mint,
-    manager.metadata,
-    payer.publicKey,
-    payer,
-    args,
-    handler,
-    null,
-    null,
-    manager.token,
-  );
-
-  await delegateTx.assertSuccess(t);
-
   // lock asset
 
   const { tx: lockTx } = await API.lock(
-    delegate,
+    payer,
     manager.mint,
     manager.metadata,
     manager.token,
@@ -288,10 +264,10 @@ test('Unlock: unlock Fungible asset', async (t) => {
     });
   }
 
-  // lock asset
+  // unlock asset
 
   const { tx: unlockTx } = await API.unlock(
-    delegate,
+    payer,
     manager.mint,
     manager.metadata,
     manager.token,

--- a/token-metadata/program/src/instruction/mod.rs
+++ b/token-metadata/program/src/instruction/mod.rs
@@ -608,7 +608,7 @@ pub enum MetadataInstruction {
     /// 
     /// The configurable `authorization_rules` only apply to `ProgrammableNonFungible` assets and
     /// it may require additional accounts to validate the rules.
-    #[account(0, signer, name="authority", desc="Delegate account")]
+    #[account(0, signer, name="authority", desc="Delegate or freeze authority")]
     #[account(1, optional, name="token_owner", desc="Token owner account")]
     #[account(2, writable, name="token", desc="Token account")]
     #[account(3, name="mint", desc="Mint account")]
@@ -628,7 +628,7 @@ pub enum MetadataInstruction {
     /// 
     /// The configurable `authorization_rules` only apply to `ProgrammableNonFungible` assets and
     /// it may require additional accounts to validate the rules.
-    #[account(0, signer, name="authority", desc="Delegate account")]
+    #[account(0, signer, name="authority", desc="Delegate or freeze authority")]
     #[account(1, optional, name="token_owner", desc="Token owner account")]
     #[account(2, writable, name="token", desc="Token account")]
     #[account(3, name="mint", desc="Mint account")]

--- a/token-metadata/program/src/processor/state/lock.rs
+++ b/token-metadata/program/src/processor/state/lock.rs
@@ -19,10 +19,9 @@ pub fn lock<'a>(
             super::ToggleAccounts {
                 payer_info: context.accounts.payer_info,
                 authority_info: context.accounts.authority_info,
-                token_owner_info: context.accounts.token_owner_info,
                 mint_info: context.accounts.mint_info,
                 token_info: context.accounts.token_info,
-                master_edition_info: context.accounts.edition_info,
+                edition_info: context.accounts.edition_info,
                 metadata_info: context.accounts.metadata_info,
                 token_record_info: context.accounts.token_record_info,
                 system_program_info: context.accounts.system_program_info,

--- a/token-metadata/program/src/processor/state/unlock.rs
+++ b/token-metadata/program/src/processor/state/unlock.rs
@@ -19,10 +19,9 @@ pub fn unlock<'a>(
             super::ToggleAccounts {
                 payer_info: context.accounts.payer_info,
                 authority_info: context.accounts.authority_info,
-                token_owner_info: context.accounts.token_owner_info,
                 mint_info: context.accounts.mint_info,
                 token_info: context.accounts.token_info,
-                master_edition_info: context.accounts.edition_info,
+                edition_info: context.accounts.edition_info,
                 metadata_info: context.accounts.metadata_info,
                 token_record_info: context.accounts.token_record_info,
                 system_program_info: context.accounts.system_program_info,


### PR DESCRIPTION
The current logic for lock/unlock of fungibles gives the impression that a delegate can be used to freeze/thaw a token account holding fungibles assets. This PR refactors the code to clearly separate the 3 different authorities that can lock/unlock depending on the token standard:
1. `token delegate` for pNFTs
2. `spl-token delegate` for non-fungibles
3. `freeze authority` for fungibles