### PR TITLE
Fix isSigner for leafOwner account of transfer instruction

### DIFF
--- a/bubblegum/js/idl/bubblegum.json
+++ b/bubblegum/js/idl/bubblegum.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0",
+  "version": "0.7.0",
   "name": "bubblegum",
   "instructions": [
     {
@@ -8,7 +8,16 @@
         {
           "name": "treeAuthority",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "merkleTree",
@@ -64,7 +73,19 @@
         {
           "name": "treeAuthority",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          },
+          "relations": [
+            "tree_creator"
+          ]
         },
         {
           "name": "treeCreator",
@@ -95,7 +116,16 @@
         {
           "name": "treeAuthority",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -153,7 +183,16 @@
         {
           "name": "treeAuthority",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -212,7 +251,16 @@
         {
           "name": "bubblegumSigner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "collection_cpi"
+              }
+            ]
+          }
         },
         {
           "name": "logWrapper",
@@ -250,7 +298,16 @@
         {
           "name": "treeAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -343,7 +400,16 @@
         {
           "name": "treeAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -436,7 +502,16 @@
         {
           "name": "treeAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -499,7 +574,16 @@
         {
           "name": "bubblegumSigner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "collection_cpi"
+              }
+            ]
+          }
         },
         {
           "name": "logWrapper",
@@ -572,7 +656,16 @@
         {
           "name": "treeAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -635,7 +728,16 @@
         {
           "name": "bubblegumSigner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "collection_cpi"
+              }
+            ]
+          }
         },
         {
           "name": "logWrapper",
@@ -708,7 +810,16 @@
         {
           "name": "treeAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -771,7 +882,16 @@
         {
           "name": "bubblegumSigner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "collection_cpi"
+              }
+            ]
+          }
         },
         {
           "name": "logWrapper",
@@ -848,12 +968,21 @@
         {
           "name": "treeAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": true
         },
         {
           "name": "leafDelegate",
@@ -930,7 +1059,16 @@
         {
           "name": "treeAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -1012,7 +1150,16 @@
         {
           "name": "treeAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -1089,7 +1236,16 @@
         {
           "name": "treeAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -1109,7 +1265,26 @@
         {
           "name": "voucher",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "voucher"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              },
+              {
+                "kind": "arg",
+                "type": "u64",
+                "path": "nonce"
+              }
+            ]
+          }
         },
         {
           "name": "logWrapper",
@@ -1171,7 +1346,16 @@
         {
           "name": "treeAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -1186,7 +1370,29 @@
         {
           "name": "voucher",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "voucher"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              },
+              {
+                "kind": "account",
+                "type": {
+                  "defined": "LeafSchema"
+                },
+                "account": "Voucher",
+                "path": "voucher.leaf_schema"
+              }
+            ]
+          }
         },
         {
           "name": "logWrapper",
@@ -1222,7 +1428,30 @@
         {
           "name": "voucher",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "voucher"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Voucher",
+                "path": "voucher.merkle_tree"
+              },
+              {
+                "kind": "account",
+                "type": {
+                  "defined": "LeafSchema"
+                },
+                "account": "Voucher",
+                "path": "voucher.leaf_schema"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",
@@ -1237,12 +1466,44 @@
         {
           "name": "mint",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "asset"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "Voucher",
+                "path": "voucher.merkle_tree"
+              },
+              {
+                "kind": "account",
+                "type": {
+                  "defined": "LeafSchema"
+                },
+                "account": "Voucher",
+                "path": "voucher.leaf_schema"
+              }
+            ]
+          }
         },
         {
           "name": "mintAuthority",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "mint"
+              }
+            ]
+          }
         },
         {
           "name": "metadata",
@@ -1300,7 +1561,16 @@
         {
           "name": "treeAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "merkle_tree"
+              }
+            ]
+          }
         },
         {
           "name": "leafOwner",

--- a/bubblegum/js/src/generated/instructions/transfer.ts
+++ b/bubblegum/js/src/generated/instructions/transfer.ts
@@ -44,7 +44,7 @@ export const transferStruct = new beet.BeetArgsStruct<
  * Accounts required by the _transfer_ instruction
  *
  * @property [] treeAuthority
- * @property [] leafOwner
+ * @property [**signer**] leafOwner
  * @property [] leafDelegate
  * @property [] newLeafOwner
  * @property [_writable_] merkleTree
@@ -96,7 +96,7 @@ export function createTransferInstruction(
     {
       pubkey: accounts.leafOwner,
       isWritable: false,
-      isSigner: false,
+      isSigner: true,
     },
     {
       pubkey: accounts.leafDelegate,

--- a/bubblegum/program/src/lib.rs
+++ b/bubblegum/program/src/lib.rs
@@ -216,7 +216,7 @@ pub struct Transfer<'info> {
     /// CHECK: This account is neither written to nor read from.
     pub tree_authority: Account<'info, TreeConfig>,
     /// CHECK: This account is checked in the instruction
-    pub leaf_owner: UncheckedAccount<'info>,
+    pub leaf_owner: Signer<'info>,
     /// CHECK: This account is chekced in the instruction
     pub leaf_delegate: UncheckedAccount<'info>,
     /// CHECK: This account is neither written to nor read from.


### PR DESCRIPTION
We had a report that the generated Solita library had the wrong `isSigner` boolean for the `leafOwner` of the `transfer` instruction of the Bubblegum program. Since this information comes directly from the program, I updated the relevant instruction account and re-generated the Solita library.

Note that the generated IDL happens to include new seed values as well as I'm guessing it wasn't done previously when bumping Anchor to the latest version.