### PR TITLE
Remove duplicate derivation checks

### DIFF
--- a/token-metadata/program/src/processor/metadata/mint.rs
+++ b/token-metadata/program/src/processor/metadata/mint.rs
@@ -121,18 +121,6 @@ pub fn mint_v1(program_id: &Pubkey, ctx: Context<Mint>, args: MintArgs) -> Progr
             return Err(MetadataError::MissingTokenOwnerAccount.into());
         };
 
-        // if the token account is empty, we will initialize a new one but it must
-        // be an ATA account
-        assert_derivation(
-            &spl_associated_token_account::ID,
-            ctx.accounts.token_info,
-            &[
-                token_owner_info.key.as_ref(),
-                spl_token::ID.as_ref(),
-                ctx.accounts.mint_info.key.as_ref(),
-            ],
-        )?;
-
         msg!("Init ATA");
 
         // creating the associated token account

--- a/token-metadata/program/src/processor/metadata/print.rs
+++ b/token-metadata/program/src/processor/metadata/print.rs
@@ -22,7 +22,7 @@ use crate::{
         TOKEN_STANDARD_INDEX_EDITION,
     },
     utils::{
-        assert_derivation, assert_initialized, assert_owned_by, create_token_record_account,
+        assert_initialized, assert_owned_by, create_token_record_account,
         fee::{levy, set_fee_flag, LevyArgs},
         freeze, process_mint_new_edition_from_master_edition_via_token_logic,
         MintNewEditionFromMasterEditionViaTokenLogicArgs,
@@ -131,17 +131,6 @@ fn print_v1(_program_id: &Pubkey, ctx: Context<Print>, args: PrintArgs) -> Progr
         if mint_supply > 0 {
             return Err(MetadataError::MintSupplyMustBeZero.into());
         }
-        // if the token account is empty, we will initialize a new one but it must
-        // be an ATA account
-        assert_derivation(
-            &spl_associated_token_account::id(),
-            edition_token_account_info,
-            &[
-                edition_token_account_owner_info.key.as_ref(),
-                spl_token::id().as_ref(),
-                edition_mint_info.key.as_ref(),
-            ],
-        )?;
 
         // creating the associated token account
         invoke(

--- a/token-metadata/program/src/processor/metadata/transfer.rs
+++ b/token-metadata/program/src/processor/metadata/transfer.rs
@@ -27,7 +27,7 @@ use crate::{
         TokenDelegateRole, TokenMetadataAccount, TokenRecord, TokenStandard,
     },
     utils::{
-        assert_derivation, auth_rules_validate, clear_close_authority, close_program_account,
+        auth_rules_validate, clear_close_authority, close_program_account,
         create_token_record_account, frozen_transfer, AuthRulesValidateParams,
         ClearCloseAuthorityParams,
     },
@@ -115,18 +115,6 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
 
     // Check if the destination exists.
     if ctx.accounts.destination_info.data_is_empty() {
-        // if the token account is empty, we will initialize a new one but it must
-        // be a ATA account
-        assert_derivation(
-            &spl_associated_token_account::ID,
-            ctx.accounts.destination_info,
-            &[
-                ctx.accounts.destination_owner_info.key.as_ref(),
-                spl_token::ID.as_ref(),
-                ctx.accounts.mint_info.key.as_ref(),
-            ],
-        )?;
-
         // creating the associated token account
         invoke(
             &spl_associated_token_account::instruction::create_associated_token_account(


### PR DESCRIPTION
Removing assert_derivations for ATAs because the ATA program already does the derivation and will throw a missing account error if it's incorrect.