### PR TITLE
reduce redundant code

### DIFF
--- a/token-metadata/program/src/processor/verification/collection_verification.rs
+++ b/token-metadata/program/src/processor/verification/collection_verification.rs
@@ -152,30 +152,22 @@ pub(crate) fn unverify_collection_v1(program_id: &Pubkey, ctx: Context<Unverify>
     // Ensure the metadata is derived from the mint.
     assert_metadata_derivation(program_id, collection_metadata_info, collection_mint_info)?;
 
+    // Set up authority request for burned parent case.
+    let mut auth_request = AuthorityRequest {
+        authority: ctx.accounts.authority_info.key,
+        update_authority: &metadata.update_authority,
+        mint: &metadata.mint,
+        metadata_delegate_record_info: ctx.accounts.delegate_record_info,
+        metadata_delegate_roles: vec![MetadataDelegateRole::Update],
+        precedence: &[AuthorityType::Metadata, AuthorityType::MetadataDelegate],
+        ..Default::default()
+    };
+
     // Check if the collection metadata account is burned. If it is, there's no sized data to
     // update and the user can simply unverify the NFT.
     let parent_burned = collection_metadata_info.data_is_empty();
 
-    if parent_burned {
-        // If the collection parent is burned, we need to use an authority for the item rather than
-        // the collection.  The required authority is either the item's metadata update authority,
-        // or an update delegate for the item.  This call fails if no valid authority is present.
-        let authority_response = AuthorityType::get_authority_type(AuthorityRequest {
-            authority: ctx.accounts.authority_info.key,
-            update_authority: &metadata.update_authority,
-            mint: &metadata.mint,
-            metadata_delegate_record_info: ctx.accounts.delegate_record_info,
-            metadata_delegate_roles: vec![MetadataDelegateRole::Update],
-            precedence: &[AuthorityType::Metadata, AuthorityType::MetadataDelegate],
-            ..Default::default()
-        })?;
-
-        // Validate that authority type is expected.
-        match authority_response.authority_type {
-            AuthorityType::Metadata | AuthorityType::MetadataDelegate => (),
-            _ => return Err(MetadataError::UpdateAuthorityIncorrect.into()),
-        }
-    } else {
+    if !parent_burned {
         // If the parent is not burned, we need to ensure the collection metadata account is owned
         // by the token metadata program.
         assert_owned_by(collection_metadata_info, program_id)?;
@@ -183,25 +175,8 @@ pub(crate) fn unverify_collection_v1(program_id: &Pubkey, ctx: Context<Unverify>
         // Now we can deserialize the collection metadata account.
         let mut collection_metadata = Metadata::from_account_info(collection_metadata_info)?;
 
-        // Determines if we have a valid authority to perform the collection verification.  The
-        // required authority is either the collection parent's metadata update authority, or a
-        // collection delegate for the collection parent.  This call fails if no valid authority is
-        // present.
-        let authority_response = AuthorityType::get_authority_type(AuthorityRequest {
-            authority: ctx.accounts.authority_info.key,
-            update_authority: &collection_metadata.update_authority,
-            mint: collection_mint_info.key,
-            metadata_delegate_record_info: ctx.accounts.delegate_record_info,
-            metadata_delegate_roles: vec![MetadataDelegateRole::Collection],
-            precedence: &[AuthorityType::Metadata, AuthorityType::MetadataDelegate],
-            ..Default::default()
-        })?;
-
-        // Validate that authority type is expected.
-        match authority_response.authority_type {
-            AuthorityType::Metadata | AuthorityType::MetadataDelegate => (),
-            _ => return Err(MetadataError::UpdateAuthorityIncorrect.into()),
-        }
+        // Set the authority to the collection parent's update authority.
+        auth_request.update_authority = &collection_metadata.update_authority;
 
         // In the case of a sized collection, update the size on the collection parent.
         if collection_metadata.collection_details.is_some() {
@@ -209,10 +184,21 @@ pub(crate) fn unverify_collection_v1(program_id: &Pubkey, ctx: Context<Unverify>
         }
     }
 
+    // Determines if we have a valid authority to perform the collection verification.  The
+    // required authority is either the collection parent's metadata update authority, or a
+    // collection delegate for the collection parent.  This call fails if no valid authority is
+    // present.
+    let authority_response = AuthorityType::get_authority_type(auth_request)?;
+
+    // Validate that authority type is expected.
+    match authority_response.authority_type {
+        AuthorityType::Metadata | AuthorityType::MetadataDelegate => (),
+        _ => return Err(MetadataError::UpdateAuthorityIncorrect.into()),
+    }
+
     // Set item metadata collection to unverified.
     collection.verified = false;
 
     // Reserialize metadata.
-    clean_write_metadata(&mut metadata, ctx.accounts.metadata_info)?;
-    Ok(())
+    clean_write_metadata(&mut metadata, ctx.accounts.metadata_info)
 }


### PR DESCRIPTION
This reduces redundant code a bit. There might be a better refactor you see here, so feel free not to use this.

Amazingly, the binaries are the exact same size so this would only be beneficial for code readability, cleanliness, and maintainability. 