### PR TITLE
Reverting new leaf schema events for `burn`, `redeem`, and `decompress`

### DIFF
--- a/bubblegum/program/src/lib.rs
+++ b/bubblegum/program/src/lib.rs
@@ -1322,11 +1322,6 @@ pub mod bubblegum {
             creator_hash,
         );
 
-        wrap_application_data_v1(
-            previous_leaf.to_event().try_to_vec()?,
-            &ctx.accounts.log_wrapper,
-        )?;
-
         let new_leaf = Node::default();
 
         replace_leaf(
@@ -1358,11 +1353,6 @@ pub mod bubblegum {
         let asset_id = get_asset_id(&merkle_tree.key(), nonce);
         let previous_leaf =
             LeafSchema::new_v0(asset_id, owner, delegate, nonce, data_hash, creator_hash);
-
-        wrap_application_data_v1(
-            previous_leaf.to_event().try_to_vec()?,
-            &ctx.accounts.log_wrapper,
-        )?;
 
         let new_leaf = Node::default();
 
@@ -1437,12 +1427,6 @@ pub mod bubblegum {
         }
 
         let voucher = &ctx.accounts.voucher;
-
-        wrap_application_data_v1(
-            voucher.leaf_schema.to_event().try_to_vec()?,
-            &ctx.accounts.log_wrapper,
-        )?;
-
         match metadata.token_program_version {
             TokenProgramVersion::Original => {
                 if ctx.accounts.mint.data_is_empty() {


### PR DESCRIPTION
This code was added to Bubblegum to make Read API indexing of compression easier.  But instead of using these leaf schema events, we were able to derive the `asset_id` using the leaf index from the change log event.

I think it would have been more convenient to use these leaf events, but by solving it through derivation in the Read API, it keeps the Read API backwards compatible with all existing cNFT transactions that don't provide the leaf schema events in `burn`, `redeem`, and `decompress`.

Note this code was never deployed to devnet or mainnet.