### PR TITLE
add verified to computeCreatorHash

### DIFF
--- a/bubblegum/js/src/mpl-bubblegum.ts
+++ b/bubblegum/js/src/mpl-bubblegum.ts
@@ -24,14 +24,13 @@ export function computeDataHash(metadata: MetadataArgs): Buffer {
 
 export function computeCreatorHash(creators: Creator[]): Buffer {
   let bufferOfCreatorData = Buffer.from([]);
-  let bufferOfCreatorShares = Buffer.from([]);
   for (const creator of creators) {
     bufferOfCreatorData = Buffer.concat([
       bufferOfCreatorData,
       creator.address.toBuffer(),
+      Buffer.from([creator.verified ? 1 : 0]),
       Buffer.from([creator.share]),
     ]);
-    bufferOfCreatorShares = Buffer.concat([bufferOfCreatorShares, Buffer.from([creator.verified ? 1 : 0]), Buffer.from([creator.share])]);
   }
   return Buffer.from(keccak_256.digest(bufferOfCreatorData));
 }


### PR DESCRIPTION
`computeCreatorHash` did not include `verified` in the hash so it was causing issues verifying a compressed NFT with the `createVerifyLeafIx`. This was not an issue when verifying a compressed NFT with a single creator but would not verify a compressed NFT with multiple creators. 