### PR TITLE
Set primary sale happened value on create

### DIFF
--- a/token-metadata/js/test/create.test.ts
+++ b/token-metadata/js/test/create.test.ts
@@ -32,7 +32,7 @@ test('Create: ProgrammableNonFungible', async (t) => {
         verified: false,
       },
     ],
-    primarySaleHappened: false,
+    primarySaleHappened: true,
     isMutable: true,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
     collection: null,
@@ -51,7 +51,7 @@ test('Create: ProgrammableNonFungible', async (t) => {
     data: {
       sellerFeeBasisPoints: 0,
     },
-    primarySaleHappened: false,
+    primarySaleHappened: true,
     isMutable: true,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
   });

--- a/token-metadata/program/src/processor/metadata/create.rs
+++ b/token-metadata/program/src/processor/metadata/create.rs
@@ -189,6 +189,7 @@ fn create_v1(program_id: &Pubkey, ctx: Context<Create>, args: CreateArgs) -> Pro
 
     let mut metadata = Metadata::from_account_info(ctx.accounts.metadata_info)?;
     metadata.token_standard = Some(asset_data.token_standard);
+    metadata.primary_sale_happened = asset_data.primary_sale_happened;
 
     // sets the programmable config for programmable assets
 
@@ -201,7 +202,7 @@ fn create_v1(program_id: &Pubkey, ctx: Context<Create>, args: CreateArgs) -> Pro
         });
     }
 
-    // saves the state
+    // saves the metadata state
     metadata.save(&mut ctx.accounts.metadata_info.try_borrow_mut_data()?)?;
 
     Ok(())


### PR DESCRIPTION
This PR enables setting the metadata value for `primary_sale_happened` on `create`.