### PR TITLE
Fix Typos and Clarify Redundant Check in Gumdrop and Hydra Modules

### DIFF
--- a/gumdrop/program/src/lib.rs
+++ b/gumdrop/program/src/lib.rs
@@ -373,7 +373,7 @@ pub mod gumdrop {
             GumdropError::OwnerMismatch
         );
         require!(
-            // This check is redudant, we should not be able to initialize a claim status account at the same key.
+            // This check is redundant, we should not be able to initialize a claim status account at the same key.
             !claim_status.is_claimed && claim_status.claimed_at == 0,
             GumdropError::DropAlreadyClaimed
         );

--- a/hydra/js/src/generated/errors/index.ts
+++ b/hydra/js/src/generated/errors/index.ts
@@ -384,7 +384,7 @@ createErrorFromCodeLookup.set(0x1781, () => new InvalidFanoutForMintError());
 createErrorFromNameLookup.set('InvalidFanoutForMint', () => new InvalidFanoutForMintError());
 
 /**
- * MustDistribute: 'This operation must be the instruction right after a distrobution on the same accounts.'
+ * MustDistribute: 'This operation must be the instruction right after a distribution on the same accounts.'
  *
  * @category Errors
  * @category generated
@@ -394,7 +394,7 @@ export class MustDistributeError extends Error {
   readonly name: string = 'MustDistribute';
   constructor() {
     super(
-      'This operation must be the instruction right after a distrobution on the same accounts.',
+      'This operation must be the instruction right after a distribution on the same accounts.',
     );
     if (typeof Error.captureStackTrace === 'function') {
       Error.captureStackTrace(this, MustDistributeError);


### PR DESCRIPTION


**Description:**  
- Corrected spelling mistake: "distrobution" → "distribution" in Hydra error messages.
- Minor code and comment cleanups for better readability.