### PR TITLE
Remove logs on transfer

### DIFF
--- a/token-metadata/program/src/processor/metadata/transfer.rs
+++ b/token-metadata/program/src/processor/metadata/transfer.rs
@@ -5,7 +5,6 @@ use mpl_utils::{assert_signer, token::TokenTransferParams};
 use solana_program::{
     account_info::AccountInfo,
     entrypoint::ProgramResult,
-    msg,
     program::invoke,
     program_error::ProgramError,
     program_option::COption,
@@ -207,7 +206,6 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
     let token_standard = metadata.token_standard;
     let token = Account::unpack(&ctx.accounts.token_info.try_borrow_data()?)?;
 
-    msg!("getting authority type");
     let AuthorityResponse { authority_type, .. } =
         AuthorityType::get_authority_type(AuthorityRequest {
             authority: ctx.accounts.authority_info.key,
@@ -227,8 +225,6 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
 
     match authority_type {
         AuthorityType::Holder => {
-            msg!("Owner transfer");
-
             // Wallet-to-wallet are currently exempt from auth rules so we need to check this and pass it into
             // the auth rules validator function.
             //
@@ -289,7 +285,6 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
 
     match token_standard {
         Some(TokenStandard::ProgrammableNonFungible) => {
-            msg!("pNFT");
             // All pNFTs should have a token record passed in and existing.
             // The token delegate role may not be populated, however.
             let owner_token_record_info =
@@ -320,7 +315,6 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
 
             let owner_token_record = TokenRecord::from_account_info(owner_token_record_info)?;
 
-            msg!("checking if sale delegate");
             let is_sale_delegate = owner_token_record
                 .delegate_role
                 .map(|role| role == TokenDelegateRole::Sale)
@@ -331,7 +325,6 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
                 .map(|role| role == TokenDelegateRole::LockedTransfer)
                 .unwrap_or(false);
 
-            msg!("determining scenario");
             let scenario = match authority_type {
                 AuthorityType::Holder => {
                     if is_sale_delegate {

--- a/token-metadata/program/src/utils/programmable_asset.rs
+++ b/token-metadata/program/src/utils/programmable_asset.rs
@@ -4,7 +4,7 @@ use mpl_token_auth_rules::{
 };
 use mpl_utils::{create_or_allocate_account_raw, token::TokenTransferParams};
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke_signed,
+    account_info::AccountInfo, entrypoint::ProgramResult, program::invoke_signed,
     program_error::ProgramError, program_option::COption, pubkey::Pubkey,
 };
 use spl_token::{
@@ -197,7 +197,6 @@ pub fn auth_rules_validate(params: AuthRulesValidateParams) -> ProgramResult {
     } = params;
 
     if is_wallet_to_wallet {
-        msg!("Wallet to wallet");
         return Ok(());
     }
 
@@ -211,8 +210,6 @@ pub fn auth_rules_validate(params: AuthRulesValidateParams) -> ProgramResult {
 
     if let Some(ref config) = programmable_config {
         if let ProgrammableConfig::V1 { rule_set: Some(_) } = config {
-            msg!("Programmable config exists");
-
             assert_valid_authorization(auth_rules_info, config)?;
 
             // We can safely unwrap here because they were all checked for existence


### PR DESCRIPTION
This PR removes log messages from the transfer instruction – the steps of the transfer can be inferred by the accounts and CPIs that are involved in the transaction.