### PR TITLE
Remove unnecessary account from cpi

### DIFF
--- a/token-metadata/program/src/processor/delegate/revoke.rs
+++ b/token-metadata/program/src/processor/delegate/revoke.rs
@@ -295,11 +295,7 @@ fn revoke_persistent_delegate_v1(
             ctx.accounts.authority_info.key,
             &[],
         )?,
-        &[
-            token_info.clone(),
-            ctx.accounts.delegate_info.clone(),
-            ctx.accounts.authority_info.clone(),
-        ],
+        &[token_info.clone(), ctx.accounts.authority_info.clone()],
     )?;
 
     if matches!(


### PR DESCRIPTION
PR to remove an unnecessary account being passed in on a cpi call to revoke a delegate.