### PR TITLE
Add revoke for migration delegate

### DIFF
--- a/token-metadata/program/src/instruction/delegate.rs
+++ b/token-metadata/program/src/instruction/delegate.rs
@@ -67,6 +67,7 @@ pub enum RevokeArgs {
     StakingV1,
     StandardV1,
     LockedTransferV1,
+    MigrationV1,
 }
 
 #[repr(C)]

--- a/token-metadata/program/src/processor/delegate/revoke.rs
+++ b/token-metadata/program/src/processor/delegate/revoke.rs
@@ -50,6 +50,9 @@ pub fn revoke<'a>(
         RevokeArgs::LockedTransferV1 => {
             revoke_persistent_delegate(program_id, context, TokenDelegateRole::LockedTransfer)
         }
+        RevokeArgs::MigrationV1 => {
+            revoke_persistent_delegate(program_id, context, TokenDelegateRole::Migration)
+        }
     }
 }
 

--- a/token-metadata/program/src/state/programmable.rs
+++ b/token-metadata/program/src/state/programmable.rs
@@ -131,7 +131,7 @@ impl TokenRecord {
 
 impl Resizable for TokenRecord {
     fn from_bytes<'a>(account_data: &[u8]) -> Result<TokenRecord, ProgramError> {
-        // we perform a manual deserializagtion since we are potentially dealing
+        // we perform a manual deserialization since we are potentially dealing
         // with accounts of different sizes
         let length = TokenRecord::size() as i64 - account_data.len() as i64;
 

--- a/token-metadata/program/tests/utils/digital_asset.rs
+++ b/token-metadata/program/tests/utils/digital_asset.rs
@@ -368,7 +368,8 @@ impl DigitalAsset {
             | RevokeArgs::TransferV1
             | RevokeArgs::UtilityV1
             | RevokeArgs::StakingV1
-            | RevokeArgs::LockedTransferV1 => {
+            | RevokeArgs::LockedTransferV1
+            | RevokeArgs::MigrationV1 => {
                 let (token_record, _) =
                     find_token_record_account(&self.mint.pubkey(), &self.token.unwrap());
                 builder.token_record(token_record);


### PR DESCRIPTION
This PR adds the ability to revoke a `TokenDelegateRole::Migration` delegate.