### PR TITLE
feature: `mpl-utils`: Log assert failures for easier debugging

### DIFF
--- a/core/rust/utils/src/assertions.rs
+++ b/core/rust/utils/src/assertions.rs
@@ -63,7 +63,7 @@ pub fn assert_derivation(
     let (key, bump) = Pubkey::find_program_address(path, program_id);
     if key != *account.key {
         msg!(
-            "derivation assertion failed for {actual_key}:\n
+            "derivation assertion failed for {actual_key}:
                 \x20   expected {key} with program {program_id}, path {path:?}",
             actual_key = account.key,
             key = key,

--- a/core/rust/utils/src/assertions.rs
+++ b/core/rust/utils/src/assertions.rs
@@ -1,7 +1,7 @@
 use solana_program::{
     account_info::AccountInfo,
     entrypoint::ProgramResult,
-    log::sol_log,
+    msg,
     program_error::ProgramError,
     program_pack::{IsInitialized, Pack},
     pubkey::Pubkey,
@@ -10,12 +10,9 @@ use solana_program::{
 
 pub fn assert_signer(account_info: &AccountInfo) -> ProgramResult {
     if !account_info.is_signer {
-        sol_log(
-            format!(
-                "signer assertion failed for {key}: not signer",
-                key = account_info.key,
-            )
-            .as_str(),
+        msg!(
+            "signer assertion failed for {key}: not signer",
+            key = account_info.key,
         );
         Err(ProgramError::MissingRequiredSignature)
     } else {
@@ -29,12 +26,9 @@ pub fn assert_initialized<T: Pack + IsInitialized>(
 ) -> Result<T, ProgramError> {
     let account: T = T::unpack_unchecked(&account_info.data.borrow())?;
     if !account.is_initialized() {
-        sol_log(
-            format!(
-                "initialized assertion failed for {key}: not initialized",
-                key = account_info.key,
-            )
-            .as_str(),
+        msg!(
+            "initialized assertion failed for {key}: not initialized",
+            key = account_info.key,
         );
         Err(error.into())
     } else {
@@ -48,14 +42,11 @@ pub fn assert_owned_by(
     error: impl Into<ProgramError>,
 ) -> ProgramResult {
     if account.owner != owner {
-        sol_log(
-            format!(
-                "owner assertion failed for {key}: expected {expected}, got {actual}",
-                key = account.key,
-                expected = owner,
-                actual = account.owner
-            )
-            .as_str(),
+        msg!(
+            "owner assertion failed for {key}: expected {expected}, got {actual}",
+            key = account.key,
+            expected = owner,
+            actual = account.owner
         );
         Err(error.into())
     } else {
@@ -71,16 +62,13 @@ pub fn assert_derivation(
 ) -> Result<u8, ProgramError> {
     let (key, bump) = Pubkey::find_program_address(path, program_id);
     if key != *account.key {
-        sol_log(
-            format!(
-                "derivation assertion failed for {actual_key}:\n
+        msg!(
+            "derivation assertion failed for {actual_key}:\n
                 \x20   expected {key} with program {program_id}, path {path:?}",
-                actual_key = account.key,
-                key = key,
-                program_id = program_id,
-                path = path,
-            )
-            .as_str(),
+            actual_key = account.key,
+            key = key,
+            program_id = program_id,
+            path = path,
         );
         return Err(error.into());
     }
@@ -93,14 +81,11 @@ pub fn assert_rent_exempt(
     error: impl Into<ProgramError>,
 ) -> ProgramResult {
     if !rent.is_exempt(account_info.lamports(), account_info.data_len()) {
-        sol_log(
-            format!(
+        msg!(
                 "rent exempt assertion failed for {key}: has {balance} lamports, requires at least {min} lamports",
                 key = account_info.key,
                 balance = account_info.lamports(),
                 min = rent.minimum_balance(account_info.data_len()),
-            )
-            .as_str(),
         );
         Err(error.into())
     } else {

--- a/core/rust/utils/src/assertions.rs
+++ b/core/rust/utils/src/assertions.rs
@@ -10,10 +10,7 @@ use solana_program::{
 
 pub fn assert_signer(account_info: &AccountInfo) -> ProgramResult {
     if !account_info.is_signer {
-        msg!(
-            "signer assertion failed for {key}: not signer",
-            key = account_info.key,
-        );
+        msg!("{key} is not a signer", key = account_info.key,);
         Err(ProgramError::MissingRequiredSignature)
     } else {
         Ok(())
@@ -26,10 +23,7 @@ pub fn assert_initialized<T: Pack + IsInitialized>(
 ) -> Result<T, ProgramError> {
     let account: T = T::unpack_unchecked(&account_info.data.borrow())?;
     if !account.is_initialized() {
-        msg!(
-            "initialized assertion failed for {key}: not initialized",
-            key = account_info.key,
-        );
+        msg!("{key} is not initialized", key = account_info.key,);
         Err(error.into())
     } else {
         Ok(account)
@@ -43,7 +37,7 @@ pub fn assert_owned_by(
 ) -> ProgramResult {
     if account.owner != owner {
         msg!(
-            "owner assertion failed for {key}: expected {expected}, got {actual}",
+            "invalid owner for {key}: expected {expected}, got {actual}",
             key = account.key,
             expected = owner,
             actual = account.owner
@@ -82,10 +76,10 @@ pub fn assert_rent_exempt(
 ) -> ProgramResult {
     if !rent.is_exempt(account_info.lamports(), account_info.data_len()) {
         msg!(
-                "rent exempt assertion failed for {key}: has {balance} lamports, requires at least {min} lamports",
-                key = account_info.key,
-                balance = account_info.lamports(),
-                min = rent.minimum_balance(account_info.data_len()),
+            "{key} is not rent-exempt: has {balance} lamports, requires {min} lamports",
+            key = account_info.key,
+            balance = account_info.lamports(),
+            min = rent.minimum_balance(account_info.data_len()),
         );
         Err(error.into())
     } else {

--- a/core/rust/utils/src/assertions.rs
+++ b/core/rust/utils/src/assertions.rs
@@ -1,6 +1,7 @@
 use solana_program::{
     account_info::AccountInfo,
     entrypoint::ProgramResult,
+    log::sol_log,
     program_error::ProgramError,
     program_pack::{IsInitialized, Pack},
     pubkey::Pubkey,
@@ -9,6 +10,13 @@ use solana_program::{
 
 pub fn assert_signer(account_info: &AccountInfo) -> ProgramResult {
     if !account_info.is_signer {
+        sol_log(
+            format!(
+                "signer assertion failed for {key}: not signer",
+                key = account_info.key,
+            )
+            .as_str(),
+        );
         Err(ProgramError::MissingRequiredSignature)
     } else {
         Ok(())
@@ -21,6 +29,13 @@ pub fn assert_initialized<T: Pack + IsInitialized>(
 ) -> Result<T, ProgramError> {
     let account: T = T::unpack_unchecked(&account_info.data.borrow())?;
     if !account.is_initialized() {
+        sol_log(
+            format!(
+                "initialized assertion failed for {key}: not initialized",
+                key = account_info.key,
+            )
+            .as_str(),
+        );
         Err(error.into())
     } else {
         Ok(account)
@@ -33,6 +48,15 @@ pub fn assert_owned_by(
     error: impl Into<ProgramError>,
 ) -> ProgramResult {
     if account.owner != owner {
+        sol_log(
+            format!(
+                "owner assertion failed for {key}: expected {expected}, got {actual}",
+                key = account.key,
+                expected = owner,
+                actual = account.owner
+            )
+            .as_str(),
+        );
         Err(error.into())
     } else {
         Ok(())
@@ -47,6 +71,17 @@ pub fn assert_derivation(
 ) -> Result<u8, ProgramError> {
     let (key, bump) = Pubkey::find_program_address(path, program_id);
     if key != *account.key {
+        sol_log(
+            format!(
+                "derivation assertion failed for {actual_key}:\n
+                \x20   expected {key} with program {program_id}, path {path:?}",
+                actual_key = account.key,
+                key = key,
+                program_id = program_id,
+                path = path,
+            )
+            .as_str(),
+        );
         return Err(error.into());
     }
     Ok(bump)
@@ -58,6 +93,15 @@ pub fn assert_rent_exempt(
     error: impl Into<ProgramError>,
 ) -> ProgramResult {
     if !rent.is_exempt(account_info.lamports(), account_info.data_len()) {
+        sol_log(
+            format!(
+                "rent exempt assertion failed for {key}: has {balance} lamports, requires at least {min} lamports",
+                key = account_info.key,
+                balance = account_info.lamports(),
+                min = rent.minimum_balance(account_info.data_len()),
+            )
+            .as_str(),
+        );
         Err(error.into())
     } else {
         Ok(())


### PR DESCRIPTION
At the moment, when an assertion fails, the program only throws an error about the type of assertion that has failed.
This there no indication to _which_ account is the incorrect one, making it a nightmare to debug.

[For example](https://explorer.solana.com/tx/4deWJFAux67HLu4k1EtmoBovt31zRcKhHSHD1QB2xf77PPA7KrvBiQrRV56REz1fXtNYQR5MpZbYAM7jiJfW93my):
```console
> Program invoked: Token Metadata Program
  > Program logged: "IX: Delegate"
  > Program logged: "Public key does not match expected value"
  > Program consumed: 18426 of 373338 compute units
  > Program returned error: "custom program error: 0x9a"
```

This PR adds logs that print the account that failed the assertion and some debug information about why the assertion failed.
They only trigger if the assertion fails, so shouldn't effect the compute unit budget during normal operation.