### PR TITLE
Typo fix in pr_template.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_template.md
@@ -1,7 +1,7 @@
 ### Note
 Pull Requests that make fundamental changes to the Metaplex standard are unlikely to be accepted without a discussion first. Please open a feature request issue instead to discuss your desired changes. We are working on a more formal process for proposing changes to the Metaplex standard.
 
-It's much easier for us to read and review a PR that is small, linted, and contains only one material enhancement. If your PR is very large and encompasing many features consider breaking it up in to a few PRs so we can digest the information in each pr with more accuracy.
+It's much easier for us to read and review a PR that is small, linted, and contains only one material enhancement. If your PR is very large and encompassing many features consider breaking it up in to a few PRs so we can digest the information in each pr with more accuracy.
 
 ### Description
 Describe the purpose of and changes within this Pull Request.


### PR DESCRIPTION
# Title:
Fix Typo in `pr_template.md`

# Description:
This pull request fixes a typo in the `pr_template.md` file. Specifically, it corrects the word "encompasing" to "encompassing."

# Changes:
- Corrected the word **"encompasing"** to **"encompassing"** in the template.
- Cleaned up the formatting slightly.

