### PR TITLE
move edition derivation checks to common handler

### DIFF
--- a/token-metadata/program/src/processor/burn/burn.rs
+++ b/token-metadata/program/src/processor/burn/burn.rs
@@ -2,7 +2,10 @@ use super::*;
 
 use crate::{
     processor::burn::{fungible::burn_fungible, nonfungible_edition::burn_nonfungible_edition},
-    state::{AuthorityRequest, AuthorityType, TokenDelegateRole, TokenRecord, TokenState},
+    state::{
+        AuthorityRequest, AuthorityType, TokenDelegateRole, TokenRecord, TokenState,
+        EDITION_MARKER_BIT_SIZE,
+    },
     utils::{check_token_standard, thaw},
 };
 
@@ -89,6 +92,77 @@ fn burn_v1(program_id: &Pubkey, ctx: Context<Burn>, args: BurnArgs) -> ProgramRe
 
     if ctx.accounts.spl_token_program_info.key != &spl_token::ID {
         return Err(ProgramError::IncorrectProgramId);
+    }
+
+    // Assert derivations.
+
+    if let Some(edition_info) = ctx.accounts.edition_info {
+        // Burn item has a valid edition.
+        let edition_info_path = Vec::from([
+            PREFIX.as_bytes(),
+            crate::ID.as_ref(),
+            ctx.accounts.mint_info.key.as_ref(),
+            EDITION.as_bytes(),
+        ]);
+        assert_derivation(&crate::ID, edition_info, &edition_info_path)?;
+    }
+
+    if let Some(parent_edition_info) = ctx.accounts.parent_edition_info {
+        let parent_mint_info = ctx
+            .accounts
+            .parent_mint_info
+            .ok_or(MetadataError::MissingParentMintAccount)?;
+
+        // Burn item has a valid parent edition.
+        let parent_edition_info_path = Vec::from([
+            PREFIX.as_bytes(),
+            crate::ID.as_ref(),
+            parent_mint_info.key.as_ref(),
+            EDITION.as_bytes(),
+        ]);
+        assert_derivation(&crate::ID, parent_edition_info, &parent_edition_info_path)
+            .map_err(|_| MetadataError::InvalidMasterEdition)?;
+    }
+
+    if let Some(edition_marker_info) = ctx.accounts.edition_marker_info {
+        let edition_info = ctx
+            .accounts
+            .edition_info
+            .ok_or(MetadataError::MissingEditionAccount)?;
+
+        let parent_edition_info = ctx
+            .accounts
+            .parent_edition_info
+            .ok_or(MetadataError::MissingEditionAccount)?;
+
+        let parent_mint_info = ctx
+            .accounts
+            .parent_mint_info
+            .ok_or(MetadataError::MissingParentMintAccount)?;
+
+        let print_edition = Edition::from_account_info(edition_info)?;
+
+        // Print Edition actually belongs to the master edition.
+        if print_edition.parent != *parent_edition_info.key {
+            return Err(MetadataError::PrintEditionDoesNotMatchMasterEdition.into());
+        }
+
+        // Which edition marker is this edition in
+        let edition_marker_number = print_edition
+            .edition
+            .checked_div(EDITION_MARKER_BIT_SIZE)
+            .ok_or(MetadataError::NumericalOverflowError)?;
+        let edition_marker_number_str = edition_marker_number.to_string();
+
+        let edition_marker_info_path = Vec::from([
+            PREFIX.as_bytes(),
+            crate::ID.as_ref(),
+            parent_mint_info.key.as_ref(),
+            EDITION.as_bytes(),
+            edition_marker_number_str.as_bytes(),
+        ]);
+        assert_derivation(&crate::ID, edition_marker_info, &edition_marker_info_path)
+            .map_err(|_| MetadataError::InvalidEditionMarker)?;
     }
 
     // Deserialize accounts.

--- a/token-metadata/program/src/processor/burn/nonfungible.rs
+++ b/token-metadata/program/src/processor/burn/nonfungible.rs
@@ -51,15 +51,6 @@ pub(crate) fn burn_nonfungible(ctx: &Context<Burn>, args: BurnNonFungibleArgs) -
     // close_program_account.
     drop(edition_account_data);
 
