### PR TITLE
Adding escrows for pNFTs and removing check for closing the account

### DIFF
--- a/token-metadata/program/src/processor/escrow/close_escrow_account.rs
+++ b/token-metadata/program/src/processor/escrow/close_escrow_account.rs
@@ -11,8 +11,7 @@ use crate::{
     assertions::{assert_derivation, assert_initialized, assert_keys_equal, assert_owned_by},
     error::MetadataError,
     pda::{EDITION, PREFIX},
-    state::{EscrowAuthority, Metadata, TokenMetadataAccount, TokenOwnedEscrow, TokenStandard},
-    utils::check_token_standard,
+    state::{EscrowAuthority, Metadata, TokenMetadataAccount, TokenOwnedEscrow},
 };
 
 pub fn process_close_escrow_account(
@@ -50,12 +49,6 @@ pub fn process_close_escrow_account(
     if &metadata.mint != mint_account_info.key {
         return Err(MetadataError::MintMismatch.into());
     }
-
-    if check_token_standard(mint_account_info, Some(edition_account_info))?
-        != TokenStandard::NonFungible
-    {
-        return Err(MetadataError::MustBeNonFungible.into());
-    };
 
     // Check that the edition account is for this mint.
     let _edition_bump = assert_derivation(

--- a/token-metadata/program/src/processor/escrow/create_escrow_account.rs
+++ b/token-metadata/program/src/processor/escrow/create_escrow_account.rs
@@ -70,12 +70,14 @@ pub fn process_create_escrow_account(
         return Err(MetadataError::MintMismatch.into());
     }
 
-    // Only non-fungible tokens (i.e. unique) can have escrow accounts.
-    if check_token_standard(mint_account_info, Some(edition_account_info))?
-        != TokenStandard::NonFungible
-    {
+    // Only standard or programmable non-fungible tokens (i.e. unique) can have escrow accounts.
+    let token_standard = check_token_standard(mint_account_info, Some(edition_account_info))?;
+    if !matches!(
+        token_standard,
+        TokenStandard::NonFungible | TokenStandard::ProgrammableNonFungible
+    ) {
         return Err(MetadataError::MustBeNonFungible.into());
-    };
+    }
 
     // Check that the edition account is for this mint.
     let _edition_bump = assert_derivation(


### PR DESCRIPTION
The check was removed because it redundantly checked if you could close an account that can never be created do to the check in create.