### PR TITLE
Add token-metadata Update ts test for V2 args

### DIFF
--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -5037,7 +5037,7 @@
             ]
           },
           {
-            "name": "AsProgConfigDelegateV2",
+            "name": "AsProgrammableConfigDelegateV2",
             "fields": [
               {
                 "name": "rule_set",

--- a/token-metadata/js/src/generated/types/UpdateArgs.ts
+++ b/token-metadata/js/src/generated/types/UpdateArgs.ts
@@ -63,7 +63,7 @@ export type UpdateArgsRecord = {
     data: beet.COption<Data>;
     authorizationData: beet.COption<AuthorizationData>;
   };
-  AsProgConfigDelegateV2: {
+  AsProgrammableConfigDelegateV2: {
     ruleSet: RuleSetToggle;
     authorizationData: beet.COption<AuthorizationData>;
   };
@@ -109,9 +109,10 @@ export const isUpdateArgsAsCollectionDelegateV2 = (
 export const isUpdateArgsAsDataDelegateV2 = (
   x: UpdateArgs,
 ): x is UpdateArgs & { __kind: 'AsDataDelegateV2' } => x.__kind === 'AsDataDelegateV2';
-export const isUpdateArgsAsProgConfigDelegateV2 = (
+export const isUpdateArgsAsProgrammableConfigDelegateV2 = (
   x: UpdateArgs,
-): x is UpdateArgs & { __kind: 'AsProgConfigDelegateV2' } => x.__kind === 'AsProgConfigDelegateV2';
+): x is UpdateArgs & { __kind: 'AsProgrammableConfigDelegateV2' } =>
+  x.__kind === 'AsProgrammableConfigDelegateV2';
 export const isUpdateArgsAsDataItemDelegateV2 = (
   x: UpdateArgs,
 ): x is UpdateArgs & { __kind: 'AsDataItemDelegateV2' } => x.__kind === 'AsDataItemDelegateV2';
@@ -203,13 +204,13 @@ export const updateArgsBeet = beet.dataEnum<UpdateArgsRecord>([
   ],
 
   [
-    'AsProgConfigDelegateV2',
-    new beet.FixableBeetArgsStruct<UpdateArgsRecord['AsProgConfigDelegateV2']>(
+    'AsProgrammableConfigDelegateV2',
+    new beet.FixableBeetArgsStruct<UpdateArgsRecord['AsProgrammableConfigDelegateV2']>(
       [
         ['ruleSet', ruleSetToggleBeet],
         ['authorizationData', beet.coption(authorizationDataBeet)],
       ],
-      'UpdateArgsRecord["AsProgConfigDelegateV2"]',
+      'UpdateArgsRecord["AsProgrammableConfigDelegateV2"]',
     ),
   ],
 

--- a/token-metadata/js/test/setup/txs-init.ts
+++ b/token-metadata/js/test/setup/txs-init.ts
@@ -501,6 +501,7 @@ export class InitTransactions {
     metadata: PublicKey,
     authority: Keypair,
     updateTestData: UpdateTestData,
+    kind: string,
     delegateRecord: PublicKey | null = null,
     masterEdition: PublicKey | null = null,
     token: PublicKey | null = null,
@@ -527,20 +528,34 @@ export class InitTransactions {
       authorizationRules: ruleSetPda,
     };
 
-    const updateArgs: UpdateInstructionArgs = {
-      updateArgs: {
-        __kind: 'V1',
-        newUpdateAuthority: updateTestData.newUpdateAuthority,
-        data: updateTestData.data,
-        primarySaleHappened: updateTestData.primarySaleHappened,
-        isMutable: updateTestData.isMutable,
-        collection: updateTestData.collection,
-        uses: updateTestData.uses,
-        collectionDetails: updateTestData.collectionDetails,
-        ruleSet: updateTestData.ruleSet,
-        authorizationData,
-      },
-    };
+    const updateArgs: UpdateInstructionArgs = (function () {
+      switch (kind) {
+        case 'V1':
+          return {
+            updateArgs: {
+              __kind: 'V1',
+              newUpdateAuthority: updateTestData.newUpdateAuthority,
+              data: updateTestData.data,
+              primarySaleHappened: updateTestData.primarySaleHappened,
+              isMutable: updateTestData.isMutable,
+              collection: updateTestData.collection,
+              uses: updateTestData.uses,
+              collectionDetails: updateTestData.collectionDetails,
+              ruleSet: updateTestData.ruleSet,
+              authorizationData,
+            },
+          };
+        case 'AsProgrammableConfigDelegateV2':
+          return {
+            updateArgs: {
+              __kind: 'AsProgrammableConfigDelegateV2',
+              ruleSet: updateTestData.ruleSet,
+              authorizationData,
+            },
+          };
+      }
+      throw new Error('Unsupported variant in test');
+    })();
 
     const updateIx = createUpdateInstruction(updateAcccounts, updateArgs);
 

--- a/token-metadata/js/test/update.test.ts
+++ b/token-metadata/js/test/update.test.ts
@@ -54,6 +54,7 @@ test('Update: NonFungible asset', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -102,6 +103,7 @@ test('Update: Fungible Token', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -150,6 +152,7 @@ test('Update: Fungible Asset', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -176,6 +179,7 @@ test('Update: Cannot Flip IsMutable to True', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -197,6 +201,7 @@ test('Update: Cannot Flip IsMutable to True', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -223,6 +228,7 @@ test('Update: Cannot Flip PrimarySaleHappened to False', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -244,6 +250,7 @@ test('Update: Cannot Flip PrimarySaleHappened to False', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -271,6 +278,7 @@ test('Update: Set New Update Authority', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -303,6 +311,7 @@ test('Update: Cannot Update Immutable Data', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -324,6 +333,7 @@ test('Update: Cannot Update Immutable Data', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -355,6 +365,7 @@ test('Update: Name Cannot Exceed 32 Bytes', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -386,6 +397,7 @@ test('Update: Symbol Cannot Exceed 10 Bytes', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -417,6 +429,7 @@ test('Update: URI Cannot Exceed 200 Bytes', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -448,6 +461,7 @@ test('Update: SellerFeeBasisPoints Cannot Exceed 10_000', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -489,6 +503,7 @@ test('Update: Creators Array Cannot Exceed Five Items', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -530,6 +545,7 @@ test('Update: No Duplicate Creator Addresses', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -569,6 +585,7 @@ test('Update: Creator Shares Must Equal 100', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -617,6 +634,7 @@ test('Update: Cannot Unverify Another Creator', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -654,6 +672,7 @@ test('Update: Cannot Unverify Another Creator', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -697,6 +716,7 @@ test('Update: Cannot Verify Another Creator', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -732,6 +752,7 @@ test('Update: Cannot Verify Another Creator', async (t) => {
     metadata,
     authority,
     updateData2,
+    'V1',
     null,
     masterEdition,
   );
@@ -808,6 +829,7 @@ test('Update: Update Unverified Collection Key', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -889,6 +911,7 @@ test('Update: Fail to Verify an Unverified Collection', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -983,6 +1006,7 @@ test('Update: Fail to Update a Verified Collection', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -1020,6 +1044,7 @@ test('Update: Update pNFT Config', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
     token,
@@ -1064,6 +1089,7 @@ test('Update: Fail to update rule set on NFT', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
     token,
@@ -1133,6 +1159,7 @@ test('Update: Update existing pNFT rule set config to None', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
     token,
@@ -1171,6 +1198,7 @@ test('Update: Invalid Update Authority Fails', async (t) => {
     metadata,
     invalidUpdateAuthority,
     updateData,
+    'V1',
     null,
     masterEdition,
   );
@@ -1242,6 +1270,7 @@ test('Update: Delegate Authority Role Not Allowed to Update Data', async (t) => 
     daManager.metadata,
     authority,
     updateData,
+    'V1',
     delegateRecord,
     daManager.masterEdition,
   );
@@ -1315,6 +1344,7 @@ test('Update: Holder Authority Type Not Supported', async (t) => {
     metadata,
     holder,
     updateData,
+    'V1',
     null,
     masterEdition,
     token,
@@ -1412,6 +1442,7 @@ test('Update: Cannot Update pNFT Config with locked token', async (t) => {
     metadata,
     authority,
     updateData,
+    'V1',
     null,
     masterEdition,
     token,
@@ -1514,6 +1545,114 @@ test('Update: rule set update with programmable config delegate', async (t) => {
     nft.metadata,
     delegate,
     updateData,
+    'V1',
+    delegateRecord,
+    nft.masterEdition,
+    nft.token,
+  );
+  await updateTx.assertSuccess(t);
+
+  metadata = await Metadata.fromAccountAddress(connection, nft.metadata);
+
+  spok(t, metadata, {
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+    programmableConfig: { __kind: 'V1', ruleSet: spokSamePubkey(dummyRuleSet) },
+  });
+});
+
+test('Update: rule set update with programmable config delegate V2 args', async (t) => {
+  const API = new InitTransactions();
+  const { fstTxHandler: handler, payerPair: payer, connection } = await API.payer();
+
+  const collection = await createAndMintDefaultAsset(
+    t,
+    connection,
+    API,
+    handler,
+    payer,
+    TokenStandard.ProgrammableNonFungible,
+  );
+
+  const nft = await createAndMintDefaultAsset(
+    t,
+    connection,
+    API,
+    handler,
+    payer,
+    TokenStandard.ProgrammableNonFungible,
+    null,
+    1,
+    collection.mint,
+  );
+
+  let metadata = await Metadata.fromAccountAddress(connection, nft.metadata);
+
+  spok(t, metadata, {
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+    programmableConfig: { __kind: 'V1', ruleSet: null },
+  });
+
+  // creates a delegate
+
+  const [, delegate] = await API.getKeypair('Delegate');
+  // delegate PDA
+  const [delegateRecord] = PublicKey.findProgramAddressSync(
+    [
+      Buffer.from('metadata'),
+      PROGRAM_ID.toBuffer(),
+      collection.mint.toBuffer(),
+      Buffer.from('programmable_config_delegate'),
+      payer.publicKey.toBuffer(),
+      delegate.publicKey.toBuffer(),
+    ],
+    PROGRAM_ID,
+  );
+  amman.addr.addLabel('Metadata Delegate Record', delegateRecord);
+
+  const args: DelegateArgs = {
+    __kind: 'ProgrammableConfigV1',
+    authorizationData: null,
+  };
+
+  const { tx: delegateTx } = await API.delegate(
+    delegate.publicKey,
+    collection.mint,
+    collection.metadata,
+    payer.publicKey,
+    payer,
+    args,
+    handler,
+    delegateRecord,
+    collection.masterEdition,
+  );
+
+  await delegateTx.assertSuccess(t);
+
+  const pda = await MetadataDelegateRecord.fromAccountAddress(connection, delegateRecord);
+
+  spok(t, pda, {
+    delegate: spokSamePubkey(delegate.publicKey),
+    mint: spokSamePubkey(collection.mint),
+  });
+
+  // update the nft via the delegate
+
+  const dummyRuleSet = Keypair.generate().publicKey;
+
+  const updateData = new UpdateTestData();
+  updateData.ruleSet = {
+    __kind: 'Set',
+    fields: [dummyRuleSet],
+  };
+
+  const { tx: updateTx } = await API.update(
+    t,
+    handler,
+    nft.mint,
+    nft.metadata,
+    delegate,
+    updateData,
+    'AsProgrammableConfigDelegateV2',
     delegateRecord,
     nft.masterEdition,
     nft.token,
@@ -1630,6 +1769,7 @@ test('Update: fail to update metadata with programmable config delegate', async 
     nft.metadata,
     delegate,
     updateData,
+    'V1',
     delegateRecord,
     nft.masterEdition,
     nft.token,

--- a/token-metadata/program/src/instruction/metadata.rs
+++ b/token-metadata/program/src/instruction/metadata.rs
@@ -150,7 +150,7 @@ pub enum UpdateArgs {
         /// Required authorization data to validate the request.
         authorization_data: Option<AuthorizationData>,
     },
-    AsProgConfigDelegateV2 {
+    AsProgrammableConfigDelegateV2 {
         // Programmable rule set configuration (only applicable to `Programmable` asset types).
         rule_set: RuleSetToggle,
         /// Required authorization data to validate the request.
@@ -231,7 +231,7 @@ impl UpdateArgs {
     }
 
     pub fn default_as_programmable_config_delegate() -> Self {
-        Self::AsProgConfigDelegateV2 {
+        Self::AsProgrammableConfigDelegateV2 {
             rule_set: RuleSetToggle::default(),
             authorization_data: None,
         }

--- a/token-metadata/program/src/processor/metadata/update.rs
+++ b/token-metadata/program/src/processor/metadata/update.rs
@@ -310,7 +310,7 @@ fn validate_update(
             ) => true,
             (
                 MetadataDelegateRole::ProgrammableConfig,
-                UpdateArgs::AsProgConfigDelegateV2 { .. },
+                UpdateArgs::AsProgrammableConfigDelegateV2 { .. },
             ) => true,
             (
                 MetadataDelegateRole::ProgrammableConfigItem,

--- a/token-metadata/program/src/state/metadata.rs
+++ b/token-metadata/program/src/state/metadata.rs
@@ -237,7 +237,7 @@ impl Metadata {
         match &args {
             UpdateArgs::V1 { rule_set, .. }
             | UpdateArgs::AsUpdateAuthorityV2 { rule_set, .. }
-            | UpdateArgs::AsProgConfigDelegateV2 { rule_set, .. }
+            | UpdateArgs::AsProgrammableConfigDelegateV2 { rule_set, .. }
             | UpdateArgs::AsProgrammableConfigItemDelegateV2 { rule_set, .. } => {
                 // if the rule_set data is either 'Set' or 'Clear', only allow updating if the
                 // token standard is equal to `ProgrammableNonFungible` and no SPL delegate is set.

--- a/token-metadata/program/tests/update.rs
+++ b/token-metadata/program/tests/update.rs
@@ -902,7 +902,9 @@ mod update {
 
         let mut update_args = UpdateArgs::default_as_programmable_config_delegate();
         match &mut update_args {
-            UpdateArgs::AsProgConfigDelegateV2 { rule_set, .. } => *rule_set = RuleSetToggle::Clear,
+            UpdateArgs::AsProgrammableConfigDelegateV2 { rule_set, .. } => {
+                *rule_set = RuleSetToggle::Clear
+            }
             _ => panic!("Unexpected enum variant"),
         }
 
@@ -2143,7 +2145,9 @@ mod update {
         // Change programmable config, removing the RuleSet.
         let mut args = UpdateArgs::default_as_programmable_config_delegate();
         match &mut args {
-            UpdateArgs::AsProgConfigDelegateV2 { rule_set, .. } => *rule_set = RuleSetToggle::Clear,
+            UpdateArgs::AsProgrammableConfigDelegateV2 { rule_set, .. } => {
+                *rule_set = RuleSetToggle::Clear
+            }
             _ => panic!("Unexpected enum variant"),
         }
 


### PR DESCRIPTION
Wanted to add one ts test to use the `V2` update args.

Found I had missed an abbreviation change on `AsProgrammableConfigDelegateV2` so fixed that as well.