### PR TITLE
remove redundant token standard check

### DIFF
--- a/token-metadata/program/src/processor/metadata/migrate.rs
+++ b/token-metadata/program/src/processor/metadata/migrate.rs
@@ -93,17 +93,6 @@ pub fn migrate_v1(program_id: &Pubkey, ctx: Context<Migrate>, args: MigrateArgs)
     let mut metadata = Metadata::from_account_info(metadata_info)?;
     let collection_metadata = Metadata::from_account_info(collection_metadata_info)?;
 
-    let token_standard = metadata.token_standard.ok_or_else(|| {
-        <MetadataError as std::convert::Into<ProgramError>>::into(
-            MetadataError::InvalidTokenStandard,
-        )
-    })?;
-
-    // Can only migrate NFT --> PNFT right now.
-    if !matches!(token_standard, TokenStandard::NonFungible) {
-        return Err(MetadataError::InvalidTokenStandard.into());
-    }
-
     match migration_type {
         MigrationType::CollectionV1 => return Err(MetadataError::FeatureNotSupported.into()),
         MigrationType::ProgrammableV1 => {


### PR DESCRIPTION
The token standard checks are too strict since there are many legacy `NonFungible` assets without a Token Standard set. The validation of the token standard is done in `mpl-migration-validator` [here](https://github.com/metaplex-foundation/mpl-migration-validator/blob/e8dd04252b3a24548c80f6e285209a62d95c43d4/program/src/processor/migrate/validate.rs#L146), so can be removed from this handler. 