### PR TITLE
Add Bubblegum transfer and burn js tests

### DIFF
--- a/bubblegum/js/src/mpl-bubblegum.ts
+++ b/bubblegum/js/src/mpl-bubblegum.ts
@@ -30,7 +30,7 @@ export function computeCreatorHash(creators: Creator[]) {
         Buffer.from([creator.verified ? 1 : 0]),
         Buffer.from([creator.share]),
       ]);
-    })
+    }),
   );
   return Buffer.from(keccak_256.digest(bufferOfCreatorData));
 }


### PR DESCRIPTION
Added a test to transfer and burn a compressed NFT.

One thing I'm concerned about is this warning I get:
```
Transaction references a signature that is unnecessary, only the fee payer and instruction signer accounts should sign a transaction. This behavior is deprecated and will throw an error in the next major version release.
```

I believe this is because Burn does not have the leaf owner listed as a signer in the Accounts validation struct, but checks that either the owner or the delegate is a signer at runtime.  So then the owner and delegate are not listed as signers in the generated JS code.  But this seems like it might cause issues soon.

_UPDATE_: We will fix the above with Kinobi/Umi in new repo.