### PR TITLE
Fix toolchain env variable name in action

### DIFF
--- a/.github/actions/build-program/action.yml
+++ b/.github/actions/build-program/action.yml
@@ -19,8 +19,8 @@ runs:
         mkdir -p ../../test-programs
         solana program dump -u https://api.mainnet-beta.solana.com auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg ../../test-programs/mpl_token_auth_rules.so
         solana program dump -u https://api.mainnet-beta.solana.com Roostrnex2Z9Y2XZC49sFAdZARP8E4iFpEnZC5QJWdz ../../test-programs/rooster.so
-        cargo +${{ env.RUST_STABLE }} build-bpf --version
+        cargo +${{ env.RUST_TOOLCHAIN }} build-bpf --version
         export BPF_OUT_DIR=../../test-programs/
-        cargo +${{ env.RUST_STABLE }} build-bpf --bpf-out-dir ../../test-programs/
+        cargo +${{ env.RUST_TOOLCHAIN }} build-bpf --bpf-out-dir ../../test-programs/
       shell: bash
 


### PR DESCRIPTION
Not sure how this was working prior to today because `RUST_STABLE` was not defined, which resulted in failures in my [`Update` PR](https://github.com/metaplex-foundation/metaplex-program-library/pull/1058).

Example of failing test run: https://github.com/metaplex-foundation/metaplex-program-library/actions/runs/4803372354/jobs/8552304748

This PR won't trigger the CI that uses it, but here's a passing run with this change applied on my PR branch:
https://github.com/metaplex-foundation/metaplex-program-library/actions/runs/4805994642/jobs/8552987442