### PR TITLE
Use different UpdateArg types for different delegates

### DIFF
--- a/token-metadata/program/src/instruction/metadata.rs
+++ b/token-metadata/program/src/instruction/metadata.rs
@@ -100,7 +100,7 @@ pub enum UpdateArgs {
         /// Required authorization data to validate the request.
         authorization_data: Option<AuthorizationData>,
     },
-    V2 {
+    UpdateAuthorityV1 {
         /// The new update authority.
         new_update_authority: Option<Pubkey>,
         /// The metadata details.
@@ -124,11 +124,47 @@ pub enum UpdateArgs {
         /// Required authorization data to validate the request.
         authorization_data: Option<AuthorizationData>,
     },
+    AuthorityItemDelegateV1 {
+        /// The new update authority.
+        new_update_authority: Option<Pubkey>,
+        /// Indicates whether the primary sale has happened or not (once set to `true`, it cannot be
+        /// changed back).
+        primary_sale_happened: Option<bool>,
+        // Indicates Whether the data struct is mutable or not (once set to `true`, it cannot be
+        /// changed back).
+        is_mutable: Option<bool>,
+        /// Token standard.
+        token_standard: Option<TokenStandard>,
+    },
+    CollectionDelegateV1 {
+        /// Collection information.
+        collection: CollectionToggle,
+    },
+    DataDelegateV1 {
+        /// The metadata details.
+        data: Option<Data>,
+    },
+    ProgConfigDelegateV1 {
+        // Programmable rule set configuration (only applicable to `Programmable` asset types).
+        rule_set: RuleSetToggle,
+    },
+    DataItemDelegateV1 {
+        /// The metadata details.
+        data: Option<Data>,
+    },
+    CollectionItemDelegateV1 {
+        /// Collection information.
+        collection: CollectionToggle,
+    },
+    ProgConfigItemDelegateV1 {
+        // Programmable rule set configuration (only applicable to `Programmable` asset types).
+        rule_set: RuleSetToggle,
+    },
 }
 
 impl Default for UpdateArgs {
     fn default() -> Self {
-        Self::V2 {
+        Self::UpdateAuthorityV1 {
             new_update_authority: None,
             data: None,
             primary_sale_happened: None,
@@ -143,14 +179,130 @@ impl Default for UpdateArgs {
     }
 }
 
-#[macro_export]
-macro_rules! get_update_args_fields {
-    ($args:expr, $($field:ident),+) => {
-        match $args {
-            UpdateArgs::V1 { $($field,)+ .. } => ($($field,)+),
-            UpdateArgs::V2 { $($field,)+ .. } => ($($field,)+),
+pub(crate) struct InternalUpdateArgs {
+    /// The new update authority.
+    pub new_update_authority: Option<Pubkey>,
+    /// The metadata details.
+    pub data: Option<Data>,
+    /// Indicates whether the primary sale has happened or not (once set to `true`, it cannot be
+    /// changed back).
+    pub primary_sale_happened: Option<bool>,
+    // Indicates Whether the data struct is mutable or not (once set to `true`, it cannot be
+    /// changed back).
+    pub is_mutable: Option<bool>,
+    /// Collection information.
+    pub collection: CollectionToggle,
+    /// Additional details of the collection.
+    pub collection_details: CollectionDetailsToggle,
+    /// Uses information.
+    pub uses: UsesToggle,
+    // Programmable rule set configuration (only applicable to `Programmable` asset types).
+    pub rule_set: RuleSetToggle,
+    /// Token standard.
+    pub token_standard: Option<TokenStandard>,
+}
+
+impl From<UpdateArgs> for InternalUpdateArgs {
+    fn from(args: UpdateArgs) -> Self {
+        match args {
+            UpdateArgs::V1 {
+                new_update_authority,
+                data,
+                primary_sale_happened,
+                is_mutable,
+                collection,
+                collection_details,
+                uses,
+                rule_set,
+                ..
+            } => Self {
+                new_update_authority,
+                data,
+                primary_sale_happened,
+                is_mutable,
+                collection,
+                collection_details,
+                uses,
+                rule_set,
+                token_standard: None,
+            },
+            UpdateArgs::UpdateAuthorityV1 {
+                new_update_authority,
+                data,
+                primary_sale_happened,
+                is_mutable,
+                collection,
+                collection_details,
+                uses,
+                rule_set,
+                token_standard,
+                ..
+            } => Self {
+                new_update_authority,
+                data,
+                primary_sale_happened,
+                is_mutable,
+                collection,
+                collection_details,
+                uses,
+                rule_set,
+                token_standard,
+            },
+            UpdateArgs::AuthorityItemDelegateV1 {
+                new_update_authority,
+                primary_sale_happened,
+                is_mutable,
+                token_standard,
+                ..
+            } => Self {
+                new_update_authority,
+                data: None,
+                primary_sale_happened,
+                is_mutable,
+                collection: CollectionToggle::None,
+                collection_details: CollectionDetailsToggle::None,
+                uses: UsesToggle::None,
+                rule_set: RuleSetToggle::None,
+                token_standard,
+            },
+            UpdateArgs::CollectionDelegateV1 { collection, .. }
+            | UpdateArgs::CollectionItemDelegateV1 { collection, .. } => Self {
+                new_update_authority: None,
+                data: None,
+                primary_sale_happened: None,
+                is_mutable: None,
+                collection,
+                collection_details: CollectionDetailsToggle::None,
+                uses: UsesToggle::None,
+                rule_set: RuleSetToggle::None,
+                token_standard: None,
+            },
+            UpdateArgs::DataDelegateV1 { data, .. }
+            | UpdateArgs::DataItemDelegateV1 { data, .. } => Self {
+                new_update_authority: None,
+                data,
+                primary_sale_happened: None,
+                is_mutable: None,
+                collection: CollectionToggle::None,
+                collection_details: CollectionDetailsToggle::None,
+                uses: UsesToggle::None,
+                rule_set: RuleSetToggle::None,
+                token_standard: None,
+            },
+            UpdateArgs::ProgConfigDelegateV1 { rule_set, .. }
+            | UpdateArgs::ProgConfigItemDelegateV1 { rule_set, .. } => Self {
+                new_update_authority: None,
+                data: None,
+                primary_sale_happened: None,
+                is_mutable: None,
+                collection: CollectionToggle::None,
+                collection_details: CollectionDetailsToggle::None,
+                uses: UsesToggle::None,
+                rule_set,
+                token_standard: None,
+            },
         }
-    };
+    }
 }
 
 //-- Toggle implementations

--- a/token-metadata/program/src/instruction/metadata.rs
+++ b/token-metadata/program/src/instruction/metadata.rs
@@ -100,7 +100,7 @@ pub enum UpdateArgs {
         /// Required authorization data to validate the request.
         authorization_data: Option<AuthorizationData>,
     },
-    UpdateAuthorityV1 {
+    UpdateAuthorityV2 {
         /// The new update authority.
         new_update_authority: Option<Pubkey>,
         /// The metadata details.
@@ -124,7 +124,7 @@ pub enum UpdateArgs {
         /// Required authorization data to validate the request.
         authorization_data: Option<AuthorizationData>,
     },
-    AuthorityItemDelegateV1 {
+    AuthorityItemDelegateV2 {
         /// The new update authority.
         new_update_authority: Option<Pubkey>,
         /// Indicates whether the primary sale has happened or not (once set to `true`, it cannot be
@@ -136,27 +136,27 @@ pub enum UpdateArgs {
         /// Token standard.
         token_standard: Option<TokenStandard>,
     },
-    CollectionDelegateV1 {
+    CollectionDelegateV2 {
         /// Collection information.
         collection: CollectionToggle,
     },
-    DataDelegateV1 {
+    DataDelegateV2 {
         /// The metadata details.
         data: Option<Data>,
     },
-    ProgConfigDelegateV1 {
+    ProgConfigDelegateV2 {
         // Programmable rule set configuration (only applicable to `Programmable` asset types).
         rule_set: RuleSetToggle,
     },
-    DataItemDelegateV1 {
+    DataItemDelegateV2 {
         /// The metadata details.
         data: Option<Data>,
     },
-    CollectionItemDelegateV1 {
+    CollectionItemDelegateV2 {
         /// Collection information.
         collection: CollectionToggle,
     },
-    ProgConfigItemDelegateV1 {
+    ProgConfigItemDelegateV2 {
         // Programmable rule set configuration (only applicable to `Programmable` asset types).
         rule_set: RuleSetToggle,
     },
@@ -164,7 +164,7 @@ pub enum UpdateArgs {
 
 impl Default for UpdateArgs {
     fn default() -> Self {
-        Self::UpdateAuthorityV1 {
+        Self::UpdateAuthorityV2 {
             new_update_authority: None,
             data: None,
             primary_sale_happened: None,
@@ -202,6 +202,22 @@ pub(crate) struct InternalUpdateArgs {
     pub token_standard: Option<TokenStandard>,
 }
 
+impl Default for InternalUpdateArgs {
+    fn default() -> Self {
+        Self {
+            new_update_authority: None,
+            data: None,
+            primary_sale_happened: None,
+            is_mutable: None,
+            collection: CollectionToggle::None,
+            collection_details: CollectionDetailsToggle::None,
+            uses: UsesToggle::None,
+            rule_set: RuleSetToggle::None,
+            token_standard: None,
+        }
+    }
+}
+
 impl From<UpdateArgs> for InternalUpdateArgs {
     fn from(args: UpdateArgs) -> Self {
         match args {
@@ -226,7 +242,7 @@ impl From<UpdateArgs> for InternalUpdateArgs {
                 rule_set,
                 token_standard: None,
             },
-            UpdateArgs::UpdateAuthorityV1 {
+            UpdateArgs::UpdateAuthorityV2 {
                 new_update_authority,
                 data,
                 primary_sale_happened,
@@ -248,7 +264,7 @@ impl From<UpdateArgs> for InternalUpdateArgs {
                 rule_set,
                 token_standard,
             },
-            UpdateArgs::AuthorityItemDelegateV1 {
+            UpdateArgs::AuthorityItemDelegateV2 {
                 new_update_authority,
                 primary_sale_happened,
                 is_mutable,
@@ -256,50 +272,25 @@ impl From<UpdateArgs> for InternalUpdateArgs {
                 ..
             } => Self {
                 new_update_authority,
-                data: None,
                 primary_sale_happened,
                 is_mutable,
-                collection: CollectionToggle::None,
-                collection_details: CollectionDetailsToggle::None,
-                uses: UsesToggle::None,
-                rule_set: RuleSetToggle::None,
                 token_standard,
+                ..Default::default()
             },
-            UpdateArgs::CollectionDelegateV1 { collection, .. }
-            | UpdateArgs::CollectionItemDelegateV1 { collection, .. } => Self {
-                new_update_authority: None,
-                data: None,
-                primary_sale_happened: None,
-                is_mutable: None,
+            UpdateArgs::CollectionDelegateV2 { collection, .. }
+            | UpdateArgs::CollectionItemDelegateV2 { collection, .. } => Self {
                 collection,
-                collection_details: CollectionDetailsToggle::None,
-                uses: UsesToggle::None,
-                rule_set: RuleSetToggle::None,
-                token_standard: None,
+                ..Default::default()
             },
-            UpdateArgs::DataDelegateV1 { data, .. }
-            | UpdateArgs::DataItemDelegateV1 { data, .. } => Self {
-                new_update_authority: None,
+            UpdateArgs::DataDelegateV2 { data, .. }
+            | UpdateArgs::DataItemDelegateV2 { data, .. } => Self {
                 data,
-                primary_sale_happened: None,
-                is_mutable: None,
-                collection: CollectionToggle::None,
-                collection_details: CollectionDetailsToggle::None,
-                uses: UsesToggle::None,
-                rule_set: RuleSetToggle::None,
-                token_standard: None,
+                ..Default::default()
             },
-            UpdateArgs::ProgConfigDelegateV1 { rule_set, .. }
-            | UpdateArgs::ProgConfigItemDelegateV1 { rule_set, .. } => Self {
-                new_update_authority: None,
-                data: None,
-                primary_sale_happened: None,
-                is_mutable: None,
-                collection: CollectionToggle::None,
-                collection_details: CollectionDetailsToggle::None,
-                uses: UsesToggle::None,
+            UpdateArgs::ProgConfigDelegateV2 { rule_set, .. }
+            | UpdateArgs::ProgConfigItemDelegateV2 { rule_set, .. } => Self {
                 rule_set,
-                token_standard: None,
+                ..Default::default()
             },
         }
     }

--- a/token-metadata/program/src/processor/metadata/update.rs
+++ b/token-metadata/program/src/processor/metadata/update.rs
@@ -260,31 +260,31 @@ fn validate_update(
     if let Some(metadata_delegate_role) = metadata_delegate_role {
         match metadata_delegate_role {
             MetadataDelegateRole::AuthorityItem => match args {
-                UpdateArgs::AuthorityItemDelegateV1 { .. } => (),
+                UpdateArgs::AuthorityItemDelegateV2 { .. } => (),
                 _ => return Err(MetadataError::InvalidUpdateArgs.into()),
             },
             MetadataDelegateRole::Data => match args {
-                UpdateArgs::DataDelegateV1 { .. } => (),
+                UpdateArgs::DataDelegateV2 { .. } => (),
                 _ => return Err(MetadataError::InvalidUpdateArgs.into()),
             },
             MetadataDelegateRole::DataItem => match args {
-                UpdateArgs::DataItemDelegateV1 { .. } => (),
+                UpdateArgs::DataItemDelegateV2 { .. } => (),
                 _ => return Err(MetadataError::InvalidUpdateArgs.into()),
             },
             MetadataDelegateRole::Collection => match args {
-                UpdateArgs::CollectionDelegateV1 { .. } => (),
+                UpdateArgs::CollectionDelegateV2 { .. } => (),
                 _ => return Err(MetadataError::InvalidUpdateArgs.into()),
             },
             MetadataDelegateRole::CollectionItem => match args {
-                UpdateArgs::CollectionItemDelegateV1 { .. } => (),
+                UpdateArgs::CollectionItemDelegateV2 { .. } => (),
                 _ => return Err(MetadataError::InvalidUpdateArgs.into()),
             },
             MetadataDelegateRole::ProgrammableConfig => match args {
-                UpdateArgs::ProgConfigDelegateV1 { .. } => (),
+                UpdateArgs::ProgConfigDelegateV2 { .. } => (),
                 _ => return Err(MetadataError::InvalidUpdateArgs.into()),
             },
             MetadataDelegateRole::ProgrammableConfigItem => match args {
-                UpdateArgs::ProgConfigItemDelegateV1 { .. } => (),
+                UpdateArgs::ProgConfigItemDelegateV2 { .. } => (),
                 _ => return Err(MetadataError::InvalidUpdateArgs.into()),
             },
             _ => return Err(MetadataError::InvalidAuthorityType.into()),

--- a/token-metadata/program/src/processor/metadata/update.rs
+++ b/token-metadata/program/src/processor/metadata/update.rs
@@ -10,8 +10,9 @@ use spl_token::state::Account;
 use crate::{
     assertions::{assert_owned_by, programmable::assert_valid_authorization},
     error::MetadataError,
-    get_update_args_fields,
-    instruction::{CollectionToggle, Context, MetadataDelegateRole, Update, UpdateArgs},
+    instruction::{
+        CollectionToggle, Context, InternalUpdateArgs, MetadataDelegateRole, Update, UpdateArgs,
+    },
     pda::{EDITION, PREFIX},
     state::{
         AuthorityRequest, AuthorityResponse, AuthorityType, Collection, Metadata,
@@ -44,10 +45,7 @@ pub fn update<'a>(
 ) -> ProgramResult {
     let context = Update::to_context(accounts)?;
 
-    match args {
-        UpdateArgs::V1 { .. } => update_v1(program_id, context, args),
-        UpdateArgs::V2 { .. } => update_v1(program_id, context, args),
-    }
+    update_v1(program_id, context, args)
 }
 
 fn update_v1(program_id: &Pubkey, ctx: Context<Update>, args: UpdateArgs) -> ProgramResult {
@@ -127,6 +125,9 @@ fn update_v1(program_id: &Pubkey, ctx: Context<Update>, args: UpdateArgs) -> Pro
         (None, None)
     };
 
+    // Copy the args into a struct that contains all available fields.
+    let internal_args = InternalUpdateArgs::from(args.clone());
+
     // there is a special case for collection-level delegates, where the
     // validation should use the collection key as the mint parameter
     let existing_collection_mint = metadata
@@ -139,7 +140,7 @@ fn update_v1(program_id: &Pubkey, ctx: Context<Update>, args: UpdateArgs) -> Pro
     // `MetadataDelegateRole::Collection` or `MetadataDelegateRole::CollectionItem`,
     // then it will fail in `validate_update` because those are the only roles that
     // can change collection.
-    let collection_mint = match get_update_args_fields!(&args, collection).0 {
+    let collection_mint = match &internal_args.collection {
         CollectionToggle::Set(Collection { key, .. }) => Some(key),
         _ => existing_collection_mint,
     };
@@ -181,24 +182,11 @@ fn update_v1(program_id: &Pubkey, ctx: Context<Update>, args: UpdateArgs) -> Pro
         ..Default::default()
     })?;
 
-    // Check if caller passed in a desired token standard.
-    let desired_token_standard = match args {
-        UpdateArgs::V1 { .. } => None,
-        UpdateArgs::V2 { token_standard, .. } => token_standard,
-    };
-
-    // Validate that authority has permission to update the fields that have been specified in the
-    // update args.
-    validate_update(
-        &args,
-        &authority_type,
-        metadata_delegate_role,
-        desired_token_standard,
-    )?;
+    // Validate that authority has permission to use the update args that were provided.
+    validate_update(&args, &authority_type, metadata_delegate_role)?;
 
     // Find existing token standard from metadata or infer it.
-    let existing_or_inferred_token_standard = if let Some(token_standard) = metadata.token_standard
-    {
+    let existing_or_inferred_token_std = if let Some(token_standard) = metadata.token_standard {
         token_standard
     } else {
         check_token_standard(ctx.accounts.mint_info, ctx.accounts.edition_info)?
@@ -206,15 +194,12 @@ fn update_v1(program_id: &Pubkey, ctx: Context<Update>, args: UpdateArgs) -> Pro
 
     // If there is a desired token standard, use it if it passes the check.  If there is not a
     // desired token standard, use the existing or inferred token standard.
-    let token_standard = match desired_token_standard {
+    let token_standard = match internal_args.token_standard {
         Some(desired_token_standard) => {
-            check_desired_token_standard(
-                existing_or_inferred_token_standard,
-                desired_token_standard,
-            )?;
+            check_desired_token_standard(existing_or_inferred_token_std, desired_token_standard)?;
             desired_token_standard
         }
-        None => existing_or_inferred_token_standard,
+        None => existing_or_inferred_token_std,
     };
 
     // For pNFTs, we need to validate the authorization rules.
@@ -251,7 +236,6 @@ fn validate_update(
     args: &UpdateArgs,
     authority_type: &AuthorityType,
     metadata_delegate_role: Option<MetadataDelegateRole>,
-    desired_token_standard: Option<TokenStandard>,
 ) -> ProgramResult {
     // validate the authority type
     match authority_type {
@@ -271,93 +255,38 @@ fn validate_update(
         _ => return Err(MetadataError::InvalidAuthorityType.into()),
     }
 
-    // Destructure args.
-    let (
-        new_update_authority,
-        data,
-        primary_sale_happened,
-        is_mutable,
-        collection,
-        collection_details,
-        uses,
-        rule_set,
-    ) = get_update_args_fields!(
-        args,
-        new_update_authority,
-        data,
-        primary_sale_happened,
-        is_mutable,
-        collection,
-        collection_details,
-        uses,
-        rule_set
-    );
-
     // validate the delegate role: this consist in checking that
     // the delegate is only updating fields that it has access to
     if let Some(metadata_delegate_role) = metadata_delegate_role {
         match metadata_delegate_role {
-            MetadataDelegateRole::AuthorityItem => {
-                // Fields allowed for `Authority`:
-                // `new_update_authority`
-                // `primary_sale_happened`
-                // `is_mutable`
-                // `token_standard`
-                if data.is_some()
-                    || collection.is_some()
-                    || collection_details.is_some()
-                    || uses.is_some()
-                    || rule_set.is_some()
-                {
-                    return Err(MetadataError::InvalidUpdateArgs.into());
-                }
-            }
-            MetadataDelegateRole::Data | MetadataDelegateRole::DataItem => {
-                // Fields allowed for `Data`:
-                // `data`
-                if new_update_authority.is_some()
-                    || primary_sale_happened.is_some()
-                    || is_mutable.is_some()
-                    || collection.is_some()
-                    || collection_details.is_some()
-                    || uses.is_some()
-                    || rule_set.is_some()
-                    || desired_token_standard.is_some()
-                {
-                    return Err(MetadataError::InvalidUpdateArgs.into());
-                }
-            }
-            MetadataDelegateRole::Collection | MetadataDelegateRole::CollectionItem => {
-                // Fields allowed for `Collection` and `CollectionItem`:
-                // `collection`
-                if new_update_authority.is_some()
-                    || data.is_some()
-                    || primary_sale_happened.is_some()
-                    || is_mutable.is_some()
-                    || collection_details.is_some()
-                    || uses.is_some()
-                    || rule_set.is_some()
-                    || desired_token_standard.is_some()
-                {
-                    return Err(MetadataError::InvalidUpdateArgs.into());
-                }
-            }
-            MetadataDelegateRole::ProgrammableConfig
-            | MetadataDelegateRole::ProgrammableConfigItem => {
-                // Fields allowed for `ProgrammableConfig` and `ProgrammableConfigItem`:
-                // `rule_set`
-                if new_update_authority.is_some()
-                    || data.is_some()
-                    || primary_sale_happened.is_some()
-                    || is_mutable.is_some()
-                    || collection.is_some()
-                    || collection_details.is_some()
-                    || uses.is_some()
-                    || desired_token_standard.is_some()
-                {
-                    return Err(MetadataError::InvalidUpdateArgs.into());
-                }
-            }
+            MetadataDelegateRole::AuthorityItem => match args {
+                UpdateArgs::AuthorityItemDelegateV1 { .. } => (),
+                _ => return Err(MetadataError::InvalidUpdateArgs.into()),
+            },
+            MetadataDelegateRole::Data => match args {
+                UpdateArgs::DataDelegateV1 { .. } => (),
+                _ => return Err(MetadataError::InvalidUpdateArgs.into()),
+            },
+            MetadataDelegateRole::DataItem => match args {
+                UpdateArgs::DataItemDelegateV1 { .. } => (),
+                _ => return Err(MetadataError::InvalidUpdateArgs.into()),
+            },
+            MetadataDelegateRole::Collection => match args {
+                UpdateArgs::CollectionDelegateV1 { .. } => (),
+                _ => return Err(MetadataError::InvalidUpdateArgs.into()),
+            },
+            MetadataDelegateRole::CollectionItem => match args {
+                UpdateArgs::CollectionItemDelegateV1 { .. } => (),
+                _ => return Err(MetadataError::InvalidUpdateArgs.into()),
+            },
+            MetadataDelegateRole::ProgrammableConfig => match args {
+                UpdateArgs::ProgConfigDelegateV1 { .. } => (),
+                _ => return Err(MetadataError::InvalidUpdateArgs.into()),
+            },
+            MetadataDelegateRole::ProgrammableConfigItem => match args {
+                UpdateArgs::ProgConfigItemDelegateV1 { .. } => (),
+                _ => return Err(MetadataError::InvalidUpdateArgs.into()),
+            },
             _ => return Err(MetadataError::InvalidAuthorityType.into()),
         }
     }
@@ -366,12 +295,12 @@ fn validate_update(
 }
 
 fn check_desired_token_standard(
-    existing_or_inferred_token_standard: TokenStandard,
+    existing_or_inferred_token_std: TokenStandard,
     desired_token_standard: TokenStandard,
 ) -> ProgramResult {
     // This function only allows switching between Fungible and FungibleAsset.  Mint decimals must
     // be zero.
-    match existing_or_inferred_token_standard {
+    match existing_or_inferred_token_std {
         TokenStandard::Fungible | TokenStandard::FungibleAsset => match desired_token_standard {
             TokenStandard::Fungible | TokenStandard::FungibleAsset => Ok(()),
             _ => Err(MetadataError::InvalidTokenStandard.into()),


### PR DESCRIPTION
Use different `UpdateArgs` enum values for each delegate to control what fields can be updated.

Originally inspired by @samuelvanderwaal 's statement
> Defining these by negative fields feels a bit repetitive and perhaps easy to make a mistake. Is there a cleaner way to solve this with a HashSet of allow values for each type or something?

And thinking about type safety as a Rust idiom to solve this problem.