### PR TITLE
Bubblegum add event log for burn, redeem, and decompress

### DIFF
--- a/bubblegum/js/.solitarc.js
+++ b/bubblegum/js/.solitarc.js
@@ -13,4 +13,5 @@ module.exports = {
   sdkDir,
   binaryInstallDir,
   programDir,
+  rustbin: { locked: true }
 };

--- a/bubblegum/js/package.json
+++ b/bubblegum/js/package.json
@@ -13,7 +13,7 @@
     "postpublish": "git push origin && git push origin --tags",
     "build:docs": "typedoc",
     "build": "rimraf dist && tsc -p tsconfig.json",
-    "start-validator": "solana-test-validator -ud --quiet --reset -c cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK -c 4VTQredsAmr1yzRJugLV6Mt6eu6XMeCwdkZ73wwVMWHv -c noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV -c 3RHkdjCwWyK2firrwFQGvXCxbUpBky1GTmb9EDK9hUnX -c metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s --bpf-program BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY ../program/target/deploy/mpl_bubblegum.so",
+    "start-validator": "solana-test-validator -ud --quiet --reset -c cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK -c 4VTQredsAmr1yzRJugLV6Mt6eu6XMeCwdkZ73wwVMWHv -c noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV -c 3RHkdjCwWyK2firrwFQGvXCxbUpBky1GTmb9EDK9hUnX -c metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s -c PwDiXFxQsGra4sFFTT8r1QWRMd4vfumiWC1jfWNfdYT -c TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA -c ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL --bpf-program BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY ../program/target/deploy/mpl_bubblegum.so",
     "run-tests": "jest tests --detectOpenHandles",
     "test": "start-server-and-test start-validator http://localhost:8899/health run-tests",
     "api:gen": "DEBUG='(solita|rustbin):(info|error)' solita",

--- a/bubblegum/js/src/mpl-bubblegum.ts
+++ b/bubblegum/js/src/mpl-bubblegum.ts
@@ -30,7 +30,7 @@ export function computeCreatorHash(creators: Creator[]) {
         Buffer.from([creator.verified ? 1 : 0]),
         Buffer.from([creator.share]),
       ]);
-    })
+    }),
   );
   return Buffer.from(keccak_256.digest(bufferOfCreatorData));
 }

--- a/bubblegum/program/src/lib.rs
+++ b/bubblegum/program/src/lib.rs
@@ -1322,6 +1322,11 @@ pub mod bubblegum {
             creator_hash,
         );
 
+        wrap_application_data_v1(
+            previous_leaf.to_event().try_to_vec()?,
+            &ctx.accounts.log_wrapper,
+        )?;
+
         let new_leaf = Node::default();
 
         replace_leaf(
@@ -1353,6 +1358,11 @@ pub mod bubblegum {
         let asset_id = get_asset_id(&merkle_tree.key(), nonce);
         let previous_leaf =
             LeafSchema::new_v0(asset_id, owner, delegate, nonce, data_hash, creator_hash);
+
+        wrap_application_data_v1(
+            previous_leaf.to_event().try_to_vec()?,
+            &ctx.accounts.log_wrapper,
+        )?;
 
         let new_leaf = Node::default();
 
@@ -1427,6 +1437,12 @@ pub mod bubblegum {
         }
 
         let voucher = &ctx.accounts.voucher;
+
+        wrap_application_data_v1(
+            voucher.leaf_schema.to_event().try_to_vec()?,
+            &ctx.accounts.log_wrapper,
+        )?;
+
         match metadata.token_program_version {
             TokenProgramVersion::Original => {
                 if ctx.accounts.mint.data_is_empty() {


### PR DESCRIPTION
### Notes
* These event logs are needed so that the indexer can get the leaf schemas for the assets being affected by these Bubblegum instructions and index them properly.
* Also add JS tests for transfer, burn, redeem and decompress.
* Also fix yarn API gen so Solita can build Anchor 0.26.0 the way cargo install does.

### Test warning
Note there is one warning when running the tests:
```
Transaction references a signature that is unnecessary, only the fee payer and instruction
signer accounts should sign a transaction. This behavior is deprecated and will throw an
error in the next major version release.
```
This is because the leaf owner is not marked as a Signer in the Anchor account validation struct.  It is only checked at runtime because either the leaf owner or the leaf delegate needs to be a signer but not both.  This is planned to be fixed when we switch to Kinobi/Umi to generate the JS SDK.

### Read API Testing
I tested these event generations with the Read API by running the JS tests in this PR while running the read API locally.

Previously before this PR I would see `decompress` get indexed, but I would NOT see `burn` get indexed properly.  I also am fairly confident `redeem` was not indexing properly but did not isolate it.  But not indexing `redeem` would not result in significant corruption because no key data gets changed by `redeem`.  However, the sequence number is supposed to be updated so results in slight incorrect asset table.

With this PR change in place, when I ran the "transfer and burn" test, I saw it indexed by the Read API, with `compressed` still set to true and `burnt` is now set to true:
```
-[ RECORD 1 ]-------------+-------------------------------------------------------------------
id                        | \x49d6919c1d29bab97e52b0503a6335f79a90548aad66b82204cd5f998ee6f68f
alt_id                    | 
specification_version     | v1
specification_asset_class | NFT
owner                     | \x1eee305b675dead00c05e715223312ac159f9996a36e51c3f041019c6fc95320
owner_type                | single
delegate                  | 
frozen                    | f
supply                    | 1
supply_mint               | 
compressed                | t
compressible              | f
seq                       | 3
tree_id                   | \xed0afe0803913513e628aade7ac7b402780f98b02670d04d3d5f4bec4becf326
leaf                      | \xc4f16e218a0d8a803601eef3015b6311e29abe8a0bbd0046f33ebf5142c5494c
nonce                     | 0
royalty_target_type       | creators
royalty_target            | 
royalty_amount            | 0
asset_data                | \x49d6919c1d29bab97e52b0503a6335f79a90548aad66b82204cd5f998ee6f68f
created_at                | 2023-06-13 23:36:47.733342+00
burnt                     | t
slot_updated              | 307
data_hash                 | 5LGgLYymenGxywBTUSJRKzcemigs6jXc7SwZQmJU1VmZ      
creator_hash              | CtHfCypsUk53L5Xzocmq8MXma2BNMV7pX7wrJNhuRL1t
```
With this PR change in place, when I ran the "redeem and decompress" test, I saw it still indexed by the Read API, with `compressed` set to false (this tests decompress is still working):
```
-[ RECORD 1 ]-------------+-------------------------------------------------------------------
id                        | \x238115e4c1968306bb191ccb927fe13fd7d162facbf66521d04c259d537a20ac
alt_id                    | 
specification_version     | v1
specification_asset_class | NFT
owner                     | \xdc53343c46e5d7a1bd08f4780285621202f66b596f984e940a5eb423ac560fed
owner_type                | single
delegate                  | 
frozen                    | f
supply                    | 1
supply_mint               | 
compressed                | f
compressible              | f
seq                       | 0
tree_id                   | 
leaf                      | 
nonce                     | 0
royalty_target_type       | creators
royalty_target            | 
royalty_amount            | 0
asset_data                | \x238115e4c1968306bb191ccb927fe13fd7d162facbf66521d04c259d537a20ac
created_at                | 2023-06-13 23:40:30.187896+00
burnt                     | f
slot_updated              | 77
data_hash                 | BkD3QnwCGu8oJ8XA6bBWxWbasg7MquQhvwZMbwwNrWZh      
creator_hash              | 9xPpgWT7ADAp65akSw4CZnyETUMLgm7Kwm51mNnFXfoR
```