### PR TITLE
Adding expiration for delegates

### DIFF
--- a/token-metadata/program/src/error.rs
+++ b/token-metadata/program/src/error.rs
@@ -741,6 +741,14 @@ pub enum MetadataError {
     /// 187
     #[error("Invalid token record account")]
     InvalidTokenRecord,
+
+    /// 188
+    #[error("Invalid metadata delegate record account")]
+    InvalidDelegateRecord,
+
+    /// 189
+    #[error("Delegate has expired")]
+    DelegateExpired,
 }
 
 impl PrintProgramError for MetadataError {

--- a/token-metadata/program/src/instruction/delegate.rs
+++ b/token-metadata/program/src/instruction/delegate.rs
@@ -120,6 +120,26 @@ impl fmt::Display for MetadataDelegateRole {
     }
 }
 
+pub trait MetadataDelegateExpiration {
+    fn expiration_time_secs(&self) -> i64;
+}
+
+impl MetadataDelegateExpiration for MetadataDelegateRole {
+    fn expiration_time_secs(&self) -> i64 {
+        let one_week: i64 = 3600 * 24 * 7;
+        let four_weeks = one_week * 4;
+        match self {
+            Self::Authority => one_week,
+            Self::Collection => four_weeks,
+            Self::Use => four_weeks,
+            Self::Data => four_weeks,
+            Self::ProgrammableConfig => four_weeks,
+            Self::CollectionItem => four_weeks,
+            Self::ProgrammableConfigItem => four_weeks,
+        }
+    }
+}
+
 /// Delegates an action over an asset to a specific account.
 ///
 /// # Accounts:

--- a/token-metadata/program/src/state/delegate.rs
+++ b/token-metadata/program/src/state/delegate.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::instruction::{MetadataDelegateExpiration, MetadataDelegateRole};
+use solana_program::sysvar::Sysvar;
 
 const SIZE: usize = 98;
 
@@ -51,5 +53,75 @@ impl MetadataDelegateRecord {
         let delegate: MetadataDelegateRecord =
             try_from_slice_checked(data, Key::MetadataDelegate, MetadataDelegateRecord::size())?;
         Ok(delegate)
+    }
+}
+
+// V2
+
+#[repr(C)]
+#[cfg_attr(feature = "serde-feature", derive(Serialize, Deserialize))]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone, ShankAccount)]
+/// SEEDS = [
+///     "metadata",
+///     program id,
+///     mint id,
+///     delegate role,
+///     update authority id,
+///     delegate id
+/// ]
+pub struct MetadataDelegateRecordV2 {
+    pub key: Key, // 1
+    pub bump: u8, // 1
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
+    pub mint: Pubkey, // 32
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
+    pub delegate: Pubkey, // 32
+    #[cfg_attr(feature = "serde-feature", serde(with = "As::<DisplayFromStr>"))]
+    pub update_authority: Pubkey, // 32
+    pub creation_time: i64, // 8
+}
+
+impl Default for MetadataDelegateRecordV2 {
+    fn default() -> Self {
+        Self {
+            key: Key::MetadataDelegateV2,
+            bump: 255,
+            mint: Pubkey::default(),
+            delegate: Pubkey::default(),
+            update_authority: Pubkey::default(),
+            creation_time: 0,
+        }
+    }
+}
+
+impl TokenMetadataAccount for MetadataDelegateRecordV2 {
+    fn key() -> Key {
+        Key::MetadataDelegateV2
+    }
+
+    fn size() -> usize {
+        SIZE + 8
+    }
+}
+
+impl MetadataDelegateRecordV2 {
+    pub fn from_bytes(data: &[u8]) -> Result<MetadataDelegateRecordV2, ProgramError> {
+        let delegate: MetadataDelegateRecordV2 = try_from_slice_checked(
+            data,
+            Key::MetadataDelegateV2,
+            MetadataDelegateRecordV2::size(),
+        )?;
+        Ok(delegate)
+    }
+
+    pub fn check_expiration(&self, role: MetadataDelegateRole) -> ProgramResult {
+        // Get the current time.
+        let current_time = solana_program::clock::Clock::get()?;
+
+        if current_time.unix_timestamp > self.creation_time + role.expiration_time_secs() {
+            Err(MetadataError::DelegateExpired.into())
+        } else {
+            Ok(())
+        }
     }
 }

