### PR TITLE
Fix/utility delegate

### DIFF
--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -6413,7 +6413,7 @@
     {
       "code": 185,
       "name": "MissingCollectionMint",
-      "msg": "Missing collection mint account"
+      "msg": "Missing collection account"
     },
     {
       "code": 186,
@@ -6424,6 +6424,11 @@
       "code": 187,
       "name": "InvalidTokenRecord",
       "msg": "Invalid token record account"
+    },
+    {
+      "code": 188,
+      "name": "InvalidCloseAuthority",
+      "msg": "The close authority needs to be revoked by the Utility Delegate"
     }
   ],
   "metadata": {

--- a/token-metadata/js/src/generated/errors/index.ts
+++ b/token-metadata/js/src/generated/errors/index.ts
@@ -3967,7 +3967,7 @@ createErrorFromNameLookup.set(
 );
 
 /**
- * MissingCollectionMint: 'Missing collection mint account'
+ * MissingCollectionMint: 'Missing collection account'
  *
  * @category Errors
  * @category generated
@@ -3976,7 +3976,7 @@ export class MissingCollectionMintError extends Error {
   readonly code: number = 0xb9;
   readonly name: string = 'MissingCollectionMint';
   constructor() {
-    super('Missing collection mint account');
+    super('Missing collection account');
     if (typeof Error.captureStackTrace === 'function') {
       Error.captureStackTrace(this, MissingCollectionMintError);
     }
@@ -4028,6 +4028,26 @@ export class InvalidTokenRecordError extends Error {
 
 createErrorFromCodeLookup.set(0xbb, () => new InvalidTokenRecordError());
 createErrorFromNameLookup.set('InvalidTokenRecord', () => new InvalidTokenRecordError());
+
+/**
+ * InvalidCloseAuthority: 'The close authority needs to be revoked by the Utility Delegate'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class InvalidCloseAuthorityError extends Error {
+  readonly code: number = 0xbc;
+  readonly name: string = 'InvalidCloseAuthority';
+  constructor() {
+    super('The close authority needs to be revoked by the Utility Delegate');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, InvalidCloseAuthorityError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0xbc, () => new InvalidCloseAuthorityError());
+createErrorFromNameLookup.set('InvalidCloseAuthority', () => new InvalidCloseAuthorityError());
 
 /**
  * Attempts to resolve a custom program error from the provided error code.

--- a/token-metadata/js/test/transfer.test.ts
+++ b/token-metadata/js/test/transfer.test.ts
@@ -1057,12 +1057,9 @@ test('Transfer: ProgrammableNonFungible (rule set revision)', async (t) => {
     'token amount after transfer equal to 0',
   );
 
-  // revision on the source token must be null
-  pda = await TokenRecord.fromAccountAddress(connection, ownerTokenRecord);
-
-  spok(t, pda, {
-    ruleSetRevision: null,
-  });
+  // Sourec token record is close after transfer.
+  const info = await connection.getAccountInfo(ownerTokenRecord, 'confirmed');
+  t.true(info === null);
 
   // revision on the destination token must be null
   pda = await TokenRecord.fromAccountAddress(connection, destinationTokenRecord);

--- a/token-metadata/program/src/error.rs
+++ b/token-metadata/program/src/error.rs
@@ -731,7 +731,7 @@ pub enum MetadataError {
     InsufficientTokenBalance,
 
     /// 185
-    #[error("Missing collection mint account")]
+    #[error("Missing collection account")]
     MissingCollectionMint,
 
     /// 186
@@ -741,6 +741,10 @@ pub enum MetadataError {
     /// 187
     #[error("Invalid token record account")]
     InvalidTokenRecord,
+
+    /// 188
+    #[error("The close authority needs to be revoked by the Utility Delegate")]
+    InvalidCloseAuthority,
 }
 
 impl PrintProgramError for MetadataError {

--- a/token-metadata/program/src/instruction/burn.rs
+++ b/token-metadata/program/src/instruction/burn.rs
@@ -121,7 +121,7 @@ pub enum BurnArgs {
 ///   4.   `[writable]` Mint of token account
 ///   5.   `[writable]` Token account to close
 ///   6.   `[optional, writable]` Master edition token account
-///   7.   `[optional]` Master edition mint of the assset
+///   7.   `[optional]` Master edition mint of the asset
 ///   8.   `[optional]` Master edition token account
 ///   9.   `[optional, writable]` Edition marker account
 ///  10.   `[optional, writable]` Token record account

--- a/token-metadata/program/src/processor/burn/burn.rs
+++ b/token-metadata/program/src/processor/burn/burn.rs
@@ -216,14 +216,10 @@ fn burn_v1(program_id: &Pubkey, ctx: Context<Burn>, args: BurnArgs) -> ProgramRe
             // Utility Delegate is the only delegate that can burn an asset.
             if let Some(TokenDelegateRole::Utility) = token_record.delegate_role {
                 if let COption::Some(close_authority) = token.close_authority {
-                    msg!("Existing close authority: {:?}", close_authority);
-                    msg!("Master edition: {:?}", edition_info.key);
                     if &close_authority != edition_info.key {
                         return Err(MetadataError::InvalidCloseAuthority.into());
                     }
                     args.me_close_authority = true;
-                } else {
-                    msg!("No close authority found");
                 }
             }
 

--- a/token-metadata/program/src/processor/burn/burn.rs
+++ b/token-metadata/program/src/processor/burn/burn.rs
@@ -1,10 +1,12 @@
+use solana_program::program_option::COption;
+
 use super::*;
 
 use crate::{
     pda::find_token_record_account,
     processor::burn::{fungible::burn_fungible, nonfungible_edition::burn_nonfungible_edition},
     state::{AuthorityRequest, AuthorityType, TokenDelegateRole, TokenRecord, TokenState},
-    utils::{check_token_standard, clear_close_authority, thaw, ClearCloseAuthorityParams},
+    utils::{check_token_standard, thaw},
 };
 
 /// Burn an asset, closing associated accounts.
@@ -160,7 +162,10 @@ fn burn_v1(program_id: &Pubkey, ctx: Context<Burn>, args: BurnArgs) -> ProgramRe
 
     match token_standard {
         TokenStandard::NonFungible => {
-            let args = BurnNonFungibleArgs { metadata, token };
+            let args = BurnNonFungibleArgs {
+                metadata,
+                me_close_authority: false,
+            };
 
             burn_nonfungible(&ctx, args)?;
         }
@@ -203,17 +208,24 @@ fn burn_v1(program_id: &Pubkey, ctx: Context<Burn>, args: BurnArgs) -> ProgramRe
                 .edition_info
                 .ok_or(MetadataError::MissingEditionAccount)?;
 
-            
-            clear_close_authority(ClearCloseAuthorityParams {
-                token_info: ctx.accounts.token_info,
-                mint_info: ctx.accounts.mint_info,
-                token,
-                master_edition_info: edition_info,
-                authority_info: edition_info,
-                spl_token_program_info: ctx.accounts.spl_token_program_info,
-            })?;
+            let mut args = BurnNonFungibleArgs {
+                metadata,
+                me_close_authority: false,
+            };
 
-            let args = BurnNonFungibleArgs { metadata, token };
+            // Utility Delegate is the only delegate that can burn an asset.
+            if let Some(TokenDelegateRole::Utility) = token_record.delegate_role {
+                if let COption::Some(close_authority) = token.close_authority {
+                    msg!("Existing close authority: {:?}", close_authority);
+                    msg!("Master edition: {:?}", edition_info.key);
+                    if &close_authority != edition_info.key {
+                        return Err(MetadataError::InvalidCloseAuthority.into());
+                    }
+                    args.me_close_authority = true;
+                } else {
+                    msg!("No close authority found");
+                }
+            }
 
             burn_nonfungible(&ctx, args)?;
 

--- a/token-metadata/program/src/processor/burn/burn_nft.rs
+++ b/token-metadata/program/src/processor/burn/burn_nft.rs
@@ -99,6 +99,9 @@ pub fn process_burn_nft<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]
         remaining_accounts: vec![],
     };
 
-    let args = BurnNonFungibleArgs { metadata, token };
+    let args = BurnNonFungibleArgs {
+        metadata,
+        me_close_authority: false,
+    };
     burn_nonfungible(&context, args)
 }

--- a/token-metadata/program/src/processor/burn/burn_nft.rs
+++ b/token-metadata/program/src/processor/burn/burn_nft.rs
@@ -99,6 +99,6 @@ pub fn process_burn_nft<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]
         remaining_accounts: vec![],
     };
 
-    let args = BurnNonFungibleArgs { metadata };
+    let args = BurnNonFungibleArgs { metadata, token };
     burn_nonfungible(&context, args)
 }

--- a/token-metadata/program/src/processor/burn/mod.rs
+++ b/token-metadata/program/src/processor/burn/mod.rs
@@ -24,8 +24,8 @@ use crate::{
     },
     utils::{
         assert_derivation, assert_initialized, assert_owned_by,
-        assert_verified_member_of_collection, close_program_account, is_master_edition,
-        is_print_edition,
+        assert_verified_member_of_collection, close_program_account, decrement_collection_size,
+        is_master_edition, is_print_edition,
     },
 };
 

--- a/token-metadata/program/src/processor/burn/nonfungible.rs
+++ b/token-metadata/program/src/processor/burn/nonfungible.rs
@@ -93,6 +93,7 @@ pub(crate) fn burn_nonfungible(ctx: &Context<Burn>, args: BurnNonFungibleArgs) -
         },
         token_program: ctx.accounts.spl_token_program_info.clone(),
     };
+    // CPIs panic if there's an error so unwrapping is fine here.
     mpl_utils::token::spl_token_close(close_params).unwrap();
 
     close_program_account(ctx.accounts.metadata_info, ctx.accounts.authority_info)?;

--- a/token-metadata/program/src/processor/burn/nonfungible.rs
+++ b/token-metadata/program/src/processor/burn/nonfungible.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub(crate) struct BurnNonFungibleArgs {
     pub(crate) metadata: Metadata,
+    pub(crate) me_close_authority: bool,
 }
 
 pub(crate) fn burn_nonfungible(ctx: &Context<Burn>, args: BurnNonFungibleArgs) -> ProgramResult {
@@ -56,7 +57,15 @@ pub(crate) fn burn_nonfungible(ctx: &Context<Burn>, args: BurnNonFungibleArgs) -
         ctx.accounts.mint_info.key.as_ref(),
         EDITION.as_bytes(),
     ]);
-    assert_derivation(&crate::ID, edition_info, &edition_info_path)?;
+    let bump = assert_derivation(&crate::ID, edition_info, &edition_info_path)?;
+
+    let edition_seeds = &[
+        PREFIX.as_bytes(),
+        crate::ID.as_ref(),
+        ctx.accounts.mint_info.key.as_ref(),
+        EDITION.as_bytes(),
+        &[bump],
+    ];
 
     // Burn the SPL token
     let params = TokenBurnParams {
@@ -72,8 +81,16 @@ pub(crate) fn burn_nonfungible(ctx: &Context<Burn>, args: BurnNonFungibleArgs) -
     let close_params = TokenCloseParams {
         account: ctx.accounts.token_info.clone(),
         destination: ctx.accounts.authority_info.clone(),
-        owner: ctx.accounts.authority_info.clone(),
-        authority_signer_seeds: None,
+        owner: if args.me_close_authority {
+            edition_info.clone()
+        } else {
+            ctx.accounts.authority_info.clone()
+        },
+        authority_signer_seeds: if args.me_close_authority {
+            Some(edition_seeds.as_slice())
+        } else {
+            None
+        },
         token_program: ctx.accounts.spl_token_program_info.clone(),
     };
     mpl_utils::token::spl_token_close(close_params).unwrap();

--- a/token-metadata/program/src/processor/burn/nonfungible.rs
+++ b/token-metadata/program/src/processor/burn/nonfungible.rs
@@ -1,5 +1,3 @@
-use crate::utils::decrement_collection_size;
-
 use super::*;
 
 pub(crate) struct BurnNonFungibleArgs {
@@ -71,14 +69,14 @@ pub(crate) fn burn_nonfungible(ctx: &Context<Burn>, args: BurnNonFungibleArgs) -
     };
     spl_token_burn(params)?;
 
-    let params = TokenCloseParams {
-        token_program: ctx.accounts.spl_token_program_info.clone(),
+    let close_params = TokenCloseParams {
         account: ctx.accounts.token_info.clone(),
         destination: ctx.accounts.authority_info.clone(),
         owner: ctx.accounts.authority_info.clone(),
         authority_signer_seeds: None,
+        token_program: ctx.accounts.spl_token_program_info.clone(),
     };
-    spl_token_close(params)?;
+    mpl_utils::token::spl_token_close(close_params).unwrap();
 
     close_program_account(ctx.accounts.metadata_info, ctx.accounts.authority_info)?;
     close_program_account(edition_info, ctx.accounts.authority_info)?;

--- a/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/token-metadata/program/src/processor/delegate/delegate.rs
@@ -407,20 +407,20 @@ fn create_persistent_delegate_v1(
 
     // For Utility Delegates we request Close Authority as well so that the
     // token can be closed by the delegate on Burn. We assign CloseAuthority to
-    // the metadata PDA so we can close it on Transfer and revoke it in Revoke.
+    // the master edition PDA so we can close it on Transfer and revoke it in Revoke.
     if matches!(role, TokenDelegateRole::Utility) {
         // If there's an existing close authority that is not the metadata account,
-        // it willl need to be revoked by the original UtilityDelegate.
+        // it will need to be revoked by the original UtilityDelegate.
+        let master_edition_info = ctx
+            .accounts
+            .master_edition_info
+            .ok_or(MetadataError::MissingEditionAccount)?;
+
         if let COption::Some(close_authority) = token.close_authority {
-            if &close_authority != ctx.accounts.metadata_info.key {
+            if &close_authority != master_edition_info.key {
                 return Err(MetadataError::InvalidCloseAuthority.into());
             }
         } else {
-            let master_edition_info = ctx
-                .accounts
-                .master_edition_info
-                .ok_or(MetadataError::MissingEditionAccount)?;
-
             invoke(
                 &spl_token::instruction::set_authority(
                     spl_token_program_info.key,

--- a/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/token-metadata/program/src/processor/delegate/delegate.rs
@@ -4,8 +4,8 @@ use borsh::BorshSerialize;
 use mpl_token_auth_rules::utils::get_latest_revision;
 use mpl_utils::{assert_signer, create_or_allocate_account_raw};
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke,
-    program_option::COption, program_pack::Pack, pubkey::Pubkey, system_program, sysvar,
+    account_info::AccountInfo, entrypoint::ProgramResult, program::invoke, program_option::COption,
+    program_pack::Pack, pubkey::Pubkey, system_program, sysvar,
 };
 use spl_token::{instruction::AuthorityType as SplAuthorityType, state::Account};
 
@@ -409,7 +409,6 @@ fn create_persistent_delegate_v1(
     // token can be closed by the delegate on Burn. We assign CloseAuthority to
     // the metadata PDA so we can close it on Transfer and revoke it in Revoke.
     if matches!(role, TokenDelegateRole::Utility) {
-        msg!("Utility delegate");
         // If there's an existing close authority that is not the metadata account,
         // it willl need to be revoked by the original UtilityDelegate.
         if let COption::Some(close_authority) = token.close_authority {

--- a/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/token-metadata/program/src/processor/delegate/delegate.rs
@@ -4,8 +4,8 @@ use borsh::BorshSerialize;
 use mpl_token_auth_rules::utils::get_latest_revision;
 use mpl_utils::{assert_signer, create_or_allocate_account_raw};
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program::invoke, program_pack::Pack,
-    pubkey::Pubkey, system_program, sysvar,
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke,
+    program_option::COption, program_pack::Pack, pubkey::Pubkey, system_program, sysvar,
 };
 use spl_token::{instruction::AuthorityType as SplAuthorityType, state::Account};
 
@@ -406,23 +406,38 @@ fn create_persistent_delegate_v1(
     )?;
 
     // For Utility Delegates we request Close Authority as well so that the
-    // token can be closed by the delegate on Burn.
+    // token can be closed by the delegate on Burn. We assign CloseAuthority to
+    // the metadata PDA so we can close it on Transfer and revoke it in Revoke.
     if matches!(role, TokenDelegateRole::Utility) {
-        invoke(
-            &spl_token::instruction::set_authority(
-                spl_token_program_info.key,
-                token_info.key,
-                Some(ctx.accounts.delegate_info.key),
-                SplAuthorityType::CloseAccount,
-                ctx.accounts.authority_info.key,
-                &[],
-            )?,
-            &[
-                token_info.clone(),
-                ctx.accounts.delegate_info.clone(),
-                ctx.accounts.authority_info.clone(),
-            ],
-        )?;
+        msg!("Utility delegate");
+        // If there's an existing close authority that is not the metadata account,
+        // it willl need to be revoked by the original UtilityDelegate.
+        if let COption::Some(close_authority) = token.close_authority {
+            if &close_authority != ctx.accounts.metadata_info.key {
+                return Err(MetadataError::InvalidCloseAuthority.into());
+            }
+        } else {
+            let master_edition_info = ctx
+                .accounts
+                .master_edition_info
+                .ok_or(MetadataError::MissingEditionAccount)?;
+
+            invoke(
+                &spl_token::instruction::set_authority(
+                    spl_token_program_info.key,
+                    token_info.key,
+                    Some(master_edition_info.key),
+                    SplAuthorityType::CloseAccount,
+                    ctx.accounts.authority_info.key,
+                    &[],
+                )?,
+                &[
+                    token_info.clone(),
+                    ctx.accounts.delegate_info.clone(),
+                    ctx.accounts.authority_info.clone(),
+                ],
+            )?;
+        }
     }
 
     if matches!(

--- a/token-metadata/program/src/processor/delegate/revoke.rs
+++ b/token-metadata/program/src/processor/delegate/revoke.rs
@@ -1,14 +1,20 @@
 use mpl_utils::{assert_signer, close_account_raw, cmp_pubkeys};
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program::invoke, program_option::COption,
-    program_pack::Pack, pubkey::Pubkey, system_program, sysvar,
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    program::{invoke, invoke_signed},
+    program_option::COption,
+    program_pack::Pack,
+    pubkey::Pubkey,
+    system_program, sysvar,
 };
-use spl_token::state::Account;
+use spl_token::{instruction::AuthorityType as SplAuthorityType, state::Account};
 
 use crate::{
     assertions::{
         assert_keys_equal, assert_owned_by, metadata::assert_update_authority_is_correct,
     },
+    clear_close_authority, edition_seeds,
     error::MetadataError,
     instruction::{Context, MetadataDelegateRole, Revoke, RevokeArgs},
     pda::{find_metadata_delegate_record_account, find_token_record_account},
@@ -204,6 +210,46 @@ fn revoke_persistent_delegate_v1(
     } else {
         return Err(MetadataError::DelegateNotFound.into());
     }
+
+    clear_close_authority!(role, token, ctx);
+
+    // if matches!(role, TokenDelegateRole::Utility) {
+    //     // If there's an existing close authority that is not the master edition account,
+    //     // it willl need to be revoked by the original UtilityDelegate.
+    //     if let COption::Some(close_authority) = token.close_authority {
+    //         if &close_authority != ctx.accounts.metadata_info.key {
+    //             return Err(MetadataError::InvalidCloseAuthority.into());
+    //         } else {
+    //             let master_edition_info = ctx
+    //                 .accounts
+    //                 .master_edition_info
+    //                 .ok_or(MetadataError::MissingEditionAccount)?;
+
+    //             // Clear the close authority using the Master Edition PDA as the signer.
+    //             let ix = spl_token::instruction::set_authority(
+    //                 spl_token_program_info.key,
+    //                 token_info.key,
+    //                 None,
+    //                 spl_token::instruction::AuthorityType::CloseAccount,
+    //                 master_edition_info.key,
+    //                 &[],
+    //             )
+    //             .unwrap();
+
+    //             let seeds = edition_seeds!(ctx.accounts.mint_info.key);
+
+    //             invoke_signed(
+    //                 &ix,
+    //                 &[
+    //                     token_info.clone(),
+    //                     ctx.accounts.metadata_info.clone(),
+    //                     spl_token_program_info.clone(),
+    //                 ],
+    //                 &[seeds.as_slice()],
+    //             )?;
+    //         }
+    //     }
+    // }
 
     // process the revoke
 

--- a/token-metadata/program/src/processor/delegate/revoke.rs
+++ b/token-metadata/program/src/processor/delegate/revoke.rs
@@ -205,22 +205,6 @@ fn revoke_persistent_delegate_v1(
         return Err(MetadataError::DelegateNotFound.into());
     }
 
-    let master_edition_info = ctx
-        .accounts
-        .master_edition_info
-        .ok_or(MetadataError::MissingEditionAccount)?;
-
-    if matches!(role, TokenDelegateRole::Utility) {
-        clear_close_authority(ClearCloseAuthorityParams {
-            token_info,
-            mint_info: ctx.accounts.mint_info,
-            token,
-            master_edition_info,
-            authority_info: master_edition_info,
-            spl_token_program_info,
-        })?;
-    }
-
     // process the revoke
 
     // programmables assets can have delegates from any role apart from `Standard`
@@ -274,6 +258,18 @@ fn revoke_persistent_delegate_v1(
                     master_edition_info.clone(),
                     spl_token_program_info.clone(),
                 )?;
+
+                // Clear the close authority if it's a Utility Delegate.
+                if matches!(role, TokenDelegateRole::Utility) {
+                    clear_close_authority(ClearCloseAuthorityParams {
+                        token_info,
+                        mint_info: ctx.accounts.mint_info,
+                        token,
+                        master_edition_info,
+                        authority_info: master_edition_info,
+                        spl_token_program_info,
+                    })?;
+                }
             } else {
                 return Err(MetadataError::MissingEditionAccount.into());
             }

--- a/token-metadata/program/src/processor/metadata/transfer.rs
+++ b/token-metadata/program/src/processor/metadata/transfer.rs
@@ -399,23 +399,9 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
                 spl_token_program_info: ctx.accounts.spl_token_program_info,
             })?;
 
-            // let edition_seeds = edition_seeds!(ctx.accounts.mint_info.key);
-
-            // let (owner, authority_signer_seeds) =
-            //     if let COption::Some(close_authority) = token.close_authority {
-            //         if &close_authority != master_edition_info.key {
-            //             return Err(MetadataError::InvalidCloseAuthority.into());
-            //         }
-            //         (master_edition_info.clone(), Some(edition_seeds.as_slice()))
-            //     } else {
-            //         (ctx.accounts.token_owner_info.clone(), None)
-            //     };
-
             // If the token record account for the destination owner doesn't exist,
             // we create it.
             if destination_token_record_info.data_is_empty() {
-                msg!("Init new token record");
-
                 create_token_record_account(
                     program_id,
                     destination_token_record_info,

--- a/token-metadata/program/src/processor/metadata/transfer.rs
+++ b/token-metadata/program/src/processor/metadata/transfer.rs
@@ -412,10 +412,13 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
                 )?;
             }
 
-            // Close the source Token Record account, but do it after the CPI calls
-            // so as to avoid Unbalanced Accounts errors due to the CPI context not knowing
-            // about the manual lamport math done here.
-            close_program_account(owner_token_record_info, ctx.accounts.payer_info)?;
+            // Don't close token record if it's a self transfer.
+            if owner_token_record_info.key != destination_token_record_info.key {
+                // Close the source Token Record account, but do it after the CPI calls
+                // so as to avoid Unbalanced Accounts errors due to the CPI context not knowing
+                // about the manual lamport math done here.
+                close_program_account(owner_token_record_info, ctx.accounts.payer_info)?;
+            }
         }
         _ => mpl_utils::token::spl_token_transfer(token_transfer_params).unwrap(),
     }

--- a/token-metadata/program/src/processor/mod.rs
+++ b/token-metadata/program/src/processor/mod.rs
@@ -330,7 +330,7 @@ fn process_legacy_instruction<'a>(
             set_and_verify_sized_collection_item(program_id, accounts)
         }
         MetadataInstruction::UnverifySizedCollectionItem => {
-            msg!("IX: Unverify Collection");
+            msg!("IX: Unverify Sized Collection");
             unverify_sized_collection_item(program_id, accounts)
         }
         MetadataInstruction::SetCollectionSize(args) => {

--- a/token-metadata/program/src/state/master_edition.rs
+++ b/token-metadata/program/src/state/master_edition.rs
@@ -37,6 +37,26 @@ pub fn get_master_edition(account: &AccountInfo) -> Result<Box<dyn MasterEdition
     master_edition_result
 }
 
+#[macro_export]
+macro_rules! edition_seeds {
+    ($mint:expr) => {{
+        let path = vec![
+            "metadata".as_bytes(),
+            $crate::ID.as_ref(),
+            $mint.as_ref(),
+            "edition".as_bytes(),
+        ];
+        let (_, bump) = Pubkey::find_program_address(&path, &$crate::ID);
+        &[
+            "metadata".as_bytes(),
+            $crate::ID.as_ref(),
+            $mint.as_ref(),
+            "edition".as_bytes(),
+            &[bump],
+        ]
+    }};
+}
+
 #[repr(C)]
 #[cfg_attr(feature = "serde-feature", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, ShankAccount)]

--- a/token-metadata/program/src/state/metadata.rs
+++ b/token-metadata/program/src/state/metadata.rs
@@ -41,6 +41,20 @@ pub const MAX_DATA_SIZE: usize = 4
     + 4
     + MAX_CREATOR_LIMIT * MAX_CREATOR_LEN;
 
+#[macro_export]
+macro_rules! metadata_seeds {
+    ($mint:expr) => {{
+        let path = vec!["metadata".as_bytes(), $crate::ID.as_ref(), $mint.as_ref()];
+        let (_, bump) = Pubkey::find_program_address(&path, &$crate::ID);
+        &[
+            "metadata".as_bytes(),
+            $crate::ID.as_ref(),
+            $mint.as_ref(),
+            &[bump],
+        ]
+    }};
+}
+
 #[repr(C)]
 #[cfg_attr(feature = "serde-feature", derive(Serialize, Deserialize))]
 #[derive(Clone, BorshSerialize, Debug, PartialEq, Eq, ShankAccount)]

--- a/token-metadata/program/src/utils/mod.rs
+++ b/token-metadata/program/src/utils/mod.rs
@@ -334,37 +334,3 @@ macro_rules! set_close_authority {
         }
     };
 }
-
-#[macro_export]
-macro_rules! clear_close_authority {
-    ($role:expr, $token:expr, $ctx:expr) => {
-        if matches!($role, TokenDelegateRole::Utility) {
-            // If there's an existing close authority that is not the metadata account,
-            // it willl need to be revoked by the original UtilityDelegate.
-            if let COption::Some(close_authority) = $token.close_authority {
-                if &close_authority != $ctx.accounts.metadata_info.key {
-                    return Err(MetadataError::InvalidCloseAuthority.into());
-                }
-            } else {
-                let seeds = edition_seeds!($ctx.accounts.mint_info.key);
-
-                invoke_signed(
-                    &spl_token::instruction::set_authority(
-                        $ctx.accounts.spl_token_program_info.unwrap().key,
-                        $ctx.accounts.token_info.unwrap().key,
-                        None,
-                        SplAuthorityType::CloseAccount,
-                        $ctx.accounts.authority_info.key,
-                        &[],
-                    )?,
-                    &[
-                        $ctx.accounts.token_info.unwrap().clone(),
-                        $ctx.accounts.delegate_info.clone(),
-                        $ctx.accounts.authority_info.clone(),
-                    ],
-                    &[seeds.as_slice()],
-                )?;
-            }
-        }
-    };
-}

--- a/token-metadata/program/src/utils/mod.rs
+++ b/token-metadata/program/src/utils/mod.rs
@@ -288,13 +288,3 @@ mod tests {
         assert_eq!(metadata, expected_metadata);
     }
 }
-
-#[macro_export]
-macro_rules! unwrap_or_error(
-    ($option:expr, $err:expr) => {
-        match $option {
-            Ok(val) => val,
-            Err(_) => return Err($err),
-        }
-    };
-);

--- a/token-metadata/program/src/utils/mod.rs
+++ b/token-metadata/program/src/utils/mod.rs
@@ -298,39 +298,3 @@ macro_rules! unwrap_or_error(
         }
     };
 );
-
-#[macro_export]
-macro_rules! set_close_authority {
-    ($role:expr, $token:expr, $ctx:expr) => {
-        if matches!($role, TokenDelegateRole::Utility) {
-            // If there's an existing close authority that is not the metadata account,
-            // it willl need to be revoked by the original UtilityDelegate.
-            if let COption::Some(close_authority) = $token.close_authority {
-                if &close_authority != $ctx.accounts.metadata_info.key {
-                    return Err(MetadataError::InvalidCloseAuthority.into());
-                }
-            } else {
-                let master_edition_info = $ctx
-                    .accounts
-                    .master_edition_info
-                    .ok_or(MetadataError::MissingEditionAccount)?;
-
-                invoke(
-                    &spl_token::instruction::set_authority(
-                        $ctx.accounts.spl_token_program_info.unwrap().key,
-                        $ctx.accounts.token_info.unwrap().key,
-                        Some(master_edition_info.key),
-                        SplAuthorityType::CloseAccount,
-                        $ctx.accounts.authority_info.key,
-                        &[],
-                    )?,
-                    &[
-                        $ctx.accounts.token_info.unwrap().clone(),
-                        $ctx.accounts.delegate_info.clone(),
-                        $ctx.accounts.authority_info.clone(),
-                    ],
-                )?;
-            }
-        }
-    };
-}

--- a/token-metadata/program/src/utils/programmable_asset.rs
+++ b/token-metadata/program/src/utils/programmable_asset.rs
@@ -5,12 +5,16 @@ use mpl_token_auth_rules::{
 use mpl_utils::{create_or_allocate_account_raw, token::TokenTransferParams};
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke_signed,
-    program_error::ProgramError, pubkey::Pubkey,
+    program_error::ProgramError, program_option::COption, pubkey::Pubkey,
 };
-use spl_token::instruction::{freeze_account, thaw_account};
+use spl_token::{
+    instruction::{freeze_account, thaw_account, AuthorityType as SplAuthorityType},
+    state::Account,
+};
 
 use crate::{
     assertions::{assert_derivation, programmable::assert_valid_authorization},
+    edition_seeds,
     error::MetadataError,
     pda::{EDITION, PREFIX},
     processor::{AuthorizationData, TransferScenario},
@@ -329,6 +333,55 @@ pub fn frozen_transfer<'a, 'b>(
         master_edition_info.clone(),
         token_program_info.clone(),
     )?;
+
+    Ok(())
+}
+
+pub(crate) struct ClearCloseAuthorityParams<'a> {
+    pub token: Account,
+    pub mint_info: &'a AccountInfo<'a>,
+    pub token_info: &'a AccountInfo<'a>,
+    pub master_edition_info: &'a AccountInfo<'a>,
+    pub authority_info: &'a AccountInfo<'a>,
+    pub spl_token_program_info: &'a AccountInfo<'a>,
+}
+
+pub(crate) fn clear_close_authority(params: ClearCloseAuthorityParams) -> ProgramResult {
+    let ClearCloseAuthorityParams {
+        token,
+        mint_info,
+        token_info,
+        master_edition_info,
+        authority_info,
+        spl_token_program_info,
+    } = params;
+
+    // If there's an existing close authority that is not the metadata account,
+    // it willl need to be revoked by the original UtilityDelegate.
+    if let COption::Some(close_authority) = token.close_authority {
+        msg!("Existing close authority: {:?}", close_authority);
+        msg!("Master edition: {:?}", master_edition_info.key);
+        if &close_authority != master_edition_info.key {
+            return Err(MetadataError::InvalidCloseAuthority.into());
+        }
+        msg!("Clearing close authority");
+        let seeds = edition_seeds!(mint_info.key);
+
+        invoke_signed(
+            &spl_token::instruction::set_authority(
+                spl_token_program_info.key,
+                token_info.key,
+                None,
+                SplAuthorityType::CloseAccount,
+                authority_info.key,
+                &[],
+            )?,
+            &[token_info.clone(), authority_info.clone()],
+            &[seeds.as_slice()],
+        )?;
+    } else {
+        msg!("No close authority");
+    }
 
     Ok(())
 }

--- a/token-metadata/program/src/utils/programmable_asset.rs
+++ b/token-metadata/program/src/utils/programmable_asset.rs
@@ -357,7 +357,7 @@ pub(crate) fn clear_close_authority(params: ClearCloseAuthorityParams) -> Progra
     } = params;
 
     // If there's an existing close authority that is not the metadata account,
-    // it willl need to be revoked by the original UtilityDelegate.
+    // it will need to be revoked by the original UtilityDelegate.
     if let COption::Some(close_authority) = token.close_authority {
         if &close_authority != master_edition_info.key {
             return Err(MetadataError::InvalidCloseAuthority.into());

--- a/token-metadata/program/src/utils/programmable_asset.rs
+++ b/token-metadata/program/src/utils/programmable_asset.rs
@@ -359,12 +359,9 @@ pub(crate) fn clear_close_authority(params: ClearCloseAuthorityParams) -> Progra
     // If there's an existing close authority that is not the metadata account,
     // it willl need to be revoked by the original UtilityDelegate.
     if let COption::Some(close_authority) = token.close_authority {
-        msg!("Existing close authority: {:?}", close_authority);
-        msg!("Master edition: {:?}", master_edition_info.key);
         if &close_authority != master_edition_info.key {
             return Err(MetadataError::InvalidCloseAuthority.into());
         }
-        msg!("Clearing close authority");
         let seeds = edition_seeds!(mint_info.key);
 
         invoke_signed(
@@ -379,8 +376,6 @@ pub(crate) fn clear_close_authority(params: ClearCloseAuthorityParams) -> Progra
             &[token_info.clone(), authority_info.clone()],
             &[seeds.as_slice()],
         )?;
-    } else {
-        msg!("No close authority");
     }
 
     Ok(())

--- a/token-metadata/program/tests/delegate.rs
+++ b/token-metadata/program/tests/delegate.rs
@@ -270,8 +270,11 @@ mod delegate {
             assert_eq!(token_account.delegate, COption::Some(user_pubkey));
             assert_eq!(token_account.delegated_amount, 1);
 
-            // Utilty Delegate should also have the Close Authority so it can burn.
-            assert_eq!(token_account.close_authority, COption::Some(user_pubkey));
+            // Close Authority should be set to the asset's Master Edition key.
+            assert_eq!(
+                token_account.close_authority,
+                COption::Some(asset.edition.unwrap())
+            );
         } else {
             panic!("Missing token account");
         }

--- a/token-metadata/program/tests/delegate.rs
+++ b/token-metadata/program/tests/delegate.rs
@@ -615,7 +615,6 @@ mod delegate {
 
         let delegate = Keypair::new();
         let delegate_pubkey = delegate.pubkey();
-        // delegate.airdrop(&mut context, 1_000_000).await.unwrap();
 
         let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
 

--- a/token-metadata/program/tests/delegate.rs
+++ b/token-metadata/program/tests/delegate.rs
@@ -590,6 +590,52 @@ mod delegate {
 
         // asserts
 
-        assert_custom_error_ix!(1, error, RuleSetError::ProgramOwnedListCheckFailed);
+        assert_custom_error_ix!(1, error, RuleSetError::DataIsEmpty);
+    }
+
+    #[tokio::test]
+    async fn invalid_close_authority_fails() {
+        let mut context = program_test().start_with_context().await;
+
+        // asset
+
+        let mut asset = DigitalAsset::default();
+        asset
+            .create_and_mint(
+                &mut context,
+                TokenStandard::ProgrammableNonFungible,
+                None,
+                None,
+                1,
+            )
+            .await
+            .unwrap();
+
+        assert!(asset.token.is_some());
+
+        let delegate = Keypair::new();
+        let delegate_pubkey = delegate.pubkey();
+        // delegate.airdrop(&mut context, 1_000_000).await.unwrap();
+
+        let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
+
+        asset
+            .inject_close_authority(&mut context, &delegate_pubkey)
+            .await;
+
+        let err = asset
+            .delegate(
+                &mut context,
+                payer,
+                delegate_pubkey,
+                DelegateArgs::UtilityV1 {
+                    amount: 1,
+                    authorization_data: None,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert_custom_error_ix!(1, err, MetadataError::InvalidCloseAuthority);
     }
 }

--- a/token-metadata/program/tests/revoke.rs
+++ b/token-metadata/program/tests/revoke.rs
@@ -518,4 +518,154 @@ mod revoke {
             panic!("Missing token account");
         }
     }
+
+    #[tokio::test]
+    async fn revoke_utility_delegate_programmable_nonfungible() {
+        let mut context = program_test().start_with_context().await;
+
+        // asset
+
+        let mut asset = DigitalAsset::default();
+        asset
+            .create_and_mint(
+                &mut context,
+                TokenStandard::ProgrammableNonFungible,
+                None,
+                None,
+                1,
+            )
+            .await
+            .unwrap();
+
+        assert!(asset.token.is_some());
+
+        let user = Keypair::new();
+        let user_pubkey = user.pubkey();
+        let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
+
+        asset
+            .delegate(
+                &mut context,
+                payer,
+                user_pubkey,
+                DelegateArgs::UtilityV1 {
+                    amount: 1,
+                    authorization_data: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // checks that the delegate exists
+
+        let (pda_key, _) = find_token_record_account(&asset.mint.pubkey(), &asset.token.unwrap());
+
+        let pda = get_account(&mut context, &pda_key).await;
+        let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
+
+        assert_eq!(token_record.delegate, Some(user_pubkey));
+
+        let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
+        let approver = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
+
+        // revokes the delegate
+        asset
+            .revoke(
+                &mut context,
+                payer,
+                approver,
+                user_pubkey,
+                RevokeArgs::UtilityV1,
+            )
+            .await
+            .unwrap();
+
+        // asserts
+
+        let pda = get_account(&mut context, &pda_key).await;
+        let token_record: TokenRecord = try_from_slice_unchecked(&pda.data).unwrap();
+
+        assert_eq!(token_record.delegate, None);
+
+        if let Some(token) = asset.token {
+            let account = get_account(&mut context, &token).await;
+            let token_account = Account::unpack(&account.data).unwrap();
+
+            assert!(token_account.is_frozen());
+            assert_eq!(token_account.delegate, COption::None);
+        } else {
+            panic!("Missing token account");
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_close_authority_fails() {
+        let mut context = program_test().start_with_context().await;
+
+        // asset
+
+        let mut asset = DigitalAsset::default();
+        asset
+            .create_and_mint(
+                &mut context,
+                TokenStandard::ProgrammableNonFungible,
+                None,
+                None,
+                1,
+            )
+            .await
+            .unwrap();
+
+        assert!(asset.token.is_some());
+
+        let user = Keypair::new();
+        let user_pubkey = user.pubkey();
+        let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();
+
+        asset
+            .delegate(
+                &mut context,
+                payer,
+                user_pubkey,
+                DelegateArgs::UtilityV1 {
+                    amount: 1,
+                    authorization_data: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // To simulate the state where the close authority is set delegate instead of
+        // the asset's master edition account, we need to inject modified token account state.
+        let mut token_account = get_account(&mut context, &asset.token.unwrap()).await;
+        let mut token = Account::unpack(&token_account.data).unwrap();
+
+        token.close_authority = COption::Some(user_pubkey);
+        let mut data = vec![0u8; Account::LEN];
+        let buffer = &mut data[..Account::LEN];
+        Account::pack(token, buffer).unwrap();
+        token_account.data = buffer.to_vec();
+
+        let token_account_shared_data: AccountSharedData = token_account.into();
+        context.set_account(&asset.token.unwrap(), &token_account_shared_data);
+
+        let payer = context.payer.dirty_clone();
+        let approver = context.payer.dirty_clone();
+
+        // Now we call revoke, expecting to get an error since neither the owner nor Token Metadata
+        // have the authority to clear the close authority.
+        // revokes the delegate
+        let err = asset
+            .revoke(
+                &mut context,
+                payer,
+                approver,
+                user_pubkey,
+                RevokeArgs::UtilityV1,
+            )
+            .await
+            .unwrap_err();
+
+        assert_custom_error!(err, MetadataError::InvalidCloseAuthority);
+    }
 }

--- a/token-metadata/program/tests/revoke.rs
+++ b/token-metadata/program/tests/revoke.rs
@@ -592,7 +592,8 @@ mod revoke {
             let token_account = Account::unpack(&account.data).unwrap();
 
             assert!(token_account.is_frozen());
-            assert_eq!(token_account.delegate, COption::None);
+            assert!(token_account.delegate.is_none());
+            assert!(token_account.close_authority.is_none());
         } else {
             panic!("Missing token account");
         }

--- a/token-metadata/program/tests/utils/digital_asset.rs
+++ b/token-metadata/program/tests/utils/digital_asset.rs
@@ -79,6 +79,11 @@ impl DigitalAsset {
         }
     }
 
+    pub fn set_edition(&mut self) {
+        let edition = find_master_edition_account(&self.mint.pubkey()).0;
+        self.edition = Some(edition);
+    }
+
     pub async fn burn(
         &mut self,
         context: &mut ProgramTestContext,
@@ -120,6 +125,7 @@ impl DigitalAsset {
         }
 
         if let Some(edition) = self.edition {
+            println!("edition: {:?}", edition);
             builder.edition(edition);
         }
 
@@ -423,6 +429,17 @@ impl DigitalAsset {
         // mints tokens
         self.mint(context, authorization_rules, authorization_data, amount)
             .await
+            .unwrap();
+
+        if matches!(
+            token_standard,
+            TokenStandard::NonFungible
+                | TokenStandard::ProgrammableNonFungible
+                | TokenStandard::NonFungibleEdition
+        ) {
+            self.set_edition();
+        }
+        Ok(())
     }
 
     pub async fn create_and_mint_with_creators(
@@ -454,6 +471,18 @@ impl DigitalAsset {
         // mints tokens
         self.mint(context, authorization_rules, authorization_data, amount)
             .await
+            .unwrap();
+
+        if matches!(
+            token_standard,
+            TokenStandard::NonFungible
+                | TokenStandard::ProgrammableNonFungible
+                | TokenStandard::NonFungibleEdition
+        ) {
+            self.set_edition();
+        }
+
+        Ok(())
     }
 
     pub async fn create_and_mint_item_with_collection(
@@ -485,6 +514,18 @@ impl DigitalAsset {
         // mints tokens
         self.mint(context, authorization_rules, authorization_data, amount)
             .await
+            .unwrap();
+
+        if matches!(
+            token_standard,
+            TokenStandard::NonFungible
+                | TokenStandard::ProgrammableNonFungible
+                | TokenStandard::NonFungibleEdition
+        ) {
+            self.set_edition();
+        }
+
+        Ok(())
     }
 
     pub async fn create_and_mint_collection_parent(
@@ -516,6 +557,18 @@ impl DigitalAsset {
         // mints tokens
         self.mint(context, authorization_rules, authorization_data, amount)
             .await
+            .unwrap();
+
+        if matches!(
+            token_standard,
+            TokenStandard::NonFungible
+                | TokenStandard::ProgrammableNonFungible
+                | TokenStandard::NonFungibleEdition
+        ) {
+            self.set_edition();
+        }
+
+        Ok(())
     }
 
     pub async fn create_and_mint_nonfungible(
@@ -541,7 +594,11 @@ impl DigitalAsset {
         .unwrap();
 
         // mints tokens
-        self.mint(context, None, None, 1).await
+        self.mint(context, None, None, 1).await.unwrap();
+
+        self.set_edition();
+
+        Ok(())
     }
 
     pub async fn delegate(

--- a/token-metadata/program/tests/utils/digital_asset.rs
+++ b/token-metadata/program/tests/utils/digital_asset.rs
@@ -429,17 +429,6 @@ impl DigitalAsset {
         // mints tokens
         self.mint(context, authorization_rules, authorization_data, amount)
             .await
-            .unwrap();
-
-        if matches!(
-            token_standard,
-            TokenStandard::NonFungible
-                | TokenStandard::ProgrammableNonFungible
-                | TokenStandard::NonFungibleEdition
-        ) {
-            self.set_edition();
-        }
-        Ok(())
     }
 
     pub async fn create_and_mint_with_creators(
@@ -471,18 +460,6 @@ impl DigitalAsset {
         // mints tokens
         self.mint(context, authorization_rules, authorization_data, amount)
             .await
-            .unwrap();
-
-        if matches!(
-            token_standard,
-            TokenStandard::NonFungible
-                | TokenStandard::ProgrammableNonFungible
-                | TokenStandard::NonFungibleEdition
-        ) {
-            self.set_edition();
-        }
-
-        Ok(())
     }
 
     pub async fn create_and_mint_item_with_collection(
@@ -514,18 +491,6 @@ impl DigitalAsset {
         // mints tokens
         self.mint(context, authorization_rules, authorization_data, amount)
             .await
-            .unwrap();
-
-        if matches!(
-            token_standard,
-            TokenStandard::NonFungible
-                | TokenStandard::ProgrammableNonFungible
-                | TokenStandard::NonFungibleEdition
-        ) {
-            self.set_edition();
-        }
-
-        Ok(())
     }
 
     pub async fn create_and_mint_collection_parent(
@@ -557,18 +522,6 @@ impl DigitalAsset {
         // mints tokens
         self.mint(context, authorization_rules, authorization_data, amount)
             .await
-            .unwrap();
-
-        if matches!(
-            token_standard,
-            TokenStandard::NonFungible
-                | TokenStandard::ProgrammableNonFungible
-                | TokenStandard::NonFungibleEdition
-        ) {
-            self.set_edition();
-        }
-
-        Ok(())
     }
 
     pub async fn create_and_mint_nonfungible(
@@ -594,11 +547,7 @@ impl DigitalAsset {
         .unwrap();
 
         // mints tokens
-        self.mint(context, None, None, 1).await.unwrap();
-
-        self.set_edition();
-
-        Ok(())
+        self.mint(context, None, None, 1).await
     }
 
     pub async fn delegate(

--- a/token-metadata/program/tests/utils/digital_asset.rs
+++ b/token-metadata/program/tests/utils/digital_asset.rs
@@ -1102,9 +1102,8 @@ impl DigitalAsset {
 
         token.close_authority = COption::Some(*close_authority);
         let mut data = vec![0u8; Account::LEN];
-        let buffer = &mut data[..Account::LEN];
-        Account::pack(token, buffer).unwrap();
-        token_account.data = buffer.to_vec();
+        Account::pack(token, &mut data).unwrap();
+        token_account.data = data;
 
         let token_account_shared_data: AccountSharedData = token_account.into();
         context.set_account(&self.token.unwrap(), &token_account_shared_data);

--- a/token-metadata/program/tests/utils/programmable.rs
+++ b/token-metadata/program/tests/utils/programmable.rs
@@ -160,16 +160,13 @@ pub async fn create_default_metaplex_rule_set(
             .unwrap();
     } else {
         royalty_rule_set
-            .add(delegate_sale_operation.to_string(), Rule::Pass.clone())
+            .add(delegate_sale_operation.to_string(), Rule::Pass)
             .unwrap();
         royalty_rule_set
-            .add(
-                delegate_lockedtransfer_operation.to_string(),
-                Rule::Pass.clone(),
-            )
+            .add(delegate_lockedtransfer_operation.to_string(), Rule::Pass)
             .unwrap();
         royalty_rule_set
-            .add(delegate_transfer_operation.to_string(), Rule::Pass.clone())
+            .add(delegate_transfer_operation.to_string(), Rule::Pass)
             .unwrap();
         royalty_rule_set
             .add(delegate_utility_operation.to_string(), Rule::Pass)

--- a/token-metadata/program/tests/utils/programmable.rs
+++ b/token-metadata/program/tests/utils/programmable.rs
@@ -121,6 +121,10 @@ pub async fn create_default_metaplex_rule_set(
         scenario: DelegateScenario::Token(TokenDelegateRole::Transfer),
     };
 
+    let delegate_utility_operation = Operation::Delegate {
+        scenario: DelegateScenario::Token(TokenDelegateRole::Utility),
+    };
+
     let mut royalty_rule_set = RuleSetV1::new(name, creator.pubkey());
     royalty_rule_set
         .add(owner_operation.to_string(), transfer_rule.clone())
@@ -146,7 +150,13 @@ pub async fn create_default_metaplex_rule_set(
             )
             .unwrap();
         royalty_rule_set
-            .add(delegate_transfer_operation.to_string(), delegate_rule)
+            .add(
+                delegate_transfer_operation.to_string(),
+                delegate_rule.clone(),
+            )
+            .unwrap();
+        royalty_rule_set
+            .add(delegate_utility_operation.to_string(), delegate_rule)
             .unwrap();
     } else {
         royalty_rule_set
@@ -160,6 +170,9 @@ pub async fn create_default_metaplex_rule_set(
             .unwrap();
         royalty_rule_set
             .add(delegate_transfer_operation.to_string(), Rule::Pass.clone())
+            .unwrap();
+        royalty_rule_set
+            .add(delegate_utility_operation.to_string(), Rule::Pass)
             .unwrap();
     }
 

--- a/token-metadata/program/tests/utils/rooster_manager.rs
+++ b/token-metadata/program/tests/utils/rooster_manager.rs
@@ -44,7 +44,7 @@ impl RoosterManager {
     }
 
     pub async fn withdraw(
-        self,
+        &self,
         context: &mut ProgramTestContext,
         authority: &Keypair,
         destination_owner: Pubkey,


### PR DESCRIPTION
## Issue
In the present system, a `UtilityDelegate` is granted `CloseAuthority` on the token account to enable token burning. Upon transfer, the token account remains open, and although the SPL token program resets the delegate, it does not clear the `CloseAuthority`. Consequently, re-delegation of the token fails due to a mismatch between the current close authority and the calling authority (i.e., the owner). The SPL program only permits the current `CloseAuthority` to change to a new close authority, and if none is set, it defaults to the owner. However, the owner is unable to modify the `CloseAuthority` once established.
Additionally, the owner cannot revoke a `UtilityDelegate`, which is an unintended side effect resulting from granting `UtilityDelegates` the burn capability. A feasible solution requires either clearing the `CloseAuthority` or closing the token account upon transfer. However, the `UtilityDelegate` is unable to perform these actions, as it is not a signer on either the Transfer or Revoke instructions. Adding it as an additional signer introduces a breaking change and an extra account, which is undesirable.

## Solution
The solution in this PR entails using the master edition account of the asset as the actual `CloseAuthority` stored on the token account. This allows Token Metadata to sign via Cross-Program Invocation (CPI) to clear the close authority or close the token account. This method is viable since the master edition account is already included in `Delegate`, `Revoke`, and `Transfer` instructions. The actual `UtilityDelegate` will continue to be stored in the token record for validation purposes, but upon validation, if the delegate role is `Utility`, the master edition PDA will be employed as the signer instead of the standard authority.

## Implementation
This solution updates `Delegate`, `Revoke`, and `Transfer` instructions to accommodate the proposed changes and return informative errors in cases where there is an existing `CloseAuthority` that is not the asset's master edition account. 

The implementation adds a new helper function to `utils/programmable_asset.rs` called `clear_close_authority`. It checks the provided token account for an existing close authority and fails if it's not set to the master edition account. Otherwise, it calls SPL token's `set_authority` instruction with the new authority set to `None`.

```rust
pub(crate) fn clear_close_authority(params: ClearCloseAuthorityParams) -> ProgramResult {
    let ClearCloseAuthorityParams {
        token,
        mint_info,
        token_info,
        master_edition_info,
        authority_info,
        spl_token_program_info,
    } = params;

    // If there's an existing close authority that is not the metadata account,
    // it willl need to be revoked by the original UtilityDelegate.
    if let COption::Some(close_authority) = token.close_authority {
        msg!("Existing close authority: {:?}", close_authority);
        msg!("Master edition: {:?}", master_edition_info.key);
        if &close_authority != master_edition_info.key {
            return Err(MetadataError::InvalidCloseAuthority.into());
        }
        msg!("Clearing close authority");
        let seeds = edition_seeds!(mint_info.key);

        invoke_signed(
            &spl_token::instruction::set_authority(
                spl_token_program_info.key,
                token_info.key,
                None,
                SplAuthorityType::CloseAccount,
                authority_info.key,
                &[],
            )?,
            &[token_info.clone(), authority_info.clone()],
            &[seeds.as_slice()],
        )?;
    } else {
        msg!("No close authority");
    }

    Ok(())
}
```

In addition, a new macro was added to `state/master_edition.rs` called `edition_seeds` which reduces the redundant code required to generate edition seeds in a manner useful to pass into `invoke_sign` calls as signing seeds.

```rust
#[macro_export]
macro_rules! edition_seeds {
    ($mint:expr) => {{
        let path = vec![
            "metadata".as_bytes(),
            $crate::ID.as_ref(),
            $mint.as_ref(),
            "edition".as_bytes(),
        ];
        let (_, bump) = Pubkey::find_program_address(&path, &$crate::ID);
        &[
            "metadata".as_bytes(),
            $crate::ID.as_ref(),
            $mint.as_ref(),
            "edition".as_bytes(),
            &[bump],
        ]
    }};
}
```

Finally, a new error was also added to inform the user of the case where there is an invalid close authority that is not the master edition pubkey:

```rust
    /// 188
    #[error("The close authority needs to be revoked by the Utility Delegate")]
    InvalidCloseAuthority,
```


### Delegate
When delegating a `UtilityDelegate` we request Close Authority and now assign it to the asset's master edition account. We check if there's an existing `CloseAuthority` that is not the master edition account and fail in that case as the delegate will need to clear the `CloseAuthority` manually in that case.

```rust
    // For Utility Delegates we request Close Authority as well so that the
    // token can be closed by the delegate on Burn. We assign CloseAuthority to
    // the metadata PDA so we can close it on Transfer and revoke it in Revoke.
    if matches!(role, TokenDelegateRole::Utility) {
        // If there's an existing close authority that is not the metadata account,
        // it willl need to be revoked by the original UtilityDelegate.
        if let COption::Some(close_authority) = token.close_authority {
            if &close_authority != ctx.accounts.metadata_info.key {
                return Err(MetadataError::InvalidCloseAuthority.into());
            }
        } else {
            let master_edition_info = ctx
                .accounts
                .master_edition_info
                .ok_or(MetadataError::MissingEditionAccount)?;

            invoke(
                &spl_token::instruction::set_authority(
                    spl_token_program_info.key,
                    token_info.key,
                    Some(master_edition_info.key),
                    SplAuthorityType::CloseAccount,
                    ctx.accounts.authority_info.key,
                    &[],
                )?,
                &[
                    token_info.clone(),
                    ctx.accounts.delegate_info.clone(),
                    ctx.accounts.authority_info.clone(),
                ],
            )?;
        }
    }
```

### Revoke
When revoking we check if it's a `UtilityDelegate` and ensure we clear the `CloseAuthority` in addition to the rest of the delegate data.

```rust
                // Clear the close authority if it's a Utility Delegate.
                if matches!(role, TokenDelegateRole::Utility) {
                    clear_close_authority(ClearCloseAuthorityParams {
                        token_info,
                        mint_info: ctx.accounts.mint_info,
                        token,
                        master_edition_info,
                        authority_info: master_edition_info,
                        spl_token_program_info,
                    })?;
                }
```

### Transfer
Transfers of pNFTs now 1) clear the close authority if present and 2) close the source token record. The first is needed as the rest of the delegate data is cleared on transfer so this keeps our delegate abstraction synced up with the underlying SPL token delegate. The latter is just a rent reclamation change and something users have requested.

Token accounts are not closed in the current implementation because they cannot be closed consistently in all cases. They can only be closed on owner transfers because only owners or the master edition as close authority can close token accounts. Transfer delegates such as Sale and Transfer don't have close authority and are not the owner of the token account so cannot close it.