### PR TITLE
Removing remaining clippy errors from Bubblegum tests

### DIFF
--- a/bubblegum/program/tests/utils/context.rs
+++ b/bubblegum/program/tests/utils/context.rs
@@ -94,7 +94,7 @@ impl BubblegumTestContext {
             .banks_client
             .process_transaction(tx)
             .await
-            .map_err(Error::BanksClient)
+            .map_err(|err| Box::new(Error::BanksClient(err)))
     }
 
     pub fn payer(&self) -> Keypair {
@@ -150,7 +150,7 @@ impl BubblegumTestContext {
         &self,
     ) -> Result<Tree<MAX_DEPTH, MAX_BUFFER_SIZE>> {
         let payer = self.payer();
-        let tree = Tree::<MAX_DEPTH, MAX_BUFFER_SIZE>::with_creator(&payer, self.client());
+        let mut tree = Tree::<MAX_DEPTH, MAX_BUFFER_SIZE>::with_creator(&payer, self.client());
         tree.alloc(&payer).await?;
         tree.create(&payer).await?;
         Ok(tree)
@@ -160,7 +160,7 @@ impl BubblegumTestContext {
         &self,
     ) -> Result<Tree<MAX_DEPTH, MAX_BUFFER_SIZE>> {
         let payer = self.payer();
-        let tree = Tree::<MAX_DEPTH, MAX_BUFFER_SIZE>::with_creator(&payer, self.client());
+        let mut tree = Tree::<MAX_DEPTH, MAX_BUFFER_SIZE>::with_creator(&payer, self.client());
         tree.alloc(&payer).await?;
         tree.create_public(&payer).await?;
         Ok(tree)
@@ -171,7 +171,7 @@ impl BubblegumTestContext {
         &self,
         num_mints: u64,
     ) -> Result<(Tree<MAX_DEPTH, MAX_BUFFER_SIZE>, Vec<LeafArgs>)> {
-        let tree = self
+        let mut tree = self
             .default_create_tree::<MAX_DEPTH, MAX_BUFFER_SIZE>()
             .await?;
 

--- a/bubblegum/program/tests/utils/mod.rs
+++ b/bubblegum/program/tests/utils/mod.rs
@@ -22,7 +22,7 @@ pub enum Error {
     Signer(SignerError),
 }
 
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Box<Error>>;
 
 pub fn program_test() -> ProgramTest {
     let mut test = ProgramTest::new("mpl_bubblegum", mpl_bubblegum::id(), None);

--- a/bubblegum/program/tests/utils/tx_builder.rs
+++ b/bubblegum/program/tests/utils/tx_builder.rs
@@ -1,5 +1,3 @@
-use std::cell::{RefCell, RefMut};
-
 use anchor_lang::{self, InstructionData, ToAccountMetas};
 use solana_program::pubkey::Pubkey;
 use solana_program_test::BanksClient;
@@ -23,16 +21,11 @@ pub struct TxBuilder<'a, T, U, V, const MAX_DEPTH: usize, const MAX_BUFFER_SIZE:
     pub data: U,
     // The currently configured payer for the tx.
     pub payer: Pubkey,
-    // Using `RefCell` to provide interior mutability and circumvent some
-    // annoyance with the borrow checker (i.e. provide helper methods that
-    // only need &self, vs &mut self); if we'll ever need to use this
-    // in a context with multiple threads, we can just replace the wrapper
-    // with a `Mutex`.
-    pub client: RefCell<BanksClient>,
+    pub client: BanksClient,
     // Currently configured signers for the tx. Using only `Keypair`s as
     // signers for now; can make this more generic if needed.
     pub signers: Vec<Keypair>,
-    pub tree: &'a Tree<MAX_DEPTH, MAX_BUFFER_SIZE>,
+    pub tree: &'a mut Tree<MAX_DEPTH, MAX_BUFFER_SIZE>,
     // When some, indicates that a proof for the specified leaf index should
     // be computed from the inner tree and attached in the form of additional
     // accounts (but only if `self.additional_accounts.len() == 0`, so we
@@ -54,16 +47,12 @@ where
     T: ToAccountMetas,
     U: InstructionData,
 {
-    fn client(&self) -> RefMut<BanksClient> {
-        self.client.borrow_mut()
-    }
-
     pub async fn execute(&mut self) -> Result<()>
     where
         Self: OnSuccessfulTxExec,
     {
         let recent_blockhash = self
-            .client()
+            .client
             .get_latest_blockhash()
             .await
             .map_err(Error::BanksClient)?;
@@ -89,7 +78,7 @@ where
         tx.try_partial_sign(&self.signers.iter().collect::<Vec<_>>(), recent_blockhash)
             .map_err(Error::Signer)?;
 
-        self.client()
+        self.client
             .process_transaction(tx)
             .await
             .map_err(Error::BanksClient)?;


### PR DESCRIPTION
* Changes the `Result` types in `tests/utils/mod.rs` to use `Box<Error>` for the error variant, to fix the clippy issue of large enum variant return.
* Removes use of `RefCell` for `Tree` and `TxBuilder` objects.  It looks like this was done to allow immutable references to be used for most method calls, and allow for immutable and mutable references to be used at the same time.
  * Overall the use of `RefCell` was convenient but I don't think it is the best fit for this use case.  I'd rather just follow the borrow checker rules.  Also, it is not correct to hold a `RefCell` over await statements, which is fairly fundamental to the test architecture used here.
  * For example, before this code change, a method such as `zero_leaf` would take an immutable reference to a `Tree` object instance, and then mutate it because it had a `RefCell` so it could do a `borrow_mut()`:
  ```Rust
  pub fn zero_leaf(&self, index: u32) -> Result<()> {
      let node = [0u8; 32];
      // The conversion below should never fail.
      self.proof_tree
          .borrow_mut()
          .add_leaf(node, usize::try_from(index).unwrap());
      Ok(())
  }
  ```
  * Also this allowed taking an immutable reference to a keypair and sending it to a method that would normally require a mutable reference.  Thus the borrow checker would not like this either.
