### PR TITLE
fix: typos in documentation files

### DIFF
--- a/auction-house/cli/src/commands/upload.ts
+++ b/auction-house/cli/src/commands/upload.ts
@@ -691,7 +691,7 @@ export async function upload({
   // Compile a sorted list of assets which need to be uploaded.
   const dedupedAssetKeys = getAssetKeysNeedingUpload(cache.items, files);
 
-  // Initialize variables that might be needed for uploded depending on storage
+  // Initialize variables that might be needed for uploaded depending on storage
   // type.
   // These will be needed anyway either to initialize the
   // Candy Machine Custom Program configuration, or to write the assets

--- a/auction-house/cli/src/helpers/transactions.ts
+++ b/auction-house/cli/src/helpers/transactions.ts
@@ -40,7 +40,7 @@ export const sendTransactionWithRetryWithKeypair = async (
     transaction.setSigners(...signers.map(s => s.publicKey));
   } else {
     transaction.setSigners(
-      // fee payed by the wallet owner
+      // fee paid by the wallet owner
       wallet.publicKey,
       ...signers.map(s => s.publicKey),
     );

--- a/auction-house/cli/src/helpers/upload/arweave-bundle.ts
+++ b/auction-house/cli/src/helpers/upload/arweave-bundle.ts
@@ -744,7 +744,7 @@ export const withdrawBundlr = async (walletKeyPair: Keypair) => {
       } else if (withdrawResponse.status == 400) {
         log.info(withdrawResponse.data);
         log.info(
-          'Withdraw unsucessful. An additional attempt will be made after all files are uploaded.',
+          'Withdraw unsuccessful. An additional attempt will be made after all files are uploaded.',
         );
       }
     } catch (err) {

--- a/auction-house/cli/src/helpers/upload/nft-storage.ts
+++ b/auction-house/cli/src/helpers/upload/nft-storage.ts
@@ -50,7 +50,7 @@ export async function* nftStorageUploadGenerator({
 }): AsyncGenerator<NftStorageBundleUploadResult> {
   // split asset keys into batches, each of which will be bundled into a CAR file and uploaded separately
   // default to 50 NFTs per "batch" if no batchSize is given.
-  // larger batches require fewer signatures and will be slightly faster overall if everything is sucessful,
+  // larger batches require fewer signatures and will be slightly faster overall if everything is successful,
   // but smaller batches will take less time to retry if there's an error during upload.
   batchSize = batchSize || 50;
   batchSize = Math.min(batchSize, NFTBundle.MAX_ENTRIES);

--- a/fixed-price-sale/program/src/utils.rs
+++ b/fixed-price-sale/program/src/utils.rs
@@ -8,7 +8,7 @@ use anchor_lang::{
 use mpl_token_metadata::state::EDITION_MARKER_BIT_SIZE;
 
 pub const NAME_MAX_LEN: usize = 40; // max len of a string buffer in bytes
-pub const NAME_DEFAULT_SIZE: usize = 4 + NAME_MAX_LEN; // max lenght of serialized string (str_len + <buffer>)
+pub const NAME_DEFAULT_SIZE: usize = 4 + NAME_MAX_LEN; // max length of serialized string (str_len + <buffer>)
 pub const DESCRIPTION_MAX_LEN: usize = 60;
 pub const DESCRIPTION_DEFAULT_SIZE: usize = 4 + DESCRIPTION_MAX_LEN;
 pub const HOLDER_PREFIX: &str = "holder";


### PR DESCRIPTION
Corrected `uploded` to `uploaded`
Corrected `payed` to `paid`
Corrected `unsucessful` to `unsuccessful`
Corrected `sucessful` to `successful`
Corrected `lenght` to `length`