### PR TITLE
Fix: set_token_standard() has update_authority unneccessarily set to mutable

### DIFF
--- a/token-metadata/js/idl/mpl_token_metadata.json
+++ b/token-metadata/js/idl/mpl_token_metadata.json
@@ -1932,7 +1932,7 @@
         },
         {
           "name": "updateAuthority",
-          "isMut": true,
+          "isMut": false,
           "isSigner": true,
           "desc": "Metadata update authority"
         },

--- a/token-metadata/js/src/generated/instructions/SetTokenStandard.ts
+++ b/token-metadata/js/src/generated/instructions/SetTokenStandard.ts
@@ -21,7 +21,7 @@ export const SetTokenStandardStruct = new beet.BeetArgsStruct<{ instructionDiscr
  * Accounts required by the _SetTokenStandard_ instruction
  *
  * @property [_writable_] metadata Metadata account
- * @property [_writable_, **signer**] updateAuthority Metadata update authority
+ * @property [**signer**] updateAuthority Metadata update authority
  * @property [] mint Mint account
  * @property [] edition (optional) Edition account
  * @category Instructions
@@ -65,7 +65,7 @@ export function createSetTokenStandardInstruction(
     },
     {
       pubkey: accounts.updateAuthority,
-      isWritable: true,
+      isWritable: false,
       isSigner: true,
     },
     {

--- a/token-metadata/program/src/instruction/metadata.rs
+++ b/token-metadata/program/src/instruction/metadata.rs
@@ -529,7 +529,7 @@ pub fn set_token_standard(
 ) -> Instruction {
     let mut accounts = vec![
         AccountMeta::new(metadata_account, false),
-        AccountMeta::new(update_authority, true),
+        AccountMeta::new_readonly(update_authority, true),
         AccountMeta::new_readonly(mint_account, false),
     ];
     let data = MetadataInstruction::SetTokenStandard.try_to_vec().unwrap();

--- a/token-metadata/program/src/instruction/mod.rs
+++ b/token-metadata/program/src/instruction/mod.rs
@@ -440,7 +440,7 @@ pub enum MetadataInstruction {
 
     /// Set the token standard of the asset.
     #[account(0, writable, name="metadata", desc="Metadata account")]
-    #[account(1, signer, writable, name="update_authority", desc="Metadata update authority")]
+    #[account(1, signer, name="update_authority", desc="Metadata update authority")]
     #[account(2, name="mint", desc="Mint account")]
     #[account(3, optional, name="edition", desc="Edition account")]
     SetTokenStandard,


### PR DESCRIPTION
This results in writable privilege escalation for e.g. when CPI-ing `SetTokenStandard` using anchor_spl with an immutable update_authority AccountInfo