-    // Has a valid Master Edition or Print Edition.
-    let edition_info_path = Vec::from([
-        PREFIX.as_bytes(),
-        crate::ID.as_ref(),
-        ctx.accounts.mint_info.key.as_ref(),
-        EDITION.as_bytes(),
-    ]);
-    assert_derivation(&crate::ID, edition_info, &edition_info_path)?;
-
     // Burn the SPL token
     let params = TokenBurnParams {
         mint: ctx.accounts.mint_info.clone(),

--- a/token-metadata/program/src/processor/burn/nonfungible_edition.rs
+++ b/token-metadata/program/src/processor/burn/nonfungible_edition.rs
@@ -1,4 +1,4 @@
-use crate::state::{MasterEdition, MasterEditionV2, EDITION_MARKER_BIT_SIZE};
+use crate::state::{MasterEdition, MasterEditionV2};
 
 use super::*;
 
@@ -60,49 +60,7 @@ pub(crate) fn burn_nonfungible_edition(ctx: &Context<Burn>) -> ProgramResult {
         return Err(MetadataError::InsufficientTokenBalance.into());
     }
 
-    // Master and Print editions are valid PDAs for their given mints.
-    let master_edition_info_path = Vec::from([
-        PREFIX.as_bytes(),
-        crate::ID.as_ref(),
-        parent_mint_info.key.as_ref(),
-        EDITION.as_bytes(),
-    ]);
-    assert_derivation(&crate::ID, parent_edition_info, &master_edition_info_path)
-        .map_err(|_| MetadataError::InvalidMasterEdition)?;
-
-    let print_edition_info_path = Vec::from([
-        PREFIX.as_bytes(),
-        crate::ID.as_ref(),
-        ctx.accounts.mint_info.key.as_ref(),
-        EDITION.as_bytes(),
-    ]);
-    assert_derivation(&crate::ID, edition_info, &print_edition_info_path)
-        .map_err(|_| MetadataError::InvalidPrintEdition)?;
-
     let print_edition = Edition::from_account_info(edition_info)?;
-
-    // Print Edition actually belongs to the master edition.
-    if print_edition.parent != *parent_edition_info.key {
-        return Err(MetadataError::PrintEditionDoesNotMatchMasterEdition.into());
-    }
-
-    // Which edition marker is this edition in
-    let edition_marker_number = print_edition
-        .edition
-        .checked_div(EDITION_MARKER_BIT_SIZE)
-        .ok_or(MetadataError::NumericalOverflowError)?;
-    let edition_marker_number_str = edition_marker_number.to_string();
-
-    // Ensure we were passed the correct edition marker PDA.
-    let edition_marker_info_path = Vec::from([
-        PREFIX.as_bytes(),
-        crate::ID.as_ref(),
-        parent_mint_info.key.as_ref(),
-        EDITION.as_bytes(),
-        edition_marker_number_str.as_bytes(),
-    ]);
-    assert_derivation(&crate::ID, edition_marker_info, &edition_marker_info_path)
-        .map_err(|_| MetadataError::InvalidEditionMarker)?;
 
     // Burn the SPL token
     let params = TokenBurnParams {

--- a/token-metadata/program/tests/burn.rs
+++ b/token-metadata/program/tests/burn.rs
@@ -1599,7 +1599,7 @@ mod nft {
             .await
             .unwrap_err();
 
-        assert_custom_error!(err, MetadataError::InvalidParentAccounts);
+        assert_custom_error!(err, MetadataError::DataTypeMismatch);
     }
 }
 
@@ -1943,7 +1943,7 @@ mod nft_edition {
 
         let err = print_edition.burn(&mut context, args).await.unwrap_err();
 
-        assert_custom_error!(err, MetadataError::NotAMasterEdition);
+        assert_custom_error!(err, MetadataError::InvalidMasterEdition);
     }
 
     #[tokio::test]
@@ -2067,7 +2067,7 @@ mod nft_edition {
 
         let err = print_edition.burn(&mut context, args).await.unwrap_err();
 
-        assert_custom_error!(err, MetadataError::InvalidPrintEdition);
+        assert_custom_error!(err, MetadataError::DerivedKeyInvalid);
     }
 
     #[tokio::test]
@@ -2489,7 +2489,7 @@ mod nft_edition {
             .await
             .unwrap_err();
 
-        assert_custom_error!(err, MetadataError::MintMismatch);
+        assert_custom_error!(err, MetadataError::DerivedKeyInvalid);
 
         let other_nft = Metadata::new();
         other_nft.create_v3_default(&mut context).await.unwrap();
@@ -2513,7 +2513,7 @@ mod nft_edition {
             .await
             .unwrap_err();
 
-        assert_custom_error!(err, MetadataError::MintMismatch);
+        assert_custom_error!(err, MetadataError::InvalidMasterEdition);
     }
 }
 


### PR DESCRIPTION
Saves 480 bytes by moving edition derivation checks out of individual handlers to the common `burn.rs` file.