--- a/token-metadata/program/src/state/mod.rs
+++ b/token-metadata/program/src/state/mod.rs
@@ -137,6 +137,7 @@ pub enum Key {
     TokenOwnedEscrow,
     TokenRecord,
     MetadataDelegate,
+    MetadataDelegateV2,
 }
 
 #[cfg(feature = "serde-feature")]

--- a/token-metadata/program/tests/delegate.rs
+++ b/token-metadata/program/tests/delegate.rs
@@ -17,7 +17,7 @@ mod delegate {
         instruction::{DelegateArgs, MetadataDelegateRole},
         pda::{find_metadata_delegate_record_account, find_token_record_account},
         state::{
-            Key, Metadata, MetadataDelegateRecord, TokenDelegateRole, TokenRecord, TokenStandard,
+            Key, Metadata, MetadataDelegateRecordV2, TokenDelegateRole, TokenRecord, TokenStandard,
         },
     };
     use num_traits::FromPrimitive;
@@ -146,8 +146,24 @@ mod delegate {
         );
 
         let pda = get_account(&mut context, &pda_key).await;
-        let delegate_record = MetadataDelegateRecord::from_bytes(&pda.data).unwrap();
-        assert_eq!(delegate_record.key, Key::MetadataDelegate);
+        let delegate_record = MetadataDelegateRecordV2::from_bytes(&pda.data).unwrap();
+        assert_eq!(delegate_record.key, Key::MetadataDelegateV2);
+
+        // let pda = get_account(&mut context, &pda_key).await;
+        // let key_byte = pda.data.first().unwrap();
+        // let account_key = FromPrimitive::from_u8(*key_byte).unwrap();
+
+        // match account_key {
+        //     Key::MetadataDelegate => {
+        //         let delegate_record = MetadataDelegateRecord::from_bytes(&pda.data).unwrap();
+        //         assert_eq!(delegate_record.key, Key::MetadataDelegate);
+        //     }
+        //     Key::MetadataDelegateV2 => {
+        //         let delegate_record = MetadataDelegateRecordV2::from_bytes(&pda.data).unwrap();
+        //         assert_eq!(delegate_record.key, Key::MetadataDelegateV2);
+        //     }
+        //     _ => panic!("Unexpected key"),
+        // }
     }
 
     #[tokio::test]

--- a/token-metadata/program/tests/revoke.rs
+++ b/token-metadata/program/tests/revoke.rs
@@ -17,7 +17,7 @@ mod revoke {
         instruction::{DelegateArgs, MetadataDelegateRole, RevokeArgs},
         pda::{find_metadata_delegate_record_account, find_token_record_account},
         state::{
-            Key, Metadata, MetadataDelegateRecord, TokenDelegateRole, TokenRecord, TokenStandard,
+            Key, Metadata, MetadataDelegateRecordV2, TokenDelegateRole, TokenRecord, TokenStandard,
             TOKEN_RECORD_SIZE,
         },
     };
@@ -163,8 +163,24 @@ mod revoke {
         );
 
         let pda = get_account(&mut context, &pda_key).await;
-        let delegate_record = MetadataDelegateRecord::from_bytes(&pda.data).unwrap();
-        assert_eq!(delegate_record.key, Key::MetadataDelegate);
+        let delegate_record = MetadataDelegateRecordV2::from_bytes(&pda.data).unwrap();
+        assert_eq!(delegate_record.key, Key::MetadataDelegateV2);
+
+        // let pda = get_account(&mut context, &pda_key).await;
+        // let key_byte = pda.data.first().unwrap();
+        // let account_key = FromPrimitive::from_u8(*key_byte).unwrap();
+
+        // match account_key {
+        //     Key::MetadataDelegate => {
+        //         let delegate_record = MetadataDelegateRecord::from_bytes(&pda.data).unwrap();
+        //         assert_eq!(delegate_record.key, Key::MetadataDelegate);
+        //     }
+        //     Key::MetadataDelegateV2 => {
+        //         let delegate_record = MetadataDelegateRecordV2::from_bytes(&pda.data).unwrap();
+        //         assert_eq!(delegate_record.key, Key::MetadataDelegateV2);
+        //     }
+        //     _ => panic!("Unexpected key"),
+        // }
 
         // revokes the delegate
         let payer = Keypair::from_bytes(&context.payer.to_bytes()).unwrap();


### PR DESCRIPTION
### Notes
* WIP
* Creation time set when PDA is created.
* Expiration checked during get_authority_type.
* This is a draft idea that passes existing tests, but expiration functionality has not been thoroughly tested.