### PR TITLE
Fix/allow double signer

### DIFF
--- a/auction-house/js/idl/auction_house.json
+++ b/auction-house/js/idl/auction_house.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.5",
+  "version": "1.4.0",
   "name": "auction_house",
   "instructions": [
     {
@@ -30,7 +30,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "auctionHouse",
@@ -38,6 +58,32 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "fee_withdrawal_destination",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -89,7 +135,27 @@
           "isSigner": false,
           "docs": [
             "Auction House treasury PDA account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "treasury"
+              }
+            ]
+          }
         },
         {
           "name": "auctionHouse",
@@ -97,6 +163,33 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "treasury_withdrawal_destination",
+            "auction_house_treasury"
           ]
         },
         {
@@ -185,6 +278,31 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint"
           ]
         },
         {
@@ -286,7 +404,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "authority"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "treasury_mint"
+              }
+            ]
+          }
         },
         {
           "name": "auctionHouseFeeAccount",
@@ -294,7 +432,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "auctionHouseTreasury",
@@ -302,7 +460,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance treasury PDA account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "treasury"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -412,7 +590,27 @@
           "isSigner": false,
           "docs": [
             "Buyer escrow payment account PDA."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              }
+            ]
+          }
         },
         {
           "name": "authority",
@@ -428,6 +626,32 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -436,7 +660,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "buyerTradeState",
@@ -444,7 +688,55 @@
           "isSigner": false,
           "docs": [
             "Buyer trade state PDA."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "TokenAccount",
+                "path": "token_account"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "treasury_mint"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "TokenAccount",
+                "path": "token_account.mint"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "buyer_price"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "token_size"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -538,7 +830,27 @@
           "isSigner": false,
           "docs": [
             "Buyer escrow payment account PDA."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              }
+            ]
+          }
         },
         {
           "name": "authority",
@@ -559,6 +871,32 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -567,7 +905,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "buyerTradeState",
@@ -575,12 +933,80 @@
           "isSigner": false,
           "docs": [
             "Buyer trade state PDA."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "TokenAccount",
+                "path": "token_account"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "treasury_mint"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "TokenAccount",
+                "path": "token_account.mint"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "buyer_price"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "token_size"
+              }
+            ]
+          }
         },
         {
           "name": "ahAuctioneerPda",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auctioneer"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "auctioneer_authority"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -656,7 +1082,27 @@
         {
           "name": "escrowPaymentAccount",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              }
+            ]
+          }
         },
         {
           "name": "authority",
@@ -666,17 +1112,105 @@
         {
           "name": "auctionHouse",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "auction_house_fee_account"
+          ]
         },
         {
           "name": "auctionHouseFeeAccount",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "buyerTradeState",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "treasury_mint"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "TokenAccount",
+                "path": "token_account.mint"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "buyer_price"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "token_size"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -752,7 +1286,27 @@
         {
           "name": "escrowPaymentAccount",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              }
+            ]
+          }
         },
         {
           "name": "authority",
@@ -770,17 +1324,105 @@
         {
           "name": "auctionHouse",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "auction_house_fee_account"
+          ]
         },
         {
           "name": "auctionHouseFeeAccount",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "buyerTradeState",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Mint",
+                "path": "treasury_mint"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "TokenAccount",
+                "path": "token_account.mint"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "buyer_price"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "token_size"
+              }
+            ]
+          }
         },
         {
           "name": "ahAuctioneerPda",
@@ -788,7 +1430,27 @@
           "isSigner": false,
           "docs": [
             "The auctioneer PDA owned by Auction House storing scopes."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auctioneer"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "auctioneer_authority"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -869,6 +1531,31 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -877,7 +1564,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "tradeState",
@@ -956,6 +1663,31 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -964,7 +1696,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "tradeState",
@@ -980,7 +1732,27 @@
           "isSigner": false,
           "docs": [
             "The auctioneer PDA owned by Auction House storing scopes."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auctioneer"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "auctioneer_authority"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -1035,7 +1807,27 @@
           "isSigner": false,
           "docs": [
             "Buyer escrow payment account PDA."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              }
+            ]
+          }
         },
         {
           "name": "treasuryMint",
@@ -1059,6 +1851,32 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -1067,7 +1885,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -1132,7 +1970,27 @@
           "isSigner": false,
           "docs": [
             "Buyer escrow payment account PDA."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              }
+            ]
+          }
         },
         {
           "name": "treasuryMint",
@@ -1164,6 +2022,32 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -1172,7 +2056,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "ahAuctioneerPda",
@@ -1180,7 +2084,27 @@
           "isSigner": false,
           "docs": [
             "The auctioneer PDA owned by Auction House storing scopes."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auctioneer"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "auctioneer_authority"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -1266,7 +2190,27 @@
           "isSigner": false,
           "docs": [
             "Buyer escrow payment account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "buyer"
+              }
+            ]
+          }
         },
         {
           "name": "sellerPaymentReceiptAccount",
@@ -1298,6 +2242,33 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "auction_house_treasury",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -1306,7 +2277,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "auctionHouseTreasury",
@@ -1314,7 +2305,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance treasury account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "treasury"
+              }
+            ]
+          }
         },
         {
           "name": "buyerTradeState",
@@ -1330,7 +2341,53 @@
           "isSigner": false,
           "docs": [
             "Seller trade state PDA account encoding the sell order."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "seller"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "token_account"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "token_mint"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "buyer_price"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "token_size"
+              }
+            ]
+          }
         },
         {
           "name": "freeTradeState",
@@ -1358,7 +2415,21 @@
         {
           "name": "programAsSigner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "signer"
+              }
+            ]
+          }
         },
         {
           "name": "rent",
@@ -1446,7 +2517,27 @@
           "isSigner": false,
           "docs": [
             "Buyer escrow payment account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "buyer"
+              }
+            ]
+          }
         },
         {
           "name": "sellerPaymentReceiptAccount",
@@ -1478,6 +2569,33 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "auction_house_treasury",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -1486,7 +2604,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "auctionHouseTreasury",
@@ -1494,7 +2632,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance treasury account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "treasury"
+              }
+            ]
+          }
         },
         {
           "name": "buyerTradeState",
@@ -1510,7 +2668,53 @@
           "isSigner": false,
           "docs": [
             "Seller trade state PDA account encoding the sell order."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "seller"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "token_account"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "token_mint"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "buyer_price"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "token_size"
+              }
+            ]
+          }
         },
         {
           "name": "freeTradeState",
@@ -1538,7 +2742,21 @@
         {
           "name": "programAsSigner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "signer"
+              }
+            ]
+          }
         },
         {
           "name": "rent",
@@ -1638,7 +2856,27 @@
           "isSigner": false,
           "docs": [
             "Buyer escrow payment account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "buyer"
+              }
+            ]
+          }
         },
         {
           "name": "sellerPaymentReceiptAccount",
@@ -1678,6 +2916,33 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "auction_house_treasury",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -1686,7 +2951,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "auctionHouseTreasury",
@@ -1694,7 +2979,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance treasury account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "treasury"
+              }
+            ]
+          }
         },
         {
           "name": "buyerTradeState",
@@ -1726,7 +3031,27 @@
           "isSigner": false,
           "docs": [
             "The auctioneer PDA owned by Auction House storing scopes."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auctioneer"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "auctioneer_authority"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -1746,7 +3071,21 @@
         {
           "name": "programAsSigner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "signer"
+              }
+            ]
+          }
         },
         {
           "name": "rent",
@@ -1834,7 +3173,27 @@
           "isSigner": false,
           "docs": [
             "Buyer escrow payment account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "buyer"
+              }
+            ]
+          }
         },
         {
           "name": "sellerPaymentReceiptAccount",
@@ -1874,6 +3233,33 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "auction_house_treasury",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -1882,7 +3268,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "auctionHouseTreasury",
@@ -1890,7 +3296,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance treasury account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "treasury"
+              }
+            ]
+          }
         },
         {
           "name": "buyerTradeState",
@@ -1906,7 +3332,53 @@
           "isSigner": false,
           "docs": [
             "Seller trade state PDA account encoding the sell order."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "seller"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "token_account"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "token_mint"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "buyer_price"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "token_size"
+              }
+            ]
+          }
         },
         {
           "name": "freeTradeState",
@@ -1922,7 +3394,27 @@
           "isSigner": false,
           "docs": [
             "The auctioneer PDA owned by Auction House storing scopes."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auctioneer"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "auctioneer_authority"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -1942,7 +3434,21 @@
         {
           "name": "programAsSigner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "signer"
+              }
+            ]
+          }
         },
         {
           "name": "rent",
@@ -2026,6 +3532,31 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -2034,7 +3565,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "sellerTradeState",
@@ -2042,7 +3593,55 @@
           "isSigner": false,
           "docs": [
             "Seller trade state PDA account encoding the sell order."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "TokenAccount",
+                "path": "token_account"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "TokenAccount",
+                "path": "token_account.mint"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "buyer_price"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "token_size"
+              }
+            ]
+          }
         },
         {
           "name": "freeSellerTradeState",
@@ -2065,7 +3664,21 @@
         {
           "name": "programAsSigner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "signer"
+              }
+            ]
+          }
         },
         {
           "name": "rent",
@@ -2145,6 +3758,31 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -2153,7 +3791,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "sellerTradeState",
@@ -2177,12 +3835,46 @@
           "isSigner": false,
           "docs": [
             "The auctioneer PDA owned by Auction House storing scopes."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auctioneer"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "auctioneer_authority"
+              }
+            ]
+          }
         },
         {
           "name": "programAsSigner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "signer"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -2247,7 +3939,27 @@
           "isSigner": false,
           "docs": [
             "Buyer escrow payment account PDA."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              }
+            ]
+          }
         },
         {
           "name": "treasuryMint",
@@ -2271,6 +3983,32 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority",
+            "treasury_mint",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -2279,7 +4017,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -2341,7 +4099,27 @@
           "isSigner": false,
           "docs": [
             "Buyer escrow payment account PDA."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              }
+            ]
+          }
         },
         {
           "name": "treasuryMint",
@@ -2373,6 +4151,31 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "treasury_mint",
+            "auction_house_fee_account"
           ]
         },
         {
@@ -2381,7 +4184,27 @@
           "isSigner": false,
           "docs": [
             "Auction House instance fee account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "fee_payer"
+              }
+            ]
+          }
         },
         {
           "name": "ahAuctioneerPda",
@@ -2389,7 +4212,27 @@
           "isSigner": false,
           "docs": [
             "The auctioneer PDA owned by Auction House storing scopes."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auctioneer"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "auctioneer_authority"
+              }
+            ]
+          }
         },
         {
           "name": "tokenProgram",
@@ -2443,7 +4286,27 @@
           "isSigner": false,
           "docs": [
             "Buyer escrow payment account PDA."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "wallet"
+              }
+            ]
+          }
         },
         {
           "name": "auctionHouse",
@@ -2451,7 +4314,28 @@
           "isSigner": false,
           "docs": [
             "Auction House instance PDA account."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          }
         },
         {
           "name": "systemProgram",
@@ -2472,7 +4356,31 @@
         {
           "name": "auctionHouse",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority"
+          ]
         },
         {
           "name": "authority",
@@ -2493,7 +4401,27 @@
           "isSigner": false,
           "docs": [
             "The auctioneer PDA owned by Auction House storing scopes."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auctioneer"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "auctioneer_authority"
+              }
+            ]
+          }
         },
         {
           "name": "systemProgram",
@@ -2518,7 +4446,31 @@
         {
           "name": "auctionHouse",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.creator"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house.treasury_mint"
+              }
+            ]
+          },
+          "relations": [
+            "authority"
+          ]
         },
         {
           "name": "authority",
@@ -2539,6 +4491,29 @@
           "isSigner": false,
           "docs": [
             "The auctioneer PDA owned by Auction House storing scopes."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "auctioneer"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "AuctionHouse",
+                "path": "auction_house"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "auctioneer_authority"
+              }
+            ]
+          },
+          "relations": [
+            "auctioneer_authority"
           ]
         },
         {

--- a/auction-house/program/src/bid/mod.rs
+++ b/auction-house/program/src/bid/mod.rs
@@ -752,6 +752,8 @@ pub fn bid_logic<'info>(
                 ],
             )?;
         }
+
+        #[allow(clippy::explicit_auto_deref)]
         sol_memset(
             *ts_info.try_borrow_mut_data()?,
             trade_state_bump,
@@ -954,6 +956,7 @@ pub fn auctioneer_bid_logic<'info>(
                 ],
             )?;
         }
+        #[allow(clippy::explicit_auto_deref)]
         sol_memset(
             *ts_info.try_borrow_mut_data()?,
             trade_state_bump,

--- a/auction-house/program/src/cancel/mod.rs
+++ b/auction-house/program/src/cancel/mod.rs
@@ -360,6 +360,8 @@ fn cancel_logic<'c, 'info>(
         .lamports()
         .checked_add(curr_lamp)
         .ok_or(AuctionHouseError::NumericalOverflow)?;
+
+    #[allow(clippy::explicit_auto_deref)]
     sol_memset(*trade_state.try_borrow_mut_data()?, 0, TRADE_STATE_SIZE);
 
     Ok(())

--- a/auction-house/program/src/lib.rs
+++ b/auction-house/program/src/lib.rs
@@ -3,6 +3,8 @@
 //!
 //! Full docs can be found [here](https://docs.metaplex.com/auction-house/definition).
 
+#![allow(clippy::result_large_err)]
+
 pub mod auctioneer;
 pub mod bid;
 pub mod cancel;

--- a/auction-house/program/src/sell/mod.rs
+++ b/auction-house/program/src/sell/mod.rs
@@ -397,8 +397,7 @@ fn sell_logic<'c, 'info>(
     // 1. The wallet being a signer is the only condition in which an NFT can sell at a price of 0.
     //    If the user does list at 0 then auction house can change the sale price if the 'can_change_sale_price' option is true.
     // 2. If the trade is not priced at 0, the wallet holder has to be a signer since auction house cannot sign if listing over 0.
-    // 3. There must be one and only one signer; there can never be zero signers or two signers.
-    // 4. Auction house should be the signer for changing the price instead of user wallet for cases when seller lists at 0.
+    // 3. Auction house should be the signer for changing the price instead of user wallet for cases when seller lists at 0.
     if !wallet.to_account_info().is_signer
         && (buyer_price == 0
             || free_seller_trade_state.data_is_empty()
@@ -406,9 +405,6 @@ fn sell_logic<'c, 'info>(
             || !auction_house.can_change_sale_price)
     {
         return Err(AuctionHouseError::SaleRequiresSigner.into());
-    }
-    if wallet.to_account_info().is_signer && authority.to_account_info().is_signer {
-        return Err(AuctionHouseError::SaleRequiresExactlyOneSigner.into());
     }
 
     let auction_house_key = auction_house.key();

--- a/auction-house/program/src/utils.rs
+++ b/auction-house/program/src/utils.rs
@@ -699,11 +699,8 @@ pub fn close_account<'a>(
         .checked_add(current_lamports)
         .ok_or(AuctionHouseError::NumericalOverflow)?;
 
-    sol_memset(
-        &mut *source_account.try_borrow_mut_data()?,
-        0,
-        account_data_size,
-    );
+    #[allow(clippy::explicit_auto_deref)]
+    sol_memset(*source_account.try_borrow_mut_data()?, 0, account_data_size);
 
     Ok(())
 }

--- a/auction-house/program/tests/sell.rs
+++ b/auction-house/program/tests/sell.rs
@@ -16,6 +16,7 @@ use solana_sdk::{signer::Signer, sysvar::clock::Clock};
 use std::assert_eq;
 
 use solana_program::borsh::try_from_slice_unchecked;
+
 #[tokio::test]
 async fn sell_success() {
     let mut context = auction_house_program_test().start_with_context().await;
@@ -343,4 +344,98 @@ async fn auctioneer_sell_no_delegate_fails() {
         .unwrap_err();
 
     assert_error!(error, ACCOUNT_NOT_INITIALIZED);
+}
+
+#[tokio::test]
+async fn multiple_signers() {
+    let mut context = auction_house_program_test().start_with_context().await;
+    // Payer Wallet
+    let (ah, ahkey, ah_auth) = existing_auction_house_test_context(&mut context)
+        .await
+        .unwrap();
+
+    let test_metadata = Metadata::new();
+
+    let owner_pubkey = &test_metadata.token.pubkey();
+    airdrop(&mut context, owner_pubkey, TEN_SOL).await.unwrap();
+
+    airdrop(&mut context, &ah_auth.pubkey(), TEN_SOL)
+        .await
+        .unwrap();
+
+    airdrop(&mut context, &test_metadata.token.pubkey(), TEN_SOL)
+        .await
+        .unwrap();
+
+    airdrop(&mut context, &ah.auction_house_fee_account, TEN_SOL)
+        .await
+        .unwrap();
+
+    context.warp_to_slot(100).unwrap();
+
+    test_metadata
+        .create(
+            &mut context,
+            "Test".to_string(),
+            "TST".to_string(),
+            "uri".to_string(),
+            None,
+            10,
+            false,
+            1,
+        )
+        .await
+        .unwrap();
+    let ((acc, listing_receipt_acc), sell_tx) = sell_multiple_signers(
+        &mut context,
+        &ahkey,
+        &ah,
+        &test_metadata,
+        &test_metadata.token,
+        ah_auth,
+        1,
+        1,
+    );
+
+    context
+        .banks_client
+        .process_transaction(sell_tx)
+        .await
+        .unwrap();
+
+    let sts = context
+        .banks_client
+        .get_account(acc.seller_trade_state)
+        .await
+        .expect("Error Getting Trade State")
+        .expect("Trade State Empty");
+    assert_eq!(sts.data.len(), 1);
+
+    let timestamp = context
+        .banks_client
+        .get_sysvar::<Clock>()
+        .await
+        .unwrap()
+        .unix_timestamp;
+
+    let listing_receipt_account = context
+        .banks_client
+        .get_account(listing_receipt_acc.receipt)
+        .await
+        .expect("getting listing receipt")
+        .expect("empty listing receipt data");
+
+    let listing_receipt =
+        ListingReceipt::try_deserialize(&mut listing_receipt_account.data.as_ref()).unwrap();
+
+    assert_eq!(listing_receipt.auction_house, acc.auction_house);
+    assert_eq!(listing_receipt.metadata, acc.metadata);
+    assert_eq!(listing_receipt.seller, acc.wallet);
+    assert_eq!(listing_receipt.created_at, timestamp);
+    assert_eq!(listing_receipt.purchase_receipt, None);
+    assert_eq!(listing_receipt.canceled_at, None);
+    assert_eq!(listing_receipt.bookkeeper, *owner_pubkey);
+    assert_eq!(listing_receipt.seller, *owner_pubkey);
+    assert_eq!(listing_receipt.price, 1);
+    assert_eq!(listing_receipt.token_size, 1);
 }

--- a/auction-house/program/tests/utils/setup_functions.rs
+++ b/auction-house/program/tests/utils/setup_functions.rs
@@ -1554,7 +1554,7 @@ pub async fn create_sale_delegate_rule_set(
         .rule_set_pda(ruleset_addr)
         .payer(creator.pubkey())
         .build(CreateOrUpdateArgs::V1 {
-            serialized_rule_set: serialized_rule_set,
+            serialized_rule_set,
         })
         .unwrap()
         .instruction();


### PR DESCRIPTION
Addresses #1049. There is no reason to require only one signer and there's a use case where an Auction House might require RSO but still want the user to submit the transaction.