### PR TITLE
Update Candy Machine documentation link

### DIFF
--- a/candy-machine/program/README.md
+++ b/candy-machine/program/README.md
@@ -1,6 +1,6 @@
 ## Metaplex Candy Machine V2
 
-See [docs](https://docs.metaplex.com/programs/candy-machine/) for information and instructions on usage and setup.
+See [docs](https://developers.metaplex.com/core-candy-machine/) for information and instructions on usage and setup.
 
 See [Rust docs](https://docs.rs/mpl-candy-machine) for crate documentation.
 


### PR DESCRIPTION


Changes:
File: candy-machine/program/README.md
Old: https://docs.metaplex.com/programs/candy-machine/
New: https://developers.metaplex.com/core-candy-machine/

Reason:
The original documentation link is no longer valid as Metaplex has moved their documentation to a new domain. This PR updates the link to point to the current, active documentation portal.
