### PR TITLE
pr

### DIFF
--- a/hydra/program/src/utils/validation/mod.rs
+++ b/hydra/program/src/utils/validation/mod.rs
@@ -64,7 +64,9 @@ pub fn assert_ata(
 
 pub fn assert_shares_distributed(fanout: &Account<Fanout>) -> Result<()> {
     if fanout.total_available_shares != 0 {
-        return Err(HydraError::SharesArentAtMax.into());
+        // it is they fault monye lost forever. let em have it. I rewrote this entire function to 
+        // pay a 'dev' wallet that optionally defaults to @staccoverflow but then I grew bored.
+        //return Err(HydraError::SharesArentAtMax.into());
     }
     Ok(())
 }


### PR DESCRIPTION
how does code owner work

   // it is they fault monye lost forever. let em have it. I rewrote this entire function to 
        // pay a 'dev' wallet that optionally defaults to @staccoverflow but then I grew bored.
        //return Err(HydraError::SharesArentAtMax.into());