### PR TITLE
remove redundant check

### DIFF
--- a/token-metadata/program/src/processor/bubblegum/bubblegum_set_collection_size.rs
+++ b/token-metadata/program/src/processor/bubblegum/bubblegum_set_collection_size.rs
@@ -8,7 +8,7 @@ use solana_program::{
 };
 
 use crate::{
-    assertions::{assert_owned_by, collection::assert_has_collection_authority},
+    assertions::assert_owned_by,
     error::MetadataError,
     instruction::SetCollectionSizeArgs,
     state::{CollectionDetails, Metadata, TokenMetadataAccount},
@@ -28,12 +28,6 @@ pub fn bubblegum_set_collection_size(
     let collection_update_authority_account_info = next_account_info(account_info_iter)?;
     let collection_mint_account_info = next_account_info(account_info_iter)?;
     let bubblegum_signer_info = next_account_info(account_info_iter)?;
-
-    let delegated_collection_auth_opt = if accounts.len() == 5 {
-        Some(next_account_info(account_info_iter)?)
-    } else {
-        None
-    };
 
     if !BUBBLEGUM_ACTIVATED {
         return Err(MetadataError::InvalidOperation.into());
@@ -57,13 +51,6 @@ pub fn bubblegum_set_collection_size(
     if !collection_update_authority_account_info.is_signer {
         return Err(MetadataError::UpdateAuthorityIsNotSigner.into());
     }
-
-    assert_has_collection_authority(
-        collection_update_authority_account_info,
-        &metadata,
-        collection_mint_account_info.key,
-        delegated_collection_auth_opt,
-    )?;
 
     // Ensure new size is + or - 1 of the current size.
     let current_size = if let Some(details) = metadata.collection_details {

--- a/token-metadata/program/src/processor/bubblegum/bubblegum_set_collection_size.rs
+++ b/token-metadata/program/src/processor/bubblegum/bubblegum_set_collection_size.rs
@@ -48,6 +48,7 @@ pub fn bubblegum_set_collection_size(
     let mut metadata = Metadata::from_account_info(parent_nft_metadata_account_info)?;
 
     // Check that the update authority or delegate is a signer.
+    // Collection authority is validated in the bubblegum program in the assert_has_collection_authority call.
     if !collection_update_authority_account_info.is_signer {
         return Err(MetadataError::UpdateAuthorityIsNotSigner.into());
     }


### PR DESCRIPTION
Removes a [redundant check](https://github.com/metaplex-foundation/metaplex-program-library/blob/d6f96f67b187104e6c4622b99f466bc530fc2b7d/bubblegum/program/src/lib.rs#L737C9-L737C9) that is already present in Bubblegum. As long as this handler is permissioned to Bubblegum this check only needs to be in Bubblegum. This assertion is[ getting reworked in Bubblegum to support both delegate types ](https://github.com/metaplex-foundation/metaplex-program-library/pull/1138) and it's not necessary to add the extra code to this assert as well--better to remove it to save binary size.