### PR TITLE
Update mpl-utils in token-metadata

### DIFF
--- a/token-metadata/Cargo.lock
+++ b/token-metadata/Cargo.lock
@@ -1986,7 +1986,7 @@ dependencies = [
  "borsh",
  "mpl-token-auth-rules",
  "mpl-token-metadata-context-derive 0.2.1",
- "mpl-utils 0.1.0",
+ "mpl-utils 0.2.0",
  "num-derive",
  "num-traits",
  "rmp-serde",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayref",
  "borsh",

--- a/token-metadata/program/Cargo.toml
+++ b/token-metadata/program/Cargo.toml
@@ -26,7 +26,7 @@ borsh = "0.9.2"
 shank = { version = "0.0.11" }
 serde = { version = "1.0.149", optional = true }
 serde_with = { version = "1.14.0", optional = true }
-mpl-utils = { version = "0.1.0", path="../../core/rust/utils" }
+mpl-utils = { version = "0.2.0", path="../../core/rust/utils" }
 mpl-token-metadata-context-derive = { version = "0.2.1", path = "../macro" }
 
 [dev-dependencies]


### PR DESCRIPTION
CI was failing to select a version of mpl-utils, and this is a fixup of that
```
Warning: cargo-build-bpf is deprecated. Please, use cargo-build-sbf
cargo-build-bpf child: /home/runner/.local/share/solana/install/active_release/bin/cargo-build-sbf --sbf-out-dir ../../test-programs/ --arch bpf
[2023-04-20T18:18:59.431506224Z ERROR cargo_build_sbf] Failed to obtain package metadata: `cargo metadata` exited with an error:     Updating crates.io index
        Updating git repository `[https://github.com/metaplex-foundation/rooster`](https://github.com/metaplex-foundation/rooster%60)
    error: failed to select a version for the requirement `mpl-utils = "^0.1.0"`

    candidate versions found which didn't match: 0.2.0
    location searched: /home/runner/actions-runner/_work/metaplex-program-library/metaplex-program-library/core/rust/utils
    required by package `mpl-token-metadata v1.10.0 (/home/runner/actions-runner/_work/metaplex-program-library/metaplex-program-library/token-metadata/program)`
Error: Process completed with exit code 1.
```