### PR TITLE
Revert default feature

### DIFF
--- a/core/rust/utils/Cargo.toml
+++ b/core/rust/utils/Cargo.toml
@@ -16,10 +16,11 @@ path = "src/lib.rs"
 [dependencies]
 arrayref = "0.3.6"
 solana-program = ">= 1.14.13, < 1.17"
-spl-token-2022 = { version = ">= 0.6.0, < 0.9", features = ["no-entrypoint"] }
+spl-token-2022 = { version = ">= 0.6.0, < 0.9", features = ["no-entrypoint"], optional = true }
 
 [features]
-spl-token = []
+spl-token = ["spl-token-2022"]
+default = ["spl-token"]
 
 [profile.release]
 overflow-checks = true     # Enable integer overflow checks.


### PR DESCRIPTION
When bumping `spl-token-2022` version on mpl-utils, the `default` feature was removed. This is not compatible with a patch version bump, creating problems for projects relying on the program crate. This PR restores the `default` feature.