### PR TITLE
Reduce compute units consumption

### DIFF
--- a/core/rust/utils/src/account.rs
+++ b/core/rust/utils/src/account.rs
@@ -1,7 +1,6 @@
 use solana_program::{
     account_info::AccountInfo,
     entrypoint::ProgramResult,
-    msg,
     program::{invoke, invoke_signed},
     pubkey::Pubkey,
     rent::Rent,
@@ -25,31 +24,19 @@ pub fn create_or_allocate_account_raw<'a>(
         .max(1)
         .saturating_sub(new_account_info.lamports());
 
-    if required_lamports > 0 {
-        msg!("Transfer {} lamports to the new account", required_lamports);
-        invoke(
-            &system_instruction::transfer(payer_info.key, new_account_info.key, required_lamports),
-            &[
-                payer_info.clone(),
-                new_account_info.clone(),
-                system_program_info.clone(),
-            ],
-        )?;
-    }
-
-    let accounts = &[new_account_info.clone(), system_program_info.clone()];
-
-    msg!("Allocate space for the account");
     invoke_signed(
-        &system_instruction::allocate(new_account_info.key, size.try_into().unwrap()),
-        accounts,
-        &[signer_seeds],
-    )?;
-
-    msg!("Assign the account to the owning program");
-    invoke_signed(
-        &system_instruction::assign(new_account_info.key, &program_id),
-        accounts,
+        &system_instruction::create_account(
+            payer_info.key,
+            new_account_info.key,
+            required_lamports,
+            size as u64,
+            &program_id,
+        ),
+        &[
+            payer_info.clone(),
+            new_account_info.clone(),
+            system_program_info.clone(),
+        ],
         &[signer_seeds],
     )?;
 

--- a/token-metadata/program/src/state/master_edition.rs
+++ b/token-metadata/program/src/state/master_edition.rs
@@ -106,8 +106,12 @@ impl MasterEdition for MasterEditionV2 {
     }
 
     fn save(&self, account: &AccountInfo) -> ProgramResult {
-        let mut storage = &mut account.data.borrow_mut()[..TOKEN_STANDARD_INDEX];
-        BorshSerialize::serialize(self, &mut storage)?;
+        let mut bytes = Vec::with_capacity(TOKEN_STANDARD_INDEX);
+        BorshSerialize::serialize(&self, &mut bytes)?;
+
+        let data = &mut account.data.borrow_mut();
+        data[..bytes.len()].copy_from_slice(&bytes);
+
         Ok(())
     }
 }


### PR DESCRIPTION
This PR optimizes the compute units usage on the unified `create` instruction.