### PR TITLE
set burned metadata accounts with fees as Unitialized

### DIFF
--- a/token-metadata/js/test/burn.test.ts
+++ b/token-metadata/js/test/burn.test.ts
@@ -37,12 +37,14 @@ test.only('Burn: NonFungible asset', async (t) => {
 
   await updateTx.assertSuccess(t);
 
-  // All three accounts are closed. Metadata account should have a data length of 0 but may be open if it contains fees.
+  // Metadata account should have a data length of 1 because it still contains fees. It's discriminator will be Unitialized.
+  // Edition and token accounts should be closed.
   const metadataAccount = await connection.getAccountInfo(metadata);
   const editionAccount = await connection.getAccountInfo(masterEdition);
   const tokenAccount = await connection.getAccountInfo(token);
 
-  t?.equal(metadataAccount.data.length, 0);
+  t?.equal(metadataAccount.data.length, 1);
+  t?.equal(metadataAccount.data[0], 0);
   t.equal(editionAccount, null);
   t.equal(tokenAccount, null);
 });
@@ -79,13 +81,15 @@ test('Burn: ProgrammableNonFungible asset', async (t) => {
 
   await updateTx.assertSuccess(t);
 
-  // All three accounts are closed.
+  // Metadata account should have a data length of 1 because it still contains fees. It's discriminator will be Unitialized.
+  // Edition, token, and token record accounts should be closed.
   const metadataAccount = await connection.getAccountInfo(metadata);
   const editionAccount = await connection.getAccountInfo(masterEdition);
   const tokenAccount = await connection.getAccountInfo(token);
   const tokenRecordAccount = await connection.getAccountInfo(tokenRecord);
 
-  t?.equal(metadataAccount.data.length, 0);
+  t?.equal(metadataAccount.data.length, 1);
+  t?.equal(metadataAccount.data[0], 0);
   t.equal(editionAccount, null);
   t.equal(tokenAccount, null);
   t.equal(tokenRecordAccount, null);

--- a/token-metadata/program/src/processor/burn/nonfungible.rs
+++ b/token-metadata/program/src/processor/burn/nonfungible.rs
@@ -108,7 +108,10 @@ pub(crate) fn burn_nonfungible(ctx: &Context<Burn>, args: BurnNonFungibleArgs) -
     )?;
 
     if let Some(collection_metadata_info) = ctx.accounts.collection_metadata_info {
-        if collection_metadata_info.data_is_empty() {
+        // If collection parent is burned or Uninitialized because it stores fees, we don't need to decrement the size.
+        if collection_metadata_info.data_is_empty()
+            || collection_metadata_info.data.borrow()[0] == 0
+        {
             let Collection {
                 key: expected_collection_mint,
                 ..

--- a/token-metadata/program/src/processor/collection/unverify_collection.rs
+++ b/token-metadata/program/src/processor/collection/unverify_collection.rs
@@ -60,7 +60,8 @@ pub fn unverify_collection(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pro
     // the NFT.
     //
     // This check needs to happen before the program owned check.
-    let parent_burned = collection_metadata_info.data_is_empty();
+    let parent_burned =
+        collection_metadata_info.data_is_empty() || collection_metadata_info.data.borrow()[0] == 0;
 
     if parent_burned {
         // If the parent is burned, we need to check that the authority

--- a/token-metadata/program/src/processor/collection/unverify_sized_collection_item.rs
+++ b/token-metadata/program/src/processor/collection/unverify_sized_collection_item.rs
@@ -61,7 +61,8 @@ pub fn unverify_sized_collection_item(
     // the NFT.
     //
     // This check needs to happen before the program owned check.
-    let parent_burned = collection_metadata_info.data_is_empty();
+    let parent_burned =
+        collection_metadata_info.data_is_empty() || collection_metadata_info.data.borrow()[0] == 0;
 
     if parent_burned {
         // If the parent is burned, we need to check that the authority

--- a/token-metadata/program/src/processor/verification/collection.rs
+++ b/token-metadata/program/src/processor/verification/collection.rs
@@ -156,7 +156,8 @@ pub(crate) fn unverify_collection_v1(program_id: &Pubkey, ctx: Context<Unverify>
     };
 
     // If the collection parent metadata account has been burned then its data will be empty.
-    let parent_burned = collection_metadata_info.data_is_empty();
+    let parent_burned =
+        collection_metadata_info.data_is_empty() || collection_metadata_info.data.borrow()[0] == 0;
 
     let authority_response = if parent_burned {
         // If the collection parent is burned, we need to use an authority for the item rather than

--- a/token-metadata/program/tests/burn.rs
+++ b/token-metadata/program/tests/burn.rs
@@ -1089,9 +1089,10 @@ mod pnft_edition {
 
         // Token Metadata accounts may still be open because they are no longer being re-assigned
         // to the system program immediately, but if they exist they should have a
-        // data length of 0.
+        // data length of 1 (just the disciriminator byte, set to Uninitialized).
+
         if let Some(account) = print_md {
-            assert_eq!(account.data.len(), 0);
+            assert_eq!(account.data.len(), 1);
         }
 
         assert!(token_account.is_none());
@@ -2764,9 +2765,10 @@ mod nft_edition {
 
         // Token Metadata accounts may still be open because they are no longer being re-assigned
         // to the system program immediately, but if they exist they should have a
-        // data length of 0.
+        // data length of 1 (just the disciriminator byte, set to Uninitialized).
+
         if let Some(account) = print_md {
-            assert_eq!(account.data.len(), 0);
+            assert_eq!(account.data.len(), 1);
         }
 
         assert!(token_account.is_none());

--- a/token-metadata/program/tests/burn_edition_nft.rs
+++ b/token-metadata/program/tests/burn_edition_nft.rs
@@ -74,9 +74,10 @@ mod burn_edition_nft {
 
         // Token Metadata accounts may still be open because they are no longer being re-assigned
         // to the system program immediately, but if they exist they should have a
-        // data length of 0.
+        // data length of 1 (just the disciriminator byte, set to Uninitialized).
+
         if let Some(account) = print_md {
-            assert_eq!(account.data.len(), 0);
+            assert_eq!(account.data.len(), 1);
         }
 
         assert!(token_account.is_none());

--- a/token-metadata/program/tests/burn_nft.rs
+++ b/token-metadata/program/tests/burn_nft.rs
@@ -85,10 +85,10 @@ mod burn_nft {
 
         // Token Metadata accounts may still be open because they are no longer being re-assigned
         // to the system program immediately, but if they exist they should have a
-        // data length of 0.
+        // data length of 1 (just the disciriminator byte, set to Uninitialized).
 
         if let Some(account) = md_account {
-            assert_eq!(account.data.len(), 0);
+            assert_eq!(account.data.len(), 1);
         }
 
         if let Some(account) = master_edition_account {

--- a/token-metadata/program/tests/utils/digital_asset.rs
+++ b/token-metadata/program/tests/utils/digital_asset.rs
@@ -1276,12 +1276,12 @@ impl DigitalAsset {
             .get_account(self.edition.unwrap())
             .await?;
 
-        // The Metadata accounts may still be open because they are no longer being re-assigned
+        // Token Metadata accounts may still be open because they are no longer being re-assigned
         // to the system program immediately, but if they exist they should have a
-        // data length of 0.
+        // data length of 1 (just the disciriminator byte, set to Uninitialized).
 
         if let Some(account) = md_account {
-            assert_eq!(account.data.len(), 0);
+            assert_eq!(account.data.len(), 1);
         }
 
         assert!(edition_account.is_none());


### PR DESCRIPTION
Currently, when burn handlers are called, if a metadata account has fees on it, the data length is reallocated to 0 but the ownership is not reassigned so that fees can be collected on the account. This PR changes the behavior to set the data length to 1 in this case and set that byte to 0 so that the discriminator is `Uninitialized`. This allows indexers to actually categorize and index these accounts until they are fully closed and garbage collected.

Note on the implementation:

```rust
 if collection_metadata_info.data_is_empty()
            || collection_metadata_info.data.borrow()[0] == 0
```

Direct indexing panics if the index does not exist, but in this case it is ok to do because the if statement will short-circuit if the data is empty. 