### PR TITLE
fix: Add Creator Minimum Balance Check

### DIFF
--- a/auction-house/program/tests/execute_sale.rs
+++ b/auction-house/program/tests/execute_sale.rs
@@ -14,11 +14,11 @@ use utils::{
 
 use anchor_lang::{AccountDeserialize, InstructionData, ToAccountMetas};
 use mpl_auction_house::pda::find_auctioneer_pda;
-use mpl_token_metadata::state::Creator;
 use mpl_testing_utils::{
     solana::{airdrop, create_associated_token_account, transfer},
     utils::Metadata,
 };
+use mpl_token_metadata::state::Creator;
 use solana_sdk::{
     account::Account as SolanaAccount, commitment_config::CommitmentLevel, signer::Signer,
 };

--- a/auctioneer/program/tests/execute_sale.rs
+++ b/auctioneer/program/tests/execute_sale.rs
@@ -812,7 +812,7 @@ async fn execute_sale_with_creators(metadata_creators: Vec<(Pubkey, u8)>) {
 
     for (creator, _) in &metadata_creators {
         // airdrop 0.1 sol to ensure rent-exempt minimum
-        airdrop(&mut context, &creator, 100_000_000).await.unwrap();
+        airdrop(&mut context, creator, 100_000_000).await.unwrap();
     }
     test_metadata
         .create(


### PR DESCRIPTION
If one of the creators of an NFT has less than the rent exempt amount in their wallet, and the royalty from the sale is not enough to bring the balance over the rent exempt minimum then the sale will fail.

A workaround is to skip paying creator royalties unless they result in a valid balance for the creator wallet.