### PR TITLE
Allow for 5 creators in Bubblegum

### DIFF
--- a/bubblegum/program/src/utils.rs
+++ b/bubblegum/program/src/utils.rs
@@ -23,7 +23,7 @@ pub fn assert_metadata_is_mpl_compatible(metadata: &MetadataArgs) -> Result<()> 
         return Err(BubblegumError::MetadataBasisPointsTooHigh.into());
     }
     if !metadata.creators.is_empty() {
-        if metadata.creators.len() > mpl_token_metadata::state::MAX_CREATOR_LIMIT - 1 {
+        if metadata.creators.len() > mpl_token_metadata::state::MAX_CREATOR_LIMIT {
             return Err(BubblegumError::CreatorsTooLong.into());
         }
 


### PR DESCRIPTION
Previously in Bubblegum there was an injection of an additional creator during `decompress_v1`.  Added in [this commit](https://github.com/jarry-xiao/candyland/commit/4864f45fc1ec0f1a9a727c0d8b368ceab594c9cf#diff-0510c91bba2902bb7ddb233124c96ac8b9ca8b62f6b255dac2cac1225a9fc6ba) in Candyland July 2022.

Old Bubblegum code in Candyland repo:
```Rust
if metadata.creators.len() > 0 {
    let mut amended_metadata_creators = metadata.creators;
    amended_metadata_creators.push(Creator {
        address: ctx.accounts.mint_authority.key(),
        verified: true,
        share: 0,
    });
    Some(
        amended_metadata_creators
            .iter()
            .map(|c| c.adapt())
            .collect(),
    )
} else {
    None
},
```

The reason for this injection of a creator was because in token-metadata there was a requirement that the metadata update authority had to be in the creator array to create the metadata.  This is no longer true in token-metadata since a refactoring: https://github.com/metaplex-foundation/metaplex-program-library/pull/652 in August 2022.

This injection was removed in Bubblegum in [this commit](https://github.com/metaplex-foundation/metaplex-program-library/commit/2739d8fe78763285a239f55a33fbcb05b642713e#diff-887afc68d4b425e306186003fcac2e9d0d278472052c7c5221737ef13e477335) in October 2022.

New Bubblegum Code in Metaplex Program Library:
```Rust
if !metadata.creators.is_empty() {
    Some(metadata.creators.iter().map(|c| c.adapt()).collect())
} else {
    None
},
```
However, there was still a check during Bubblegum `process_mint_v1` to leave room for the injected creator by only allowing 4 creators.  This check is no longer relevant and we can allow for 5 creators, which is the change in this PR.