### PR TITLE
Add migration to revoke args

### DIFF
--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -4702,6 +4702,9 @@
           },
           {
             "name": "ProgrammableConfigV1"
+          },
+          {
+            "name": "MigrationV1"
           }
         ]
       }

--- a/token-metadata/js/src/generated/types/RevokeArgs.ts
+++ b/token-metadata/js/src/generated/types/RevokeArgs.ts
@@ -20,6 +20,7 @@ export enum RevokeArgs {
   StandardV1,
   LockedTransferV1,
   ProgrammableConfigV1,
+  MigrationV1,
 }
 
 /**


### PR DESCRIPTION
This PR adds the missing `MigrationV1` value to the `RevokeArgs` enum on the JS autogenerated